### PR TITLE
refactor: capability dispatch for HID++ variants

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(logitune-core PRIVATE
     hidpp/features/AdjustableDPI.cpp
     hidpp/features/DeviceName.cpp
     hidpp/capabilities/BatteryCapability.cpp
+    hidpp/capabilities/SmartShiftCapability.cpp
     ProfileEngine.cpp
     ActionExecutor.cpp
     DeviceRegistry.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(logitune-core PRIVATE
     hidpp/features/Battery.cpp
     hidpp/features/AdjustableDPI.cpp
     hidpp/features/DeviceName.cpp
+    hidpp/capabilities/BatteryCapability.cpp
     ProfileEngine.cpp
     ActionExecutor.cpp
     DeviceRegistry.cpp

--- a/src/core/DeviceManager.cpp
+++ b/src/core/DeviceManager.cpp
@@ -8,6 +8,7 @@
 #include "hidpp/features/HiResWheel.h"
 #include "hidpp/features/ReprogControls.h"
 #include "hidpp/features/ThumbWheel.h"
+#include "hidpp/capabilities/Capabilities.h"
 #include "logging/LogManager.h"
 
 #include <QDateTime>
@@ -613,17 +614,26 @@ void DeviceManager::enumerateAndSetup()
         qCDebug(lcDevice) << "device id (hash fallback):" << serial;
     }
 
-    // Read battery
+    // Resolve variant dispatches now that feature table is populated
+    m_batteryDispatch    = hidpp::capabilities::resolveCapability(
+                              m_features.get(), hidpp::capabilities::kBatteryVariants);
+    m_smartShiftDispatch = hidpp::capabilities::resolveCapability(
+                              m_features.get(), hidpp::capabilities::kSmartShiftVariants);
+
+    // Read battery using resolved dispatch
     int battLevel = 0;
     bool battCharging = false;
-    if (m_features->hasFeature(hidpp::FeatureId::BatteryUnified)) {
+    if (m_batteryDispatch) {
         auto resp = m_features->call(m_transport.get(), m_deviceIndex,
-                                     hidpp::FeatureId::BatteryUnified,
-                                     hidpp::features::Battery::kFnGetStatus);
+                                     m_batteryDispatch->feature,
+                                     m_batteryDispatch->getFn);
         if (resp.has_value()) {
-            auto status = hidpp::features::Battery::parseStatus(*resp);
+            auto status = m_batteryDispatch->parse(*resp);
             battLevel    = status.level;
             battCharging = status.charging;
+            qCDebug(lcDevice) << "battery: feature="
+                              << Qt::hex << static_cast<uint16_t>(m_batteryDispatch->feature)
+                              << Qt::dec << "level=" << battLevel << "% charging=" << battCharging;
         }
     }
 
@@ -653,31 +663,20 @@ void DeviceManager::enumerateAndSetup()
         }
     }
 
-    // Read SmartShift — try V1 (0x2110) first, fall back to Enhanced (0x2111)
-    // V1: fn0=GetStatus, fn1=SetStatus
-    // Enhanced: fn1=GetStatus, fn2=SetStatus (fn0 is getCapabilities)
-    {
-        hidpp::FeatureId ssFeature = hidpp::FeatureId::SmartShift;
-        uint8_t ssGetFn = hidpp::features::SmartShift::kFnGetStatus;  // 0x00
-
-        if (!m_features->hasFeature(hidpp::FeatureId::SmartShift) &&
-            m_features->hasFeature(hidpp::FeatureId::SmartShiftEnhanced)) {
-            ssFeature = hidpp::FeatureId::SmartShiftEnhanced;
-            ssGetFn = 0x01;  // Enhanced uses fn1 for GetStatus
-            qCDebug(lcDevice) << "using SmartShift Enhanced (0x2111)";
-        }
-
-        if (m_features->hasFeature(ssFeature)) {
-            auto resp = m_features->call(m_transport.get(), m_deviceIndex,
-                                         ssFeature, ssGetFn);
-            if (resp.has_value()) {
-                auto cfg = hidpp::features::SmartShift::parseConfig(*resp);
-                m_smartShiftEnabled = cfg.isRatchet();
-                m_smartShiftThreshold = cfg.autoDisengage;
-                qCDebug(lcDevice) << "SmartShift: mode=" << cfg.mode
-                                  << (m_smartShiftEnabled ? "(ratchet)" : "(freespin)")
-                                  << "autoDisengage=" << m_smartShiftThreshold;
-            }
+    // Read SmartShift using resolved dispatch
+    if (m_smartShiftDispatch) {
+        auto resp = m_features->call(m_transport.get(), m_deviceIndex,
+                                     m_smartShiftDispatch->feature,
+                                     m_smartShiftDispatch->getFn);
+        if (resp.has_value()) {
+            auto cfg = m_smartShiftDispatch->parseGet(*resp);
+            m_smartShiftEnabled   = cfg.isRatchet();
+            m_smartShiftThreshold = cfg.autoDisengage;
+            qCDebug(lcDevice) << "SmartShift: feature="
+                              << Qt::hex << static_cast<uint16_t>(m_smartShiftDispatch->feature)
+                              << Qt::dec << "mode=" << cfg.mode
+                              << (m_smartShiftEnabled ? "(ratchet)" : "(freespin)")
+                              << "autoDisengage=" << m_smartShiftThreshold;
         }
     }
 
@@ -789,7 +788,8 @@ void DeviceManager::enumerateAndSetup()
     m_currentHost = currentHost;
     m_hostCount = hostCount;
 
-    m_deviceName     = name;
+    // Prefer descriptor-provided name (user-facing) over HID++-reported name (internal).
+    m_deviceName     = m_activeDevice ? m_activeDevice->deviceName() : name;
     m_deviceSerial   = serial;
     m_firmwareVersion = firmwareVersion;
     m_deviceVid      = m_device->info().vendorId;
@@ -872,6 +872,8 @@ void DeviceManager::disconnectDevice()
         m_commandQueue.reset();
     }
     m_activeDevice = nullptr;
+    m_batteryDispatch.reset();
+    m_smartShiftDispatch.reset();
     m_features.reset();
     m_transport.reset();
     m_device.reset();
@@ -960,17 +962,17 @@ void DeviceManager::handleNotification(const hidpp::Report &report)
         return;
     }
 
-    // Battery notification (feature index matches BatteryUnified)
-    if (m_features && m_features->hasFeature(hidpp::FeatureId::BatteryUnified)) {
-        auto idx = m_features->featureIndex(hidpp::FeatureId::BatteryUnified);
+    // Battery notification (resolved variant)
+    if (m_batteryDispatch && m_features) {
+        auto idx = m_features->featureIndex(m_batteryDispatch->feature);
         if (idx.has_value() && report.featureIndex == *idx) {
             qCDebug(lcDevice) << "battery raw params:"
                               << Qt::hex << report.params[0] << report.params[1] << report.params[2] << report.params[3];
-            auto status = hidpp::features::Battery::parseStatus(report);
+            auto status = m_batteryDispatch->parse(report);
             qCDebug(lcDevice) << "battery notification:" << status.level << "% charging:" << status.charging;
-            bool levelChanged   = (m_batteryLevel != status.level);
-            bool chargeChanged  = (m_batteryCharging != status.charging);
-            m_batteryLevel   = status.level;
+            bool levelChanged  = (m_batteryLevel    != status.level);
+            bool chargeChanged = (m_batteryCharging != status.charging);
+            m_batteryLevel    = status.level;
             m_batteryCharging = status.charging;
             if (levelChanged)  emit batteryLevelChanged();
             if (chargeChanged) emit batteryChargingChanged();
@@ -996,22 +998,20 @@ void DeviceManager::handleNotification(const hidpp::Report &report)
         }
     }
 
-    // SmartShift feature notification (V1 or Enhanced)
-    for (auto ssId : {hidpp::FeatureId::SmartShift, hidpp::FeatureId::SmartShiftEnhanced}) {
-        if (m_features && m_features->hasFeature(ssId)) {
-            auto idx = m_features->featureIndex(ssId);
-            if (idx.has_value() && report.featureIndex == *idx) {
-                auto cfg = hidpp::features::SmartShift::parseConfig(report);
-                bool newEnabled = cfg.isRatchet();
-                if (m_smartShiftEnabled != newEnabled) {
-                    m_smartShiftEnabled = newEnabled;
-                    m_smartShiftThreshold = cfg.autoDisengage;
-                    qCDebug(lcDevice) << "SmartShift toggled:"
-                                      << (newEnabled ? "ratchet" : "freespin");
-                    emit smartShiftChanged();
-                }
-                return;
+    // SmartShift feature notification (resolved variant)
+    if (m_smartShiftDispatch && m_features) {
+        auto idx = m_features->featureIndex(m_smartShiftDispatch->feature);
+        if (idx.has_value() && report.featureIndex == *idx) {
+            auto cfg = m_smartShiftDispatch->parseGet(report);
+            bool newEnabled = cfg.isRatchet();
+            if (m_smartShiftEnabled != newEnabled) {
+                m_smartShiftEnabled   = newEnabled;
+                m_smartShiftThreshold = cfg.autoDisengage;
+                qCDebug(lcDevice) << "SmartShift toggled:"
+                                  << (newEnabled ? "ratchet" : "freespin");
+                emit smartShiftChanged();
             }
+            return;
         }
     }
 
@@ -1140,36 +1140,25 @@ void DeviceManager::setDPI(int value)
 
 void DeviceManager::setSmartShift(bool enabled, int threshold)
 {
-    if (!m_connected || !m_features || !m_commandQueue)
+    if (!m_connected || !m_features || !m_commandQueue || !m_smartShiftDispatch)
         return;
-
-    // Resolve which feature to use: V1 (0x2110) or Enhanced (0x2111)
-    hidpp::FeatureId ssFeature;
-    uint8_t ssSetFn;
-    if (m_features->hasFeature(hidpp::FeatureId::SmartShift)) {
-        ssFeature = hidpp::FeatureId::SmartShift;
-        ssSetFn = hidpp::features::SmartShift::kFnSetStatus;  // fn1
-    } else if (m_features->hasFeature(hidpp::FeatureId::SmartShiftEnhanced)) {
-        ssFeature = hidpp::FeatureId::SmartShiftEnhanced;
-        ssSetFn = 0x02;  // Enhanced uses fn2 for SetStatus
-    } else {
-        return;
-    }
 
     threshold = qBound(1, threshold, 255);
 
-    m_smartShiftEnabled = enabled;
+    m_smartShiftEnabled   = enabled;
     m_smartShiftThreshold = threshold;
     emit smartShiftChanged();
 
     uint8_t mode = enabled ? 2 : 1;
-    uint8_t ad = static_cast<uint8_t>(threshold);
+    uint8_t ad   = static_cast<uint8_t>(threshold);
 
-    auto params = hidpp::features::SmartShift::buildSetConfig(mode, ad);
-    m_commandQueue->enqueue(ssFeature, ssSetFn,
+    auto params = m_smartShiftDispatch->buildSet(mode, ad);
+    m_commandQueue->enqueue(m_smartShiftDispatch->feature,
+                            m_smartShiftDispatch->setFn,
                             std::span<const uint8_t>(params));
-    qCDebug(lcDevice) << "SmartShift set: feature=" << Qt::hex << static_cast<uint16_t>(ssFeature)
-                      << "mode=" << mode << "autoDisengage=" << ad;
+    qCDebug(lcDevice) << "SmartShift set: feature="
+                      << Qt::hex << static_cast<uint16_t>(m_smartShiftDispatch->feature)
+                      << Qt::dec << "mode=" << mode << "autoDisengage=" << ad;
 }
 
 void DeviceManager::setScrollConfig(bool hiRes, bool invert)

--- a/src/core/DeviceManager.h
+++ b/src/core/DeviceManager.h
@@ -4,10 +4,13 @@
 #include "hidpp/Transport.h"
 #include "hidpp/FeatureDispatcher.h"
 #include "hidpp/CommandQueue.h"
+#include "hidpp/capabilities/BatteryCapability.h"
+#include "hidpp/capabilities/SmartShiftCapability.h"
 #include <QObject>
 #include <QSocketNotifier>
 #include <QTimer>
 #include <memory>
+#include <optional>
 
 struct udev;
 struct udev_monitor;
@@ -150,6 +153,11 @@ private:
     std::unique_ptr<hidpp::Transport> m_transport;
     std::unique_ptr<hidpp::FeatureDispatcher> m_features;
     std::unique_ptr<hidpp::CommandQueue> m_commandQueue;
+
+    // Resolved capability dispatches — set once at enumerateAndSetup
+    std::optional<hidpp::capabilities::BatteryVariant>    m_batteryDispatch;
+    std::optional<hidpp::capabilities::SmartShiftVariant> m_smartShiftDispatch;
+
     QSocketNotifier *m_hidrawNotifier = nullptr;
     QSocketNotifier *m_receiverNotifier = nullptr;  // listens for DJ device-arrival when no device on slots
 

--- a/src/core/hidpp/FeatureDispatcher.cpp
+++ b/src/core/hidpp/FeatureDispatcher.cpp
@@ -9,6 +9,7 @@ static constexpr FeatureId kKnownFeatures[] = {
     FeatureId::FeatureSet,
     FeatureId::DeviceInfo,
     FeatureId::DeviceName,
+    FeatureId::BatteryStatus,
     FeatureId::BatteryUnified,
     FeatureId::ChangeHost,
     FeatureId::ReprogControlsV4,

--- a/src/core/hidpp/HidppTypes.h
+++ b/src/core/hidpp/HidppTypes.h
@@ -24,6 +24,7 @@ enum class FeatureId : uint16_t {
     FeatureSet      = 0x0001,
     DeviceInfo      = 0x0003,
     DeviceName      = 0x0005,
+    BatteryStatus   = 0x1000,
     BatteryUnified  = 0x1004,
     ChangeHost      = 0x1814,
     ReprogControlsV4= 0x1b04,

--- a/src/core/hidpp/capabilities/BatteryCapability.cpp
+++ b/src/core/hidpp/capabilities/BatteryCapability.cpp
@@ -1,0 +1,18 @@
+#include "hidpp/capabilities/BatteryCapability.h"
+
+namespace logitune::hidpp::capabilities {
+
+const BatteryVariant kBatteryVariants[2] = {
+    {
+        FeatureId::BatteryUnified,
+        features::Battery::kFnGetStatus,     // 0x01
+        &features::Battery::parseStatus,
+    },
+    {
+        FeatureId::BatteryStatus,
+        0x00,                                 // fn0 for legacy
+        &features::Battery::parseStatusLegacy,
+    },
+};
+
+} // namespace logitune::hidpp::capabilities

--- a/src/core/hidpp/capabilities/BatteryCapability.h
+++ b/src/core/hidpp/capabilities/BatteryCapability.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "hidpp/HidppTypes.h"
+#include "hidpp/features/Battery.h"
+
+namespace logitune::hidpp::capabilities {
+
+// One Battery variant: a feature ID + its get function + a parser.
+struct BatteryVariant {
+    FeatureId feature;
+    uint8_t   getFn;
+    logitune::hidpp::features::BatteryStatus (*parse)(const logitune::hidpp::Report&);
+};
+
+// Known battery variants in preference order.
+// UnifiedBattery (0x1004) is preferred when present because it exposes the
+// level bitmask fallback. Legacy BatteryStatus (0x1000) is used otherwise.
+extern const BatteryVariant kBatteryVariants[2];
+
+} // namespace logitune::hidpp::capabilities

--- a/src/core/hidpp/capabilities/Capabilities.h
+++ b/src/core/hidpp/capabilities/Capabilities.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <cstddef>
+#include <optional>
+#include "hidpp/FeatureDispatcher.h"
+
+namespace logitune::hidpp::capabilities {
+
+// resolveCapability walks a constexpr table of variants and returns the first
+// one whose `feature` is advertised by the given dispatcher. Returns nullopt
+// if none of the variants are supported.
+//
+// Each Variant struct must have a `FeatureId feature;` member. Other fields
+// (function IDs, parser pointers) are variant-specific.
+template<typename Variant, size_t N>
+std::optional<Variant> resolveCapability(FeatureDispatcher* dispatcher,
+                                         const Variant (&variants)[N])
+{
+    if (!dispatcher)
+        return std::nullopt;
+    for (const auto& v : variants) {
+        if (dispatcher->hasFeature(v.feature))
+            return v;
+    }
+    return std::nullopt;
+}
+
+} // namespace logitune::hidpp::capabilities

--- a/src/core/hidpp/capabilities/SmartShiftCapability.cpp
+++ b/src/core/hidpp/capabilities/SmartShiftCapability.cpp
@@ -1,0 +1,22 @@
+#include "hidpp/capabilities/SmartShiftCapability.h"
+
+namespace logitune::hidpp::capabilities {
+
+const SmartShiftVariant kSmartShiftVariants[2] = {
+    {
+        FeatureId::SmartShift,
+        features::SmartShift::kFnGetStatus,  // 0x00
+        features::SmartShift::kFnSetStatus,  // 0x01
+        &features::SmartShift::parseConfig,
+        &features::SmartShift::buildSetConfig,
+    },
+    {
+        FeatureId::SmartShiftEnhanced,
+        0x01,                                 // Enhanced: fn1 = GetStatus
+        0x02,                                 // Enhanced: fn2 = SetStatus
+        &features::SmartShift::parseConfig,   // same response layout as V1
+        &features::SmartShift::buildSetConfig, // same request layout as V1
+    },
+};
+
+} // namespace logitune::hidpp::capabilities

--- a/src/core/hidpp/capabilities/SmartShiftCapability.h
+++ b/src/core/hidpp/capabilities/SmartShiftCapability.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <vector>
+#include "hidpp/HidppTypes.h"
+#include "hidpp/features/SmartShift.h"
+
+namespace logitune::hidpp::capabilities {
+
+// SmartShift has both a read path (get current config) and a write path
+// (set mode + threshold), so the variant carries both function IDs plus
+// the request builder.
+struct SmartShiftVariant {
+    FeatureId feature;
+    uint8_t   getFn;
+    uint8_t   setFn;
+    logitune::hidpp::features::SmartShiftConfig (*parseGet)(const logitune::hidpp::Report&);
+    std::vector<uint8_t> (*buildSet)(uint8_t mode, uint8_t autoDisengage);
+};
+
+// Known SmartShift variants in preference order.
+// V1 (0x2110) is preferred on MX Master 3S and older.
+// Enhanced (0x2111) is used on MX Master 4 and newer, with different function IDs.
+extern const SmartShiftVariant kSmartShiftVariants[2];
+
+} // namespace logitune::hidpp::capabilities

--- a/src/core/hidpp/features/Battery.cpp
+++ b/src/core/hidpp/features/Battery.cpp
@@ -30,4 +30,22 @@ BatteryStatus Battery::parseStatus(const Report &r)
     return status;
 }
 
+BatteryStatus Battery::parseStatusLegacy(const Report &r)
+{
+    // BatteryStatus (0x1000) legacy format — from Solaar hidpp20.decipher_battery_status:
+    //   params[0] = current discharge level (percentage, 0 = unknown)
+    //   params[1] = next discharge threshold (informational, ignored)
+    //   params[2] = status byte (same enum as UnifiedBattery)
+    BatteryStatus status;
+    status.level        = static_cast<int>(r.params[0]);
+    status.levelBitmask = 0;  // not present in legacy format
+    status.state        = static_cast<BatteryState>(r.params[2]);
+
+    status.charging = (status.state == BatteryState::Recharging ||
+                       status.state == BatteryState::AlmostFull ||
+                       status.state == BatteryState::Full ||
+                       status.state == BatteryState::SlowRecharge);
+    return status;
+}
+
 } // namespace logitune::hidpp::features

--- a/src/core/hidpp/features/Battery.h
+++ b/src/core/hidpp/features/Battery.h
@@ -24,7 +24,11 @@ struct BatteryStatus {
 
 class Battery {
 public:
+    // UnifiedBattery (0x1004): params[0]=%, params[1]=level bitmask, params[2]=status
     static BatteryStatus parseStatus(const Report &r);
+
+    // BatteryStatus (0x1000) legacy: params[0]=%, params[1]=next threshold, params[2]=status
+    static BatteryStatus parseStatusLegacy(const Report &r);
 
     static constexpr uint8_t kFnGetCapabilities = 0x00;
     static constexpr uint8_t kFnGetStatus = 0x01;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(logitune-tests
     test_smoke.cpp
     test_transport.cpp
     test_feature_dispatcher.cpp
+    test_capability_dispatch.cpp
     test_scroll_features.cpp
     test_features.cpp
     test_button_features.cpp

--- a/tests/test_capability_dispatch.cpp
+++ b/tests/test_capability_dispatch.cpp
@@ -117,3 +117,42 @@ TEST(BatteryCapability, ParserPointerRoutesCorrectly) {
     auto legacyStatus = legacy.parse(r);
     EXPECT_EQ(legacyStatus.level, 0);     // legacy does not use bitmask
 }
+
+// ---------------------------------------------------------------------------
+// SmartShiftCapability table
+// ---------------------------------------------------------------------------
+#include "hidpp/capabilities/SmartShiftCapability.h"
+#include "hidpp/features/SmartShift.h"
+
+TEST(SmartShiftCapability, PrefersV1OverEnhanced) {
+    FeatureDispatcher fd;
+    fd.setFeatureTable({
+        {FeatureId::SmartShift,         0x02},
+        {FeatureId::SmartShiftEnhanced, 0x03},
+    });
+    auto v = resolveCapability(&fd, kSmartShiftVariants);
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->feature, FeatureId::SmartShift);
+    EXPECT_EQ(v->getFn, 0x00);  // V1 kFnGetStatus
+    EXPECT_EQ(v->setFn, 0x01);  // V1 kFnSetStatus
+}
+
+TEST(SmartShiftCapability, FallsBackToEnhanced) {
+    FeatureDispatcher fd;
+    fd.setFeatureTable({
+        {FeatureId::SmartShiftEnhanced, 0x02},
+    });
+    auto v = resolveCapability(&fd, kSmartShiftVariants);
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->feature, FeatureId::SmartShiftEnhanced);
+    EXPECT_EQ(v->getFn, 0x01);  // Enhanced fn1 for get
+    EXPECT_EQ(v->setFn, 0x02);  // Enhanced fn2 for set
+}
+
+TEST(SmartShiftCapability, BuildSetParams) {
+    auto v = kSmartShiftVariants[0];
+    auto params = v.buildSet(2, 64);  // ratchet mode, threshold 64
+    ASSERT_GE(params.size(), 2u);
+    EXPECT_EQ(params[0], 2);
+    EXPECT_EQ(params[1], 64);
+}

--- a/tests/test_capability_dispatch.cpp
+++ b/tests/test_capability_dispatch.cpp
@@ -68,3 +68,52 @@ TEST(ResolveCapability, ReturnsNulloptWhenDispatcherEmpty) {
     auto v = resolveCapability(&fd, kTestVariants);
     EXPECT_FALSE(v.has_value());
 }
+
+// ---------------------------------------------------------------------------
+// BatteryCapability table
+// ---------------------------------------------------------------------------
+#include "hidpp/capabilities/BatteryCapability.h"
+#include "hidpp/features/Battery.h"
+
+using namespace logitune::hidpp::features;
+
+TEST(BatteryCapability, PrefersUnifiedOverLegacy) {
+    FeatureDispatcher fd;
+    fd.setFeatureTable({
+        {FeatureId::BatteryUnified, 0x02},
+        {FeatureId::BatteryStatus,  0x03},
+    });
+    auto v = resolveCapability(&fd, kBatteryVariants);
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->feature, FeatureId::BatteryUnified);
+    EXPECT_EQ(v->getFn, 0x01);  // kFnGetStatus for UnifiedBattery
+}
+
+TEST(BatteryCapability, FallsBackToLegacy) {
+    FeatureDispatcher fd;
+    fd.setFeatureTable({
+        {FeatureId::BatteryStatus, 0x02},
+    });
+    auto v = resolveCapability(&fd, kBatteryVariants);
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->feature, FeatureId::BatteryStatus);
+    EXPECT_EQ(v->getFn, 0x00);  // fn0 for legacy BatteryStatus
+}
+
+TEST(BatteryCapability, ParserPointerRoutesCorrectly) {
+    // Unified variant's parser should handle bitmask fallback;
+    // Legacy variant's parser should not.
+    Report r;
+    r.params[0] = 0;
+    r.params[1] = 0x08; // interpreted as bitmask by unified, as threshold by legacy
+    r.params[2] = 0x00;
+
+    auto unified = kBatteryVariants[0];
+    auto legacy  = kBatteryVariants[1];
+
+    auto unifiedStatus = unified.parse(r);
+    EXPECT_EQ(unifiedStatus.level, 90);   // bitmask 0x08 = full = 90%
+
+    auto legacyStatus = legacy.parse(r);
+    EXPECT_EQ(legacyStatus.level, 0);     // legacy does not use bitmask
+}

--- a/tests/test_capability_dispatch.cpp
+++ b/tests/test_capability_dispatch.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+#include "hidpp/capabilities/Capabilities.h"
+#include "hidpp/FeatureDispatcher.h"
+
+using namespace logitune::hidpp;
+using namespace logitune::hidpp::capabilities;
+
+namespace {
+
+// Minimal test variant struct matching the shape real variants use.
+struct TestVariant {
+    FeatureId feature;
+    int       tag;   // differentiator for assertions
+};
+
+constexpr TestVariant kTestVariants[] = {
+    { FeatureId::BatteryUnified, 1 },
+    { FeatureId::BatteryStatus,  2 },
+};
+
+} // namespace
+
+TEST(ResolveCapability, ReturnsFirstMatch) {
+    FeatureDispatcher fd;
+    fd.setFeatureTable({
+        {FeatureId::BatteryUnified, 0x02},
+    });
+    auto v = resolveCapability(&fd, kTestVariants);
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->feature, FeatureId::BatteryUnified);
+    EXPECT_EQ(v->tag, 1);
+}
+
+TEST(ResolveCapability, FallsBackToSecondMatch) {
+    FeatureDispatcher fd;
+    fd.setFeatureTable({
+        {FeatureId::BatteryStatus, 0x02},
+    });
+    auto v = resolveCapability(&fd, kTestVariants);
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->feature, FeatureId::BatteryStatus);
+    EXPECT_EQ(v->tag, 2);
+}
+
+TEST(ResolveCapability, PrefersFirstWhenBothPresent) {
+    FeatureDispatcher fd;
+    fd.setFeatureTable({
+        {FeatureId::BatteryUnified, 0x02},
+        {FeatureId::BatteryStatus,  0x03},
+    });
+    auto v = resolveCapability(&fd, kTestVariants);
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(v->feature, FeatureId::BatteryUnified);
+    EXPECT_EQ(v->tag, 1);
+}
+
+TEST(ResolveCapability, ReturnsNulloptWhenNoneMatch) {
+    FeatureDispatcher fd;
+    fd.setFeatureTable({
+        {FeatureId::GestureV2, 0x02},
+    });
+    auto v = resolveCapability(&fd, kTestVariants);
+    EXPECT_FALSE(v.has_value());
+}
+
+TEST(ResolveCapability, ReturnsNulloptWhenDispatcherEmpty) {
+    FeatureDispatcher fd;
+    auto v = resolveCapability(&fd, kTestVariants);
+    EXPECT_FALSE(v.has_value());
+}

--- a/tests/test_features.cpp
+++ b/tests/test_features.cpp
@@ -76,6 +76,60 @@ TEST(Battery, ParseZeroPercentCritical) {
 }
 
 // ---------------------------------------------------------------------------
+// Battery (BATTERY_STATUS 0x1000 legacy format)
+// ---------------------------------------------------------------------------
+// Legacy format:
+//   params[0] = current discharge level (percentage)
+//   params[1] = next discharge threshold (ignored)
+//   params[2] = status byte (same enum as UnifiedBattery)
+
+TEST(BatteryLegacy, ParseDischarging) {
+    Report r;
+    r.params[0] = 78;    // 78%
+    r.params[1] = 50;    // next threshold (ignored)
+    r.params[2] = 0x00;  // BatteryState::Discharging
+    auto status = Battery::parseStatusLegacy(r);
+    EXPECT_EQ(status.level, 78);
+    EXPECT_EQ(status.state, BatteryState::Discharging);
+    EXPECT_FALSE(status.charging);
+}
+
+TEST(BatteryLegacy, ParseRecharging) {
+    Report r;
+    r.params[0] = 45;
+    r.params[1] = 30;
+    r.params[2] = 0x01;  // BatteryState::Recharging
+    auto status = Battery::parseStatusLegacy(r);
+    EXPECT_EQ(status.level, 45);
+    EXPECT_EQ(status.state, BatteryState::Recharging);
+    EXPECT_TRUE(status.charging);
+}
+
+TEST(BatteryLegacy, ParseFull) {
+    Report r;
+    r.params[0] = 100;
+    r.params[1] = 90;
+    r.params[2] = 0x03;  // BatteryState::Full
+    auto status = Battery::parseStatusLegacy(r);
+    EXPECT_EQ(status.level, 100);
+    EXPECT_EQ(status.state, BatteryState::Full);
+    EXPECT_TRUE(status.charging);
+}
+
+TEST(BatteryLegacy, IgnoresMiddleByte) {
+    // Legacy format's params[1] must NOT be interpreted as a level bitmask.
+    // If parseStatusLegacy accidentally fell through to bitmask logic, it
+    // would mis-report percentage. Setting params[0]=0 guards the fallback path.
+    Report r;
+    r.params[0] = 0;    // would trigger bitmask fallback in parseStatus()
+    r.params[1] = 0x08; // looks like "full" bitmask but is next-threshold %
+    r.params[2] = 0x00;
+    auto status = Battery::parseStatusLegacy(r);
+    EXPECT_EQ(status.level, 0);  // must stay 0, not become 90
+    EXPECT_FALSE(status.charging);
+}
+
+// ---------------------------------------------------------------------------
 // AdjustableDPI
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Replaces `if/else` variant branches in `DeviceManager` with table-driven capability dispatch. Adds `BATTERY_STATUS (0x1000)` support for MX Master 2S. Adds device name descriptor override.

Closes #15. Unblocks #12.

## What changed

- **New `src/core/hidpp/capabilities/`** directory:
  - `Capabilities.h` — generic `resolveCapability<>()` template
  - `BatteryCapability.{h,cpp}` — `BatteryVariant` struct + `kBatteryVariants[]` table
  - `SmartShiftCapability.{h,cpp}` — `SmartShiftVariant` struct + `kSmartShiftVariants[]` table
- **`BatteryStatus = 0x1000`** added to `FeatureId` enum
- **`Battery::parseStatusLegacy()`** for the `0x1000` response format
- **`DeviceManager` refactored** to resolve capabilities once at enumeration
- **Device name override**: UI shows `m_activeDevice->deviceName()` when a descriptor matches
- **15 new unit tests** for dispatch resolution, battery legacy parsing, and table ordering

## How it works

```cpp
template<typename V, size_t N>
std::optional<V> resolveCapability(FeatureDispatcher* f, const V (&variants)[N]) {
    for (const auto& v : variants)
        if (f->hasFeature(v.feature)) return v;
    return std::nullopt;
}
```

Adding a future variant is a single table entry, zero DeviceManager changes.

## Test results

- 410 unit tests pass (was 395, +15 new)
- 12 tray tests pass
- Smoke tested on MX Master 3S:
  - `battery: feature= 1004 level= 95% charging= false`
  - `SmartShift: feature= 2110 mode= 2 (ratchet) autoDisengage= 64`
  - SmartShift toggle writes correctly
  - Device name matches descriptor