### PR TITLE
hide non-working feature controls per device

### DIFF
--- a/src/app/models/DeviceModel.cpp
+++ b/src/app/models/DeviceModel.cpp
@@ -235,6 +235,13 @@ QVariantList DeviceModel::easySwitchSlotPositions() const
     return result;
 }
 
+bool DeviceModel::smoothScrollSupported() const
+{
+    if (m_dm && m_dm->activeDevice())
+        return m_dm->activeDevice()->features().smoothScroll;
+    return true;
+}
+
 QString DeviceModel::deviceSerial() const
 {
     if (m_dm)

--- a/src/app/models/DeviceModel.h
+++ b/src/app/models/DeviceModel.h
@@ -40,6 +40,7 @@ class DeviceModel : public QObject {
     Q_PROPERTY(QVariantList scrollHotspots READ scrollHotspots NOTIFY deviceConnectedChanged)
     Q_PROPERTY(QVariantList controlDescriptors READ controlDescriptors NOTIFY deviceConnectedChanged)
     Q_PROPERTY(QVariantList easySwitchSlotPositions READ easySwitchSlotPositions NOTIFY deviceConnectedChanged)
+    Q_PROPERTY(bool smoothScrollSupported READ smoothScrollSupported NOTIFY deviceConnectedChanged)
     Q_PROPERTY(QString deviceSerial READ deviceSerial NOTIFY deviceConnectedChanged)
     Q_PROPERTY(QString firmwareVersion READ firmwareVersion NOTIFY deviceConnectedChanged)
     Q_PROPERTY(int activeSlot READ activeSlot NOTIFY deviceConnectedChanged)
@@ -76,6 +77,7 @@ public:
     QVariantList scrollHotspots() const;
     QVariantList controlDescriptors() const;
     QVariantList easySwitchSlotPositions() const;
+    bool smoothScrollSupported() const;
     QString deviceSerial() const;
     QString firmwareVersion() const;
     int activeSlot() const;

--- a/src/app/qml/components/DetailPanel.qml
+++ b/src/app/qml/components/DetailPanel.qml
@@ -214,6 +214,7 @@ Rectangle {
 
             // Smooth scrolling toggle
             Row {
+                visible: DeviceModel.smoothScrollSupported
                 width: parent.width
 
                 Text {

--- a/src/app/qml/pages/PointScrollPage.qml
+++ b/src/app/qml/pages/PointScrollPage.qml
@@ -99,11 +99,15 @@ Item {
 
                 calloutType: "scrollwheel"
                 title: "Scroll wheel"
-                settings: [
-                    "Scroll direction: " + (DeviceModel.scrollInvert ? "Natural" : "Standard"),
-                    "Smooth scrolling: " + (DeviceModel.scrollHiRes ? "On" : "Off"),
-                    "SmartShift: " + (DeviceModel.smartShiftEnabled ? "On" : "Off")
-                ]
+                settings: {
+                    var s = [
+                        "Scroll direction: " + (DeviceModel.scrollInvert ? "Natural" : "Standard")
+                    ];
+                    if (DeviceModel.smoothScrollSupported)
+                        s.push("Smooth scrolling: " + (DeviceModel.scrollHiRes ? "On" : "Off"));
+                    s.push("SmartShift: " + (DeviceModel.smartShiftEnabled ? "On" : "Off"));
+                    return s;
+                }
 
                 onCalloutClicked: function(type) {
                     root.activePanelType = (root.activePanelType === type) ? "" : type

--- a/src/core/devices/MxMaster4Descriptor.cpp
+++ b/src/core/devices/MxMaster4Descriptor.cpp
@@ -66,6 +66,7 @@ FeatureSupport MxMaster4Descriptor::features() const
     f.thumbWheel     = true;
     f.reprogControls = true;
     f.gestureV2      = false;
+    f.smoothScroll   = false;
     return f;
 }
 

--- a/src/core/interfaces/IDevice.h
+++ b/src/core/interfaces/IDevice.h
@@ -32,6 +32,8 @@ struct FeatureSupport {
     bool thumbWheel = false;
     bool reprogControls = false;
     bool gestureV2 = false;
+    bool smoothScroll = true;
+    bool hapticFeedback = false;
 };
 
 struct EasySwitchSlotPosition {


### PR DESCRIPTION
## Summary

Add per-device feature flags so the UI hides controls for features that don't work on specific hardware.

Closes #18.

## What changed

- `FeatureSupport` struct: added `smoothScroll` (default true) and `hapticFeedback` (default false)
- MX Master 4 descriptor: `smoothScroll = false` (HiResWheel writes succeed but scroll behavior doesn't change)
- `DeviceModel`: new `smoothScrollSupported` Q_PROPERTY
- `DetailPanel.qml`: smooth scroll toggle Row has `visible: DeviceModel.smoothScrollSupported`
- `PointScrollPage.qml`: scroll wheel summary card conditionally includes smooth scroll line

## Why

MX4 users see a smooth scrolling toggle that does nothing. The HID++ writes succeed (confirmed via debug log from Jelcoo on PR #6) but the physical scroll behavior doesn't change. Until we figure out the MX4 HiResWheel protocol difference, hide the toggle so users aren't confused.

When we fix MX4 smooth scroll, flip one bool in the descriptor.