### PR TITLE
Descriptor editor mode (built on --simulate-all)

### DIFF
--- a/src/app/AppController.cpp
+++ b/src/app/AppController.cpp
@@ -67,8 +67,19 @@ void AppController::init()
     wireSignals();
 }
 
-void AppController::startMonitoring()
+void AppController::startMonitoring(bool simulateAll)
 {
+    if (simulateAll) {
+        // --simulate-all: populate the carousel with one fake session per
+        // descriptor currently loaded in DeviceRegistry instead of scanning
+        // udev for real hardware. Useful for visually walking through every
+        // community descriptor at once without owning the physical mice.
+        qCInfo(lcApp) << "--simulate-all: seeding carousel from registry";
+        m_deviceManager.simulateAllFromRegistry();
+        m_desktop->start();
+        return;
+    }
+
     m_deviceManager.start();
     m_desktop->start();
     m_deviceFetcher.fetchManifest();

--- a/src/app/AppController.h
+++ b/src/app/AppController.h
@@ -31,7 +31,15 @@ public:
     AppController(IDesktopIntegration *desktop, IInputInjector *injector, QObject *parent = nullptr);
 
     void init();
-    void startMonitoring();
+
+    /// Start the device monitor.
+    ///
+    /// When @p simulateAll is true, the app skips udev + HID++ entirely
+    /// and instead seeds the carousel with one fake session per descriptor
+    /// currently loaded in DeviceRegistry. Used by the `--simulate-all`
+    /// CLI flag for visually inspecting every community descriptor
+    /// without needing physical hardware.
+    void startMonitoring(bool simulateAll = false);
 
     friend class test::AppControllerFixture;
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,4 +1,6 @@
 #include <QApplication>
+#include <QCommandLineOption>
+#include <QCommandLineParser>
 #include <QDir>
 #include <QDirIterator>
 #include <QSettings>
@@ -52,6 +54,23 @@ int main(int argc, char *argv[])
     app.setApplicationVersion(QStringLiteral(PROJECT_VERSION));
     app.setQuitOnLastWindowClosed(false);  // tray icon keeps app alive
     app.setWindowIcon(QIcon(":/Logitune/qml/assets/logitune-icon.svg"));
+
+    // Command-line parsing
+    QCommandLineParser parser;
+    parser.setApplicationDescription(
+        QStringLiteral("Logitune — Logitech device configuration"));
+    parser.addHelpOption();
+    parser.addVersionOption();
+    QCommandLineOption simulateAllOption(
+        QStringLiteral("simulate-all"),
+        QStringLiteral(
+            "Debug: populate the carousel with one fake card per descriptor "
+            "in DeviceRegistry instead of scanning hardware. Used for "
+            "visually inspecting every community descriptor without needing "
+            "the physical mice."));
+    parser.addOption(simulateAllOption);
+    parser.process(app);
+    const bool simulateAll = parser.isSet(simulateAllOption);
 
     // Single-instance guard — prevent two instances fighting over the device
     QLockFile lockFile(QStandardPaths::writableLocation(QStandardPaths::TempLocation)
@@ -198,7 +217,7 @@ int main(int argc, char *argv[])
             qCInfo(lcApp) << "Theme.dark applied:" << isDark;
     }
 
-    controller.startMonitoring();
+    controller.startMonitoring(simulateAll);
 
     // System tray
     logitune::TrayManager tray(controller.deviceModel());

--- a/src/app/qml/pages/EasySwitchPage.qml
+++ b/src/app/qml/pages/EasySwitchPage.qml
@@ -63,9 +63,10 @@ Item {
 
                         x: imageContainer.imgX + imageContainer.imgW * pos.xPct - width / 2
                         y: imageContainer.imgY + imageContainer.imgH * pos.yPct - height / 2
-                        width: 7; height: 7; radius: 3.5
+                        width: 9; height: 9; radius: 4.5
                         color: isActive ? Theme.accent : "transparent"
-                        visible: isActive
+                        border.color: Theme.accent
+                        border.width: isActive ? 0 : 1.5
 
                         SequentialAnimation on opacity {
                             running: isActive

--- a/src/core/DeviceManager.cpp
+++ b/src/core/DeviceManager.cpp
@@ -123,6 +123,54 @@ const IDevice* DeviceManager::activeDevice() const
 }
 
 // ---------------------------------------------------------------------------
+// simulateAllFromRegistry() — --simulate-all CLI flag
+// ---------------------------------------------------------------------------
+
+void DeviceManager::simulateAllFromRegistry()
+{
+    if (!m_registry) {
+        qCWarning(lcDevice) << "simulateAllFromRegistry: no registry";
+        return;
+    }
+
+    const auto &descriptors = m_registry->devices();
+    qCInfo(lcDevice) << "simulateAllFromRegistry: seeding"
+                     << descriptors.size() << "devices from registry";
+
+    int idx = 0;
+    for (const auto &dev : descriptors) {
+        const IDevice *descriptor = dev.get();
+        if (!descriptor)
+            continue;
+
+        // Stable fake serial so duplicate calls would coalesce the same way
+        // real hardware does. Use the slot index so each descriptor gets a
+        // unique row in m_physicalDevices.
+        const QString fakeSerial = QStringLiteral("sim-%1-%2")
+            .arg(idx++, 3, 10, QLatin1Char('0'))
+            .arg(descriptor->deviceName());
+
+        auto hidraw = std::make_unique<hidpp::HidrawDevice>(QStringLiteral("/dev/null"));
+        auto session = std::make_unique<DeviceSession>(
+            std::move(hidraw),
+            DeviceManager::deviceIndexForDirect(),
+            QStringLiteral("Simulated"),
+            m_registry,
+            this);
+        session->applySimulation(descriptor, fakeSerial);
+
+        DeviceSession *sessionPtr = session.get();
+        m_sessions.push_back(std::move(session));
+
+        auto pd = std::make_unique<PhysicalDevice>(fakeSerial, this);
+        pd->attachTransport(sessionPtr);
+        PhysicalDevice *pdPtr = pd.get();
+        m_physicalDevices.emplace(fakeSerial, std::move(pd));
+        emit physicalDeviceAdded(pdPtr);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // start()
 // ---------------------------------------------------------------------------
 

--- a/src/core/DeviceManager.h
+++ b/src/core/DeviceManager.h
@@ -25,6 +25,13 @@ public:
 
     void start();
 
+    // --simulate-all CLI flag entry point — synthesizes a
+    // PhysicalDevice + DeviceSession for every descriptor currently
+    // loaded in DeviceRegistry. Bypasses udev, HID++ probing, and
+    // hardware I/O. Emits physicalDeviceAdded for each so the UI
+    // populates its carousel. Never called from production code.
+    void simulateAllFromRegistry();
+
     // Static helpers
     static bool isReceiver(uint16_t pid);
     static uint8_t deviceIndexForDirect();

--- a/src/core/DeviceSession.cpp
+++ b/src/core/DeviceSession.cpp
@@ -418,6 +418,29 @@ void DeviceSession::enumerateAndSetup()
 }
 
 // ---------------------------------------------------------------------------
+// applySimulation() — --simulate-all entry point
+// ---------------------------------------------------------------------------
+
+void DeviceSession::applySimulation(const IDevice *dev, const QString &fakeSerial)
+{
+    m_activeDevice = dev;
+    m_deviceName = dev ? dev->deviceName() : QStringLiteral("Simulated");
+    m_deviceSerial = fakeSerial;
+    m_connected = true;
+
+    // Populate a few visible-in-UI fields with plausible stubs so the
+    // cards render without empty regions. These never hit real hardware.
+    m_batteryLevel = 85;
+    m_batteryCharging = false;
+    if (dev) {
+        m_minDPI = dev->minDpi();
+        m_maxDPI = dev->maxDpi();
+        m_dpiStep = dev->dpiStep();
+        m_currentDPI = (m_minDPI + m_maxDPI) / 2;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // disconnectCleanup()
 // ---------------------------------------------------------------------------
 

--- a/src/core/DeviceSession.h
+++ b/src/core/DeviceSession.h
@@ -88,6 +88,12 @@ public:
     void setConnectedForTest(bool v) { m_connected = v; }
     void setDeviceNameForTest(const QString &n) { m_deviceName = n; }
 
+    // --simulate-all CLI flag entry point — wires a DeviceSession
+    // into a "fake connected" state against a registry descriptor so
+    // the UI renders its card without real hardware. Bypasses all
+    // HID++ probing. Never called from production code paths.
+    void applySimulation(const IDevice *dev, const QString &fakeSerial);
+
 signals:
     void setupComplete();
     void disconnected();


### PR DESCRIPTION
Closes #33.

Two-part feature on this branch:

## Part 1 — `--simulate-all` debug flag (already implemented)

A CLI flag that populates the carousel with one fake card per descriptor in `DeviceRegistry` instead of scanning udev. Lets the maintainer walk every community descriptor without owning the physical mice.

```
$ logitune --simulate-all
```

| Layer | Production | --simulate-all |
|---|---|---|
| udev / hidraw / HID++ probing | yes | no |
| Capability dispatch tables | yes | no |
| Battery poll, button divert, keystroke injection | yes | no |
| DeviceRegistry JSON load | yes | yes |
| Descriptor → DeviceModel pipeline | yes | yes |
| QML carousel + device pages render | yes | yes |
| Hotspot positioning, `kind` lookup, `isThumbWheel` | yes | yes |

Three layers, ~125 lines, all guarded by the flag. Default code path is byte-identical to today.

| File | Change |
|---|---|
| `src/app/main.cpp` | `QCommandLineParser` parses `--simulate-all` → bool passed into `AppController::startMonitoring(simulateAll)` |
| `src/app/AppController.{h,cpp}` | `startMonitoring(bool simulateAll = false)` branches between `DeviceManager::start()` (real) and `DeviceManager::simulateAllFromRegistry()` (fake) |
| `src/core/DeviceManager.{h,cpp}` | New `simulateAllFromRegistry()` iterates the registry and synthesizes a `PhysicalDevice` + `DeviceSession` per descriptor |
| `src/core/DeviceSession.{h,cpp}` | New public `applySimulation(IDevice*, QString fakeSerial)` stubs `m_activeDevice` / `m_connected` / battery / DPI defaults |

## Part 2 — In-app descriptor editor (design approved, implementation pending)

`--simulate-all` lets you *see* what's wrong; this lets you *fix* it without leaving the app. Adds an `--edit` flag (orthogonal to `--simulate-all`) that gates a WYSIWYG editor: drag easy-switch slot circles, button hotspot markers, and overlay cards directly on the existing pages, with changes saved back to the descriptor JSON the device was loaded from.

**4-tier editing surface:**

1. **Easy-switch slots** — drag the slot circles on the back image
2. **Button & point/scroll hotspots** — drag markers and overlay cards independently; connector line auto-tracks
3. **Image upload** — drag-and-drop a PNG onto the image area, or "Replace image" button opens file picker; atomic copy into the descriptor's directory
4. **Schema additions + text editing** — two new optional fields (`label` on slot objects, `displayName` on hotspots) plus double-click in-place editing of slot labels, button names, device-name header

**Architecture (MVVM, follows existing repo conventions):**

- **`EditorModel`** — ViewModel, QML singleton, instantiated only when `--edit` is set. Owns per-device pending edits, undo stacks, dirty tracking, file watcher, save flow.
- **`DescriptorWriter`** — Model layer, pure C++. Atomic round-trip JSON writer with preserve-unknown-fields semantics (writes back the parsed-from-disk JSON object with edits applied, never re-derives from `JsonDevice` — so any unknown future fields in the file survive verbatim).
- **`JsonDevice::sourcePath()`** — adds source-path tracking so the editor knows where to write back.
- **`DeviceRegistry::reload(path)`** — single entry point used by both save and the file watcher.
- **`EditorToolbar.qml`** — shared 36px bar (save / reset / undo / redo / unsaved indicator), visible only in edit mode.
- **Drag handlers** added inline to `EasySwitchPage.qml`, `ButtonsPage.qml`, `PointScrollPage.qml`, gated on `EditorModel.editing`.

**Key UX decisions (locked during brainstorm):**

- WYSIWYG in-place — fine-tuning `labelOffsetYPct` matters because cards overlap text in the *real* page, not in an abstract editor canvas
- Manual save with "unsaved changes" indicator — drag updates are in-memory until explicit save
- Per-device undo/redo persistent across device switches until save or quit
- File watcher detects external changes (`git pull`); silent reload when no pending edits, conflict prompt with diff viewer when there are
- Atomic save via `QSaveFile` (rename-into-place); self-write watcher events suppressed via a one-shot path set
- Zero impact on production binary path: editor code only runs when `--edit` is set

**Out of scope (deliberately):** editing protocol-level fields (`controlId`, `buttonIndex`, DPI, capabilities), carousel ordering, themes/icons, multi-window coordination, "publish to community-devices repo", auto-save.

**Full design:** `docs/superpowers/specs/2026-04-15-editor-mode-design.md` (this branch).

## Use case

```
# Bulk curation: walk and edit every community descriptor
git clone https://github.com/mmaher88/logitune-devices.git /tmp/logitune-devices
mkdir -p /tmp/sim/logitune
ln -s /tmp/logitune-devices /tmp/sim/logitune/devices
XDG_DATA_HOME=/tmp/sim logitune --simulate-all --edit

# Or: edit the descriptor of the real plugged-in device
logitune --edit
```

## Test plan

### Part 1 (already verified)

- [x] `logitune --help` shows the `--simulate-all` flag
- [x] `logitune` (no flag) goes through the normal udev + HID++ path — verified live with real MX Master 3S
- [x] `logitune --simulate-all` skips udev and seeds the carousel from registry — verified live with cloned community devices repo
- [x] All logitune-tests pass (unchanged)

### Part 2 (implementation pending — design approved)

- [ ] `JsonDevice::sourcePath()` returns canonicalized path; new optional fields parse
- [ ] `DeviceRegistry::reload(path)` replaces cached entry and emits `deviceUpdated`
- [ ] `DescriptorWriter` round-trip byte-identical; preserves `__future_field`; atomic under failure
- [ ] `EditorModel` undo/redo per-device; save clears stack; file watcher silent reload + conflict prompt; self-write suppression
- [ ] `--edit` instantiates `EditorModel` only when set; production binary path unaffected when off
- [ ] Tier 1 — drag easy-switch slot circle, save, restart, position persisted
- [ ] Tier 2 — drag button card, undo, reverted; double-click slot label to rename
- [ ] Tier 3 — drop PNG onto back image area, save, restart, new image renders
- [ ] External `sed` of descriptor while editor is open shows conflict banner with all three options working


## Manual smoke test (run before marking PR ready)

Setup:
```
git clone https://github.com/mmaher88/logitune-devices.git /tmp/logitune-devices-test
mkdir -p /tmp/sim-test/logitune
ln -s /tmp/logitune-devices-test /tmp/sim-test/logitune/devices
XDG_DATA_HOME=/tmp/sim-test ./build/src/app/logitune --simulate-all --edit
```

- [ ] Drag an easy-switch slot circle. Toolbar shows "Unsaved changes".
- [ ] Click Save. Toolbar clears. Restart. Position persisted.
- [ ] Drag a button card to the opposite side. Save. Restart. Side persisted.
- [ ] Double-click a slot label, type "Mac", press Enter. Save. Restart. Label persisted.
- [ ] Drop a PNG onto the back image area. Save. Restart. New image renders.
- [ ] Click "Replace image" → file picker → select PNG. Save. Restart. New image renders.
- [ ] In a separate terminal, sed -i s/Original/Mutated/ on a descriptor file. Conflict banner appears with three buttons. "View diff" opens modal showing both versions.
- [ ] Click "Load disk version". Banner clears, page repaints with disk content.
- [ ] Make an edit, then click Reset. Pending edits discarded.
- [ ] Undo and Redo work across multiple edits.
- [ ] Switch device in carousel, edit, switch back. Both devices' undo stacks intact.
- [ ] Run ./build/src/app/logitune with no flags. Production behavior unchanged: no toolbar, no amber stripe, real device detected.
