### PR TITLE
hide Easy-Switch tab for devices that don't support it

### DIFF
--- a/src/app/qml/components/SideNav.qml
+++ b/src/app/qml/components/SideNav.qml
@@ -10,13 +10,24 @@ Rectangle {
     signal pageSelected(string pageName)
     property string currentPage: "buttons"
 
-    // Nav items model
-    readonly property var navItems: [
-        { name: "buttons",     label: "BUTTONS",         icon: "\uD83D\uDDB1", enabled: true  },
-        { name: "pointscroll", label: "POINT & SCROLL",  icon: "\u25CE",       enabled: true  },
-        { name: "easyswitch",  label: "EASY-SWITCH",     icon: "\u21C4",       enabled: true  },
-        { name: "settings",    label: "SETTINGS",         icon: "\u2261",       enabled: true  }
-    ]
+    // Nav items model — easy-switch is hidden for devices that don't
+    // expose any slot positions or don't have a back image to render
+    // them on. Both come from the loaded descriptor, so the binding
+    // re-evaluates when DeviceModel switches devices.
+    readonly property bool easySwitchSupported:
+        DeviceModel.easySwitchSlotPositions.length > 0
+        && DeviceModel.backImage.length > 0
+
+    readonly property var navItems: {
+        var items = [
+            { name: "buttons",     label: "BUTTONS",         icon: "\uD83D\uDDB1", enabled: true  },
+            { name: "pointscroll", label: "POINT & SCROLL",  icon: "\u25CE",       enabled: true  }
+        ];
+        if (easySwitchSupported)
+            items.push({ name: "easyswitch", label: "EASY-SWITCH", icon: "\u21C4", enabled: true });
+        items.push({ name: "settings", label: "SETTINGS", icon: "\u2261", enabled: true });
+        return items;
+    }
 
     ColumnLayout {
         anchors.fill: parent

--- a/tests/qml/tst_SideNav.qml
+++ b/tests/qml/tst_SideNav.qml
@@ -27,14 +27,26 @@ Item {
             compare(nav.currentPage, "buttons")
         }
 
+        // Compute the y-center of a navItem by name. The easyswitch tab is
+        // conditional on DeviceModel state, so navItems.length can vary —
+        // we can't hardcode pixel offsets. Layout: 16px spacer + ~20px
+        // header (with 17px top margin) + items, each 40px tall with a
+        // 17px top margin between them.
+        function navItemCenterY(name) {
+            var idx = -1;
+            for (var i = 0; i < nav.navItems.length; i++) {
+                if (nav.navItems[i].name === name) { idx = i; break; }
+            }
+            verify(idx >= 0, "no nav item named " + name)
+            // 16 spacer + 53 header block + idx * (40 item + 17 margin) + 20 to centre
+            return 16 + 53 + idx * 57 + 20;
+        }
+
         function test_clickSettingsChangesPage() {
             var spy = createTemporaryObject(signalSpyComponent, this, { target: nav, signalName: "pageSelected" })
             waitForRendering(nav)
 
-            // Layout: 16px spacer + ~20px header + 17px margins + 40px items
-            // Header ≈ 53px. Items: 0→53, 1→110, 2→167, 3→224
-            // Settings (index 3) center ≈ 244
-            mouseClick(nav, 100, 244)
+            mouseClick(nav, 100, navItemCenterY("settings"))
 
             compare(nav.currentPage, "settings", "clicking settings should update currentPage")
             compare(spy.count, 1, "pageSelected signal should fire")
@@ -43,8 +55,7 @@ Item {
         function test_clickPointScrollChangesPage() {
             waitForRendering(nav)
 
-            // pointscroll (index 1) center ≈ 130
-            mouseClick(nav, 100, 130)
+            mouseClick(nav, 100, navItemCenterY("pointscroll"))
 
             compare(nav.currentPage, "pointscroll", "clicking point & scroll should update currentPage")
         }


### PR DESCRIPTION
Closes #35.

The Easy-Switch tab in the side nav was unconditionally shown for every device, even those without Easy-Switch hardware. For mice that don't have multi-host channels (most M-series, MX Anywhere line, MX Vertical, etc.) the tab opened to an empty back-of-mouse area with no slot markers and an irrelevant footer.

## Fix

Make the navItems list a reactive QML binding that re-evaluates when DeviceModel switches devices, and only push the easyswitch entry when both \`easySwitchSlotPositions\` is non-empty AND the descriptor has a back image (without the back image we have nothing meaningful to render anyway).

\`\`\`qml
readonly property bool easySwitchSupported:
    DeviceModel.easySwitchSlotPositions.length > 0
    && DeviceModel.backImage.length > 0

readonly property var navItems: {
    var items = [
        { name: "buttons",     ... },
        { name: "pointscroll", ... }
    ];
    if (easySwitchSupported)
        items.push({ name: "easyswitch", ... });
    items.push({ name: "settings", ... });
    return items;
}
\`\`\`

## Test fix

\`tst_SideNav.qml::test_clickSettingsChangesPage\` was hardcoding the click y-coordinate assuming \"settings\" was always at index 3. Now that the easy-switch tab can be hidden, settings can shift to index 2. Replaced the hardcoded pixel offset with a helper \`navItemCenterY(name)\` that walks the actual \`navItems\` list and computes the y-center based on the current order. Both \`test_clickSettingsChangesPage\` and \`test_clickPointScrollChangesPage\` use the helper so neither is fragile to future nav-item changes.

## Devices affected

After [logitune-devices PR #1](https://github.com/mmaher88/logitune-devices/pull/1) lands, the carousel will include 31 community descriptors. Of those, only ~6 have Easy-Switch slot positions in their Options+ metadata. The other 25 will simply not show the tab.

## How it was discovered

Walking the carousel via the \`--simulate-all\` debug flag from #34 against the regenerated logitune-devices community descriptors. The empty Easy-Switch page on M325, MX Vertical, MX Anywhere etc. made the bug obvious.

## Stacking

This branch is based on \`fix-optionsplus-extraction\` (#29), so the diff against master will currently include all of #29's changes. After #29 merges, this PR's diff will narrow to just SideNav.qml + tst_SideNav.qml.

## Test plan

- [x] All 469 logitune-tests still pass
- [x] All 12 logitune-tray-tests still pass
- [x] All 63 QML tests still pass (including the 5 SideNav tests with the updated click-position helper)
- [x] Verify on real MX Master 3S that Easy-Switch tab still appears and works
- [x] Verify on a device without Easy-Switch (e.g., M510) that the tab is hidden