### PR TITLE
In-app descriptor editor mode

### DIFF
--- a/docs/superpowers/specs/2026-04-15-editor-mode-design.md
+++ b/docs/superpowers/specs/2026-04-15-editor-mode-design.md
@@ -1,0 +1,405 @@
+# Editor Mode — Design Spec
+
+**Date:** 2026-04-15
+**Status:** Approved
+**Related:** PR #34 (`debug-simulate-all`, the predecessor passive-viewer flag)
+
+## Problem
+
+Logitune ships JSON device descriptors that hand-curate the layout of buttons, scroll wheels, and easy-switch indicators on each Logitech mouse. Today these descriptors are produced by `scripts/optionsplus_extractor` from Options+ data, then iteratively patched by hand because Options+ doesn't have all the data we need (e.g. MX Vertical has no back image; LIFT uses `core_metadata_left.json`/`_right.json` instead of `core_metadata.json`; m720-triathlon has channel buttons on the top of the device, not the back).
+
+The current iteration loop is:
+1. Open the JSON in a text editor.
+2. Edit `xPct`/`yPct` by guess.
+3. Restart Logitune with `--simulate-all`.
+4. Squint at whether the slot circle landed in the right place.
+5. Repeat.
+
+This is slow, error-prone, and impossible to do for 30+ community devices in any reasonable time. We need an in-app editor that lets us drag elements directly on the rendered device pages and save back to the source descriptor file.
+
+## Goals
+
+- Drag easy-switch slot circles, button hotspot markers, and overlay cards directly on the existing device pages, with the changes saved back to the descriptor JSON the device was loaded from.
+- Replace device images (back/front/side) by drag-and-drop or file picker.
+- Edit human-readable text fields (slot labels, button names, device name) in place.
+- Support undo/redo per-device, with manual save (no autosave).
+- Detect external file changes (e.g. `git pull` on the community-devices repo) and prompt before clobbering edits.
+- Zero impact on the production binary path: editor code only runs when the `--edit` CLI flag is set.
+
+## Non-goals
+
+- Editing protocol-level fields (`controlId`, `buttonIndex`, DPI ranges, `capabilities` flags). These come from the hardware and shouldn't be hand-edited.
+- Carousel ordering, custom themes, custom icons, capability overrides.
+- Multi-window coordination.
+- A "publish to community-devices repo" button (deferred to a future brainstorm).
+- Cleaning up orphaned uploaded PNGs after undo (acceptable cost: a few stray files until `git clean`).
+- Auto-save / drafts.
+
+## Approach
+
+**WYSIWYG in-place editor.** When `--edit` is set, the existing BUTTONS / POINT & SCROLL / EASY-SWITCH pages gain drag handles on their existing markers, circles, and cards. A toolbar at the top of the central content area shows save/undo/redo/reset and an unsaved-changes indicator. The user edits in the exact rendering they ship — no separate editor view, no tab-switching to verify positions.
+
+The choice of in-place editing over a dedicated editor tab is deliberate: fine-tuning `labelOffsetYPct` matters because cards overlap text in the *real* page, not in an abstract editor canvas. Editing in production rendering eliminates the feedback delay.
+
+The CLI flag `--edit` is **orthogonal** to `--simulate-all`. `--edit` alone edits the descriptor of whatever real device is plugged in. `--simulate-all --edit` is bulk-curation mode: every registered device loaded, all editable.
+
+## Architecture
+
+The design follows the existing MVVM split used throughout Logitune.
+
+### Model layer (pure C++, no QML knowledge)
+
+**`JsonDevice` extension**
+Add source-path tracking so the editor knows where to write back:
+
+```cpp
+class JsonDevice : public IDevice {
+public:
+    JsonDevice(QJsonObject obj, QString sourcePath);
+    QString sourcePath() const { return m_sourcePath; }
+    qint64 loadedMtime() const { return m_loadedMtime; }
+    // ... existing methods unchanged
+private:
+    QString m_sourcePath;     // canonicalized absolute path
+    qint64 m_loadedMtime;     // captured at construction
+};
+```
+
+`m_sourcePath` is set via `QFileInfo::canonicalFilePath()`. `m_loadedMtime` is captured via `QFileInfo::lastModified().toSecsSinceEpoch()` for the file watcher's stale-check.
+
+`IDevice` is **not** changed. The editor casts `qobject_cast<const JsonDevice*>` to check editability; built-in devices (if any) silently aren't editable.
+
+**`DescriptorWriter` (new C++ helper)**
+Pure file I/O service. Takes a `QJsonObject` and a path, writes atomically via `QSaveFile`:
+
+```cpp
+class DescriptorWriter {
+public:
+    enum Result { Ok, IoError, JsonError };
+    Result write(const QString &path, const QJsonObject &obj, QString *errorOut = nullptr);
+};
+```
+
+Writes use `QJsonDocument::Indented` with 4-space indent (matching the community-devices repo convention). Atomic via `QSaveFile::commit()` (rename-into-place). Importantly, the writer applies edits to the **parsed-from-disk** JSON object, not to a re-derivation from `JsonDevice`, so any unknown future fields in the file are preserved verbatim.
+
+**`EditCommand` struct**
+Tagged-struct undo entries (no class hierarchy):
+
+```cpp
+struct EditCommand {
+    enum Kind { SlotMove, HotspotMove, ImageReplace, TextEdit } kind;
+    int index;                // slot idx / button idx (-1 for top-level)
+    QString role;             // "back"/"front"/"side" for ImageReplace; field name for TextEdit
+    QJsonValue before;        // full prior subobject or value
+    QJsonValue after;         // new subobject or value
+};
+```
+
+Undo = swap `before`↔`after` and re-apply. No diffing logic.
+
+### ViewModel layer (Q_PROPERTY-rich, QML-registered)
+
+**`EditorModel` (new QML singleton — "Model" naming matches existing repo convention; it's a ViewModel in MVVM terms)**
+
+State:
+
+```cpp
+class EditorModel : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool editing READ editing CONSTANT)
+    Q_PROPERTY(bool hasUnsavedChanges READ hasUnsavedChanges NOTIFY dirtyChanged)
+    Q_PROPERTY(bool canUndo READ canUndo NOTIFY undoStateChanged)
+    Q_PROPERTY(bool canRedo READ canRedo NOTIFY undoStateChanged)
+    Q_PROPERTY(QString activeDevicePath READ activeDevicePath NOTIFY activeDevicePathChanged)
+
+public slots:
+    void updateSlotPosition(int idx, double xPct, double yPct);
+    void updateHotspot(int buttonIndex, double xPct, double yPct,
+                       QString side, double labelOffsetYPct);
+    void updateText(QString field, int index, QString value);
+    void replaceImage(QString role, QString sourcePath);
+    void save();
+    void reset();
+    void undo();
+    void redo();
+
+signals:
+    void dirtyChanged();
+    void undoStateChanged();
+    void activeDevicePathChanged();
+    void saved(QString path);
+    void saveFailed(QString path, QString error);
+    void externalChangeDetected(QString path);
+
+private:
+    bool m_editing = false;
+    QString m_activeDevicePath;
+    QHash<QString, QJsonObject> m_pendingEdits;       // path -> in-memory descriptor
+    QHash<QString, QStack<EditCommand>> m_undoStacks; // per-device
+    QHash<QString, QStack<EditCommand>> m_redoStacks;
+    QSet<QString> m_dirty;
+    QSet<QString> m_selfWrittenPaths;                 // suppress watcher self-fire
+    QFileSystemWatcher *m_watcher;
+    DeviceRegistry *m_registry;                       // for reload after save
+    DescriptorWriter m_writer;
+};
+```
+
+`EditorModel` is instantiated **only** when `--edit` is set. It is not a globally-registered singleton; it does not exist in the production binary path.
+
+**State management rules**
+- During a drag, the QML element binds its `x`/`y` directly to the drag handler's centroid so it visually tracks the cursor — `EditorModel` is **not** called on every position change. Only on drag *release* does the QML side call `EditorModel.updateSlotPosition(...)`, which mutates `m_pendingEdits[activeDevicePath]` and pushes a single `EditCommand` for the entire drag (so undo undoes the whole drag, not every pixel).
+- Switching active device leaves the prior device's pending edits and undo stack intact; switching back restores them. Per-device state is keyed by source path.
+- Save clears `m_pendingEdits[path]`, both stacks for that path, removes from `m_dirty`. Reset is the same except it doesn't write to disk; reset shows a confirm dialog if `hasUnsavedChanges`.
+- Save failures emit `saveFailed` and leave state intact for retry.
+
+**Existing `DeviceModel` integration**
+When `EditorModel` mutates the in-memory descriptor for the active device, it asks `DeviceModel` to re-emit its position-changed signals so existing bindings repaint. `DeviceModel` itself gains no new properties — it just gets a "refresh from current source" entry point that the editor (and the file watcher) can call.
+
+### View layer (QML)
+
+**`EditorToolbar.qml` (new component)**
+A 36px bar anchored to the top of the central content area in `MainWindow.qml`, visible only when `EditorModel.editing`. Shared across all pages. Layout, left to right:
+- Truncated path label (e.g. `…/devices/mx-master-3s.json`)
+- Unsaved-changes dot + "Unsaved changes" text (visible when `hasUnsavedChanges`)
+- Undo / Redo icon buttons (enabled from `canUndo`/`canRedo`)
+- Reset button (with confirm dialog when dirty)
+- Save button (primary style, disabled when not dirty)
+
+**Edit-mode visual indicator**
+When `editing` is true, the sidebar gets a 4px amber stripe along its left edge so the user always knows at a glance they're in editor mode. Otherwise the UI is visually identical to production.
+
+**Tier 1: Easy-switch slot drag (`EasySwitchPage.qml`)**
+The existing slot-circle Repeater renders a small `Rectangle` per slot. In edit mode each circle gets:
+- An invisible 24×24 hit-target wrapping the visible 9×9 circle (so it's grabbable)
+- A `DragHandler { enabled: EditorModel.editing }`
+- During drag, `x`/`y` bind to the drag handler's centroid converted back to percentages so the circle visually tracks the cursor
+- On drag release, calls `EditorModel.updateSlotPosition(index, newXPct, newYPct)`
+
+The conversion is the inverse of the existing rendering math: `xPct = (centroidX - imageContainer.imgX) / imageContainer.imgW`, clamped to `[0, 1]`. Note: the easyswitch x coordinate is already aspect-corrected at extraction time (the back-image rotation transform); the inverse must produce the *same* aspect-corrected value — this is tested explicitly.
+
+**Tier 2: Button & point/scroll marker and card drag (`ButtonsPage.qml`, `PointScrollPage.qml`)**
+Each hotspot has two draggable elements:
+- *Marker drag* — updates `xPct`/`yPct` only. The connector line auto-tracks via existing rendering bindings.
+- *Card drag* — updates `side` (snap-to-nearest-column based on which half of the screen the centroid is in) and `labelOffsetYPct` (free vertical drag).
+
+When `editing` is on, both elements get a faint outline + cursor change to `Qt.SizeAllCursor` to signal they're draggable.
+
+**Tier 2 text editing**
+Double-click on slot labels, button card names, and the sidebar device-name header turns the text into an in-place `TextField`. Enter commits, Esc cancels. Each commit pushes a `TextEdit` `EditCommand` onto the undo stack.
+
+**Tier 3: Image upload**
+Each image area in EASY-SWITCH and BUTTONS pages becomes a `DropArea` accepting PNG file drops. A small "Replace image" button anchored top-right of the image opens `QFileDialog` as a fallback. Both paths funnel into `EditorModel.replaceImage(role, sourcePath)`.
+
+The replace flow:
+1. Compute destination path: same directory as the descriptor, filename derived from role (reuse existing image's filename if any, else generate `<device-id>-<role>.png`).
+2. `QFile::copy()` the source to the destination (write to temp + atomic rename if destination exists).
+3. Push `EditCommand{ImageReplace, role, beforeFilename, afterFilename}`.
+4. Update in-memory descriptor's `assets.<role>Image` field to the new filename.
+5. Do **not** save the JSON — user still has to hit Save. (The new PNG sits on disk unreferenced until then; harmless.)
+6. On undo: revert the descriptor field. The PNG file stays on disk (orphaned, accepted cost).
+7. On save: descriptor and PNG are both committed.
+
+**Tier 4: Schema additions**
+Two new optional fields, both backwards-compatible (no version bump):
+
+1. **`label` on easy-switch slot objects** (string) — display name for the slot in the channel list at the bottom of EASY-SWITCH page. When absent, falls back to current behavior ("Available" / connection type).
+2. **`displayName` on button hotspots** (string) — overrides `defaultName` for the card heading. When absent, `defaultName` (which the protocol/extractor sets) is used. This lets the editor fix wrong extractor names without overwriting the protocol-derived field.
+
+Both are added to `JsonDevice`'s parsing in `parseEasySwitchSlots()` and `parseHotspots()`. Defaults (empty `QString`) preserve current rendering. Nothing else added to the schema in this scope.
+
+### CLI plumbing
+
+`main.cpp` adds an `--edit` `QCommandLineOption` alongside the existing `--simulate-all`. Both are orthogonal:
+
+```cpp
+const bool simulateAll = parser.isSet(simulateAllOption);
+const bool editMode = parser.isSet(editOption);
+controller.startMonitoring(simulateAll, editMode);
+```
+
+`AppController::startMonitoring(bool simulateAll, bool editMode)`:
+- If `editMode`: instantiate `EditorModel`, hand it the `DeviceRegistry` reference, register as QML singleton via `qmlRegisterSingletonInstance`.
+- Modes are independent: `--edit` alone (real device), `--simulate-all` alone (existing behavior), both (bulk curation), neither (production, unchanged).
+
+## Data flow
+
+### Drag → save round trip
+
+```
+User drags slot circle on EasySwitchPage.qml
+        |
+        v
+DragHandler.onActiveChanged (release)
+        |
+        v
+EditorModel.updateSlotPosition(idx, xPct, yPct)
+        |
+        |--> push EditCommand onto m_undoStacks[activeDevicePath]
+        |--> mutate m_pendingEdits[activeDevicePath]
+        |--> add path to m_dirty
+        |--> emit dirtyChanged, undoStateChanged
+        |--> ask DeviceModel to refresh-from-pending
+        v
+DeviceModel re-emits property change signals
+        |
+        v
+QML bindings repaint (circle stays at new position)
+
+[user clicks Save]
+        |
+        v
+EditorModel::save()
+        |
+        |--> add activeDevicePath to m_selfWrittenPaths
+        |--> DescriptorWriter::write(path, m_pendingEdits[path])
+        |       atomic via QSaveFile
+        |--> on success:
+        |       clear m_pendingEdits[path], stacks, m_dirty
+        |       call DeviceRegistry::reload(path)
+        |       emit saved(path)
+        |--> on failure:
+        |       emit saveFailed(path, error)
+        |       leave state intact
+        v
+DeviceRegistry::reload reads file, replaces cached JsonDevice,
+emits deviceUpdated → DeviceModel re-reads → bindings repaint
+        |
+        v
+QFileSystemWatcher fires for the path we just wrote
+        |
+        v
+EditorModel sees path in m_selfWrittenPaths, removes it, suppresses prompt
+```
+
+### External file change while editing
+
+```
+User runs `git pull` on community-devices repo
+        |
+        v
+QFileSystemWatcher fires fileChanged(path)
+        |
+        v
+EditorModel::onFileChanged(path)
+        |
+        |--> if path in m_selfWrittenPaths: remove, return (own write)
+        |--> compare disk mtime to JsonDevice::loadedMtime
+        |--> if path in m_dirty:
+        |       emit externalChangeDetected(path)
+        |       (banner appears, user picks: keep/load/diff)
+        |--> else:
+        |       silently call DeviceRegistry::reload(path)
+        |       (DeviceModel repaints)
+```
+
+## Schema additions
+
+Both fields are optional; existing descriptors keep working unchanged. No version bump.
+
+### `label` on easy-switch slot
+
+```json
+{
+  "easySwitchSlotPositions": [
+    { "xPct": 0.42, "yPct": 0.78, "label": "Mac" },
+    { "xPct": 0.50, "yPct": 0.78, "label": "Linux" },
+    { "xPct": 0.58, "yPct": 0.78 }
+  ]
+}
+```
+
+### `displayName` on button hotspot
+
+```json
+{
+  "hotspots": [
+    {
+      "buttonIndex": 0,
+      "controlId": 80,
+      "defaultName": "Left Click",
+      "defaultActionType": "click",
+      "displayName": "Primary Button",
+      "xPct": 0.30,
+      "yPct": 0.20,
+      "side": "left",
+      "labelOffsetYPct": 0.05
+    }
+  ]
+}
+```
+
+## Error handling
+
+- **Save failure** (disk full, permission denied, atomic-rename failure): `EditorModel` emits `saveFailed(path, errorString)`; the toolbar surfaces a non-blocking error message; the in-memory pending state is preserved so the user can retry after fixing the cause.
+- **Image copy failure**: same pattern — error surfaced, no descriptor mutation, no `EditCommand` pushed.
+- **Reset on dirty descriptor**: confirm dialog ("Discard unsaved changes?") before reverting.
+- **External file change during pending edit**: non-blocking banner with three options:
+  - **Keep my edits** — leave in-memory state, dismiss banner. Next save will overwrite the disk version (and trigger another self-write watcher event, which is correctly suppressed).
+  - **Load disk version** — discard pending edits, clear undo stack for this path, re-read file.
+  - **View diff** — modal showing on-disk JSON vs in-memory JSON, line-diffed (Myers diff via small helper or `diff` shellout).
+- **Editing a non-`JsonDevice`**: `EditorModel` silently disables editing for that device; toolbar shows "Read-only" instead of Save/Reset.
+- **Symlink target replaced**: re-stat at every reload; if canonical path changed, re-add the watch.
+
+## Testing
+
+### Unit tests (gtest, C++)
+
+- **`tst_DescriptorWriter`** — round-trip byte-identical; preserve unknown fields (`__future_field`); atomic write under failure; indent matches community convention.
+- **`tst_EditorModel`** — drag updates pending state; undo restores prior; per-device stack isolation; save clears stack and dirty; save failure leaves state intact; reset with dirty; file watcher silent reload; file watcher conflict prompt; self-write suppression.
+- **`tst_JsonDeviceSourcePath`** — `sourcePath()` returns canonicalized path; new optional fields parse correctly when present and default to empty when absent.
+- **`tst_DeviceRegistry`** — `loadFromFile(path)` for single descriptor; `reload(path)` replaces cache and emits `deviceUpdated`.
+
+### QML tests (qtest)
+
+- **`tst_EditorToolbar`** — visibility gated on `editing`; save button enabled state tracks `hasUnsavedChanges`; undo/redo state tracks `canUndo`/`canRedo`; Save click invokes `EditorModel.save()` (SignalSpy).
+- **`tst_EasySwitchPageEdit`** — no drag handlers when `editing` is false; drag handlers active when true; drag math test asserts the inverse-of-rendering produces correct `xPct`/`yPct` (including the aspect-correction case).
+- **`tst_ButtonsPageEdit`** — marker drag updates xPct/yPct only; card drag updates side and labelOffsetYPct.
+- **`tst_SideNav`** (extend existing) — amber stripe visible when `editing` is true.
+
+### Integration smoke test
+
+A checklist run before marking the PR ready (not automated CI):
+1. Drag an easy-switch slot, save, restart, assert position persisted.
+2. Drag a button card, undo, assert reverted.
+3. Drop a PNG onto the back image area, save, restart, assert new image renders.
+4. Externally `sed` a descriptor while editor is open, assert conflict banner appears with all three options working.
+
+### Test fixtures
+
+`tests/fixtures/editor/` — copy of `mx-master-3s.json` for mutation tests (so production descriptor isn't touched), plus a synthetic minimal descriptor with `__future_field` for round-trip preservation.
+
+## Risks
+
+1. **`QFileSystemWatcher` on symlinks.** The user keeps `/tmp/sim-live/logitune/devices` as a symlink; `QFileSystemWatcher` watches the resolved target on Linux. If the symlink is recreated pointing elsewhere, watching breaks silently. Mitigation: re-stat at every reload; if the canonical path changed, re-add the watch.
+
+2. **Self-write loop.** Saving fires the watcher for the file we just wrote. Mitigated by `m_selfWrittenPaths`. The suppression must clear on the *first* watcher callback for that path after save, not on a timer, to avoid losing genuine external edits in a same-second window.
+
+3. **`DeviceRegistry` ownership model.** If existing code holds raw `JsonDevice*` pointers across a reload, replacing the cache entry will dangle them. Need to verify the ownership model in `DeviceRegistry` before implementing. Possibly the reload mutates the existing `JsonDevice` object in place rather than replacing it. Flagged for the implementation plan to resolve in the foundation step.
+
+4. **Drag math sign errors on aspect-corrected easyswitch coordinates.** The easyswitch `xPct` is already aspect-multiplied at extraction time (the back-image rotation transform: `x_out = (marker_x / 100) × (back_height / back_width)`). The drag inverse must produce the *same* aspect-multiplied value, not the raw rotated coordinate. Tested explicitly with the m720-triathlon "buttons on top" case.
+
+5. **Schema additions colliding with extractor goldens.** `label` and `displayName` shouldn't appear in extractor output (extractor PR is separate). Verify the extractor's golden fixtures don't accidentally start emitting empty values.
+
+## Build sequence
+
+The writing-plans skill will turn this into TDD tasks. Rough order:
+
+1. **Foundation** — `JsonDevice::sourcePath()`, `DeviceRegistry::loadFromFile`/`reload`, schema additions parsed by `JsonDevice`. No UI yet, fully tested.
+2. **`DescriptorWriter`** — atomic round-trip writer with preserve-unknown-fields. Fully tested in isolation.
+3. **`EditorModel`** (no QML yet) — state, undo stacks, dirty tracking, save flow, file watcher integration. Fully tested via gtest.
+4. **CLI `--edit` flag + AppController plumbing** — instantiates `EditorModel` only when flag set, registers QML singleton.
+5. **`EditorToolbar.qml`** — bar, indicator, save/undo/redo/reset buttons. Smoke test renders.
+6. **Tier 1 — easy-switch slot drag** — drag handlers, drag math + inverse, QML test for the math. End-to-end first slice; fixes the original use case.
+7. **Tier 2 — button & point/scroll markers, cards, text editing** — marker drag, card drag with side-snap, double-click text editing.
+8. **Tier 3 — image upload** — DropArea + file picker, atomic copy into descriptor directory, undo support.
+9. **Conflict banner UI** — for `externalChangeDetected`, with diff modal.
+10. **Smoke-test pass** against a copy of the community-devices repo; document the manual checklist in the PR.
+
+By step 6 the user can already fix easy-switch positions in-app — exactly the workflow that triggered this brainstorm.
+
+## Open questions punted to implementation
+
+- Exact `DeviceRegistry` ownership model (reload-in-place vs. replace) — verified during step 1.
+- Whether `EditCommand` needs a per-command label for "Undo move slot 2" tooltips — defer until UX feels lacking.
+- Whether to store editor toolbar position as a `QSettings` preference — defer; fixed at the top is fine.

--- a/src/app/AppController.cpp
+++ b/src/app/AppController.cpp
@@ -67,8 +67,19 @@ void AppController::init()
     wireSignals();
 }
 
-void AppController::startMonitoring()
+void AppController::startMonitoring(bool simulateAll)
 {
+    if (simulateAll) {
+        // --simulate-all: populate the carousel with one fake session per
+        // descriptor currently loaded in DeviceRegistry instead of scanning
+        // udev for real hardware. Useful for visually walking through every
+        // community descriptor at once without owning the physical mice.
+        qCInfo(lcApp) << "--simulate-all: seeding carousel from registry";
+        m_deviceManager.simulateAllFromRegistry();
+        m_desktop->start();
+        return;
+    }
+
     m_deviceManager.start();
     m_desktop->start();
     m_deviceFetcher.fetchManifest();

--- a/src/app/AppController.cpp
+++ b/src/app/AppController.cpp
@@ -1,4 +1,5 @@
 #include "AppController.h"
+#include "devices/JsonDevice.h"
 #include "models/EditorModel.h"
 #include "desktop/KDeDesktop.h"
 #include "desktop/GnomeDesktop.h"
@@ -75,6 +76,18 @@ void AppController::startMonitoring(bool simulateAll, bool editMode)
     if (editMode) {
         m_editorModel = std::make_unique<EditorModel>(&m_registry, true, this);
         qCInfo(lcApp) << "--edit: editor mode active";
+
+        auto syncActive = [this]() {
+            if (!m_editorModel)
+                return;
+            const IDevice *dev = m_deviceModel.activeDevice();
+            if (auto *jd = dynamic_cast<const JsonDevice *>(dev))
+                m_editorModel->setActiveDevicePath(jd->sourcePath());
+            else
+                m_editorModel->setActiveDevicePath(QString());
+        };
+        connect(&m_deviceModel, &DeviceModel::selectedChanged, this, syncActive);
+        syncActive();
     }
     if (simulateAll) {
         // --simulate-all: populate the carousel with one fake session per

--- a/src/app/AppController.cpp
+++ b/src/app/AppController.cpp
@@ -1,4 +1,5 @@
 #include "AppController.h"
+#include "models/EditorModel.h"
 #include "desktop/KDeDesktop.h"
 #include "desktop/GnomeDesktop.h"
 #include "desktop/GenericDesktop.h"
@@ -48,6 +49,8 @@ AppController::AppController(IDesktopIntegration *desktop, IInputInjector *injec
     m_actionExecutor.setInjector(m_injector);
 }
 
+AppController::~AppController() = default;
+
 void AppController::init()
 {
     m_deviceModel.setDesktopIntegration(m_desktop);
@@ -67,8 +70,12 @@ void AppController::init()
     wireSignals();
 }
 
-void AppController::startMonitoring(bool simulateAll)
+void AppController::startMonitoring(bool simulateAll, bool editMode)
 {
+    if (editMode) {
+        m_editorModel = std::make_unique<EditorModel>(&m_registry, true, this);
+        qCInfo(lcApp) << "--edit: editor mode active";
+    }
     if (simulateAll) {
         // --simulate-all: populate the carousel with one fake session per
         // descriptor currently loaded in DeviceRegistry instead of scanning

--- a/src/app/AppController.cpp
+++ b/src/app/AppController.cpp
@@ -74,7 +74,7 @@ void AppController::init()
 void AppController::startMonitoring(bool simulateAll, bool editMode)
 {
     if (editMode) {
-        m_editorModel = std::make_unique<EditorModel>(&m_registry, true, this);
+        m_editorModel = std::make_unique<EditorModel>(&m_registry, &m_deviceModel, true, this);
         qCInfo(lcApp) << "--edit: editor mode active";
 
         auto syncActive = [this]() {

--- a/src/app/AppController.h
+++ b/src/app/AppController.h
@@ -31,7 +31,15 @@ public:
     AppController(IDesktopIntegration *desktop, IInputInjector *injector, QObject *parent = nullptr);
 
     void init();
-    void startMonitoring();
+
+    /// Start the device monitor.
+    ///
+    /// When @p simulateAll is true, the app skips udev + HID++ entirely
+    /// and instead seeds the carousel with one fake session per descriptor
+    /// currently loaded in DeviceRegistry. Used by the `--simulate-all`
+    /// CLI flag for visually inspecting every community descriptor
+    /// without needing physical hardware.
+    void startMonitoring(bool simulateAll = false);
 
     friend class test::AppControllerFixture;
 

--- a/src/app/AppController.h
+++ b/src/app/AppController.h
@@ -24,11 +24,14 @@ namespace logitune::test { class AppControllerFixture; }
 
 namespace logitune {
 
+class EditorModel;
+
 class AppController : public QObject {
     Q_OBJECT
 public:
     explicit AppController(QObject *parent = nullptr);
     AppController(IDesktopIntegration *desktop, IInputInjector *injector, QObject *parent = nullptr);
+    ~AppController() override;
 
     void init();
 
@@ -39,7 +42,7 @@ public:
     /// currently loaded in DeviceRegistry. Used by the `--simulate-all`
     /// CLI flag for visually inspecting every community descriptor
     /// without needing physical hardware.
-    void startMonitoring(bool simulateAll = false);
+    void startMonitoring(bool simulateAll = false, bool editMode = false);
 
     friend class test::AppControllerFixture;
 
@@ -48,6 +51,7 @@ public:
     ActionModel    *actionModel()    { return &m_actionModel; }
     ProfileModel   *profileModel()   { return &m_profileModel; }
     SettingsModel  *settingsModel()  { return &m_settingsModel; }
+    EditorModel    *editorModel() const { return m_editorModel.get(); }
 
 private slots:
     void onUserButtonChanged(int buttonId, const QString &actionName, const QString &actionType);
@@ -89,6 +93,7 @@ private:
     ProfileEngine  m_profileEngine;
     ActionExecutor m_actionExecutor;
 
+    std::unique_ptr<EditorModel>         m_editorModel;
     std::unique_ptr<IDesktopIntegration> m_ownedDesktop;
     std::unique_ptr<IInputInjector>      m_ownedInjector;
     IDesktopIntegration *m_desktop  = nullptr;

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -30,7 +30,8 @@ else()
     foreach(_file
         SideNav BatteryChip LogituneSlider LogituneToggle InfoCallout
         DetailPanel KeystrokeCapture ButtonCallout ActionsPanel
-        DeviceCard DeviceRender AppProfileBar Toast EditorToolbar)
+        DeviceCard DeviceRender AppProfileBar Toast EditorToolbar
+        EditableText)
         set_source_files_properties(qml/components/${_file}.qml
             PROPERTIES QT_RESOURCE_ALIAS qml/${_file}.qml)
     endforeach()
@@ -65,6 +66,7 @@ qt_add_qml_module(logitune-app-lib
         qml/components/AppProfileBar.qml
         qml/components/Toast.qml
         qml/components/EditorToolbar.qml
+        qml/components/EditableText.qml
         qml/pages/PointScrollPage.qml
         qml/pages/ButtonsPage.qml
         qml/pages/EasySwitchPage.qml

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
         SideNav BatteryChip LogituneSlider LogituneToggle InfoCallout
         DetailPanel KeystrokeCapture ButtonCallout ActionsPanel
         DeviceCard DeviceRender AppProfileBar Toast EditorToolbar
-        EditableText ConflictBanner)
+        EditableText ConflictBanner DiffModal)
         set_source_files_properties(qml/components/${_file}.qml
             PROPERTIES QT_RESOURCE_ALIAS qml/${_file}.qml)
     endforeach()
@@ -68,6 +68,7 @@ qt_add_qml_module(logitune-app-lib
         qml/components/EditorToolbar.qml
         qml/components/EditableText.qml
         qml/components/ConflictBanner.qml
+        qml/components/DiffModal.qml
         qml/pages/PointScrollPage.qml
         qml/pages/ButtonsPage.qml
         qml/pages/EasySwitchPage.qml

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
         SideNav BatteryChip LogituneSlider LogituneToggle InfoCallout
         DetailPanel KeystrokeCapture ButtonCallout ActionsPanel
         DeviceCard DeviceRender AppProfileBar Toast EditorToolbar
-        EditableText)
+        EditableText ConflictBanner)
         set_source_files_properties(qml/components/${_file}.qml
             PROPERTIES QT_RESOURCE_ALIAS qml/${_file}.qml)
     endforeach()
@@ -67,6 +67,7 @@ qt_add_qml_module(logitune-app-lib
         qml/components/Toast.qml
         qml/components/EditorToolbar.qml
         qml/components/EditableText.qml
+        qml/components/ConflictBanner.qml
         qml/pages/PointScrollPage.qml
         qml/pages/ButtonsPage.qml
         qml/pages/EasySwitchPage.qml

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
         SideNav BatteryChip LogituneSlider LogituneToggle InfoCallout
         DetailPanel KeystrokeCapture ButtonCallout ActionsPanel
         DeviceCard DeviceRender AppProfileBar Toast EditorToolbar
-        EditableText ConflictBanner DiffModal)
+        EditableText ConflictBanner DiffModal HotspotControl)
         set_source_files_properties(qml/components/${_file}.qml
             PROPERTIES QT_RESOURCE_ALIAS qml/${_file}.qml)
     endforeach()
@@ -69,6 +69,7 @@ qt_add_qml_module(logitune-app-lib
         qml/components/EditableText.qml
         qml/components/ConflictBanner.qml
         qml/components/DiffModal.qml
+        qml/components/HotspotControl.qml
         qml/pages/PointScrollPage.qml
         qml/pages/ButtonsPage.qml
         qml/pages/EasySwitchPage.qml

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(logitune-app-lib STATIC
     models/ButtonModel.cpp
     models/ActionModel.cpp
     models/ProfileModel.cpp
+    models/EditorModel.cpp
     dialogs/GitHubIssueBuilder.cpp
     dialogs/CrashReportDialog.cpp
     TrayManager.cpp

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
     foreach(_file
         SideNav BatteryChip LogituneSlider LogituneToggle InfoCallout
         DetailPanel KeystrokeCapture ButtonCallout ActionsPanel
-        DeviceCard DeviceRender AppProfileBar Toast)
+        DeviceCard DeviceRender AppProfileBar Toast EditorToolbar)
         set_source_files_properties(qml/components/${_file}.qml
             PROPERTIES QT_RESOURCE_ALIAS qml/${_file}.qml)
     endforeach()
@@ -64,6 +64,7 @@ qt_add_qml_module(logitune-app-lib
         qml/components/DeviceRender.qml
         qml/components/AppProfileBar.qml
         qml/components/Toast.qml
+        qml/components/EditorToolbar.qml
         qml/pages/PointScrollPage.qml
         qml/pages/ButtonsPage.qml
         qml/pages/EasySwitchPage.qml

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,4 +1,6 @@
 #include <QApplication>
+#include <QCommandLineOption>
+#include <QCommandLineParser>
 #include <QDir>
 #include <QDirIterator>
 #include <QSettings>
@@ -52,6 +54,23 @@ int main(int argc, char *argv[])
     app.setApplicationVersion(QStringLiteral(PROJECT_VERSION));
     app.setQuitOnLastWindowClosed(false);  // tray icon keeps app alive
     app.setWindowIcon(QIcon(":/Logitune/qml/assets/logitune-icon.svg"));
+
+    // Command-line parsing
+    QCommandLineParser parser;
+    parser.setApplicationDescription(
+        QStringLiteral("Logitune — Logitech device configuration"));
+    parser.addHelpOption();
+    parser.addVersionOption();
+    QCommandLineOption simulateAllOption(
+        QStringLiteral("simulate-all"),
+        QStringLiteral(
+            "Debug: populate the carousel with one fake card per descriptor "
+            "in DeviceRegistry instead of scanning hardware. Used for "
+            "visually inspecting every community descriptor without needing "
+            "the physical mice."));
+    parser.addOption(simulateAllOption);
+    parser.process(app);
+    const bool simulateAll = parser.isSet(simulateAllOption);
 
     // Single-instance guard — prevent two instances fighting over the device
     QLockFile lockFile(QStandardPaths::writableLocation(QStandardPaths::TempLocation)
@@ -198,7 +217,7 @@ int main(int argc, char *argv[])
             qCInfo(lcApp) << "Theme.dark applied:" << isDark;
     }
 
-    controller.startMonitoring();
+    controller.startMonitoring(simulateAll);
 
     // System tray
     logitune::TrayManager tray(controller.deviceModel());

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -19,6 +19,7 @@
 #include <QDBusVariant>
 
 #include "AppController.h"
+#include "models/EditorModel.h"
 #include "logging/LogManager.h"
 #include "logging/CrashHandler.h"
 #include "dialogs/CrashReportDialog.h"
@@ -69,8 +70,15 @@ int main(int argc, char *argv[])
             "visually inspecting every community descriptor without needing "
             "the physical mice."));
     parser.addOption(simulateAllOption);
+    QCommandLineOption editOption(
+        QStringLiteral("edit"),
+        QStringLiteral("Enable in-app descriptor editor mode. Drag elements on "
+                       "device pages to edit slot positions, hotspots, and images. "
+                       "Save writes back to the source descriptor JSON."));
+    parser.addOption(editOption);
     parser.process(app);
     const bool simulateAll = parser.isSet(simulateAllOption);
+    const bool editMode = parser.isSet(editOption);
 
     // Single-instance guard — prevent two instances fighting over the device
     QLockFile lockFile(QStandardPaths::writableLocation(QStandardPaths::TempLocation)
@@ -194,6 +202,16 @@ int main(int argc, char *argv[])
                              "Logitune", 1, 0, "Theme");
 #endif
 
+    controller.startMonitoring(simulateAll, editMode);
+
+    if (editMode && controller.editorModel()) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+        qmlRegisterSingletonInstance("Logitune", 1, 0, "EditorModel", controller.editorModel());
+#else
+        engine.rootContext()->setContextProperty("EditorModel", controller.editorModel());
+#endif
+    }
+
     qCInfo(lcApp) << "Loading QML...";
     engine.load(QUrl(QStringLiteral("qrc:/Logitune/qml/Main.qml")));
     qCInfo(lcApp) << "QML loaded, root objects:" << engine.rootObjects().size();
@@ -216,8 +234,6 @@ int main(int argc, char *argv[])
         else
             qCInfo(lcApp) << "Theme.dark applied:" << isDark;
     }
-
-    controller.startMonitoring(simulateAll);
 
     // System tray
     logitune::TrayManager tray(controller.deviceModel());

--- a/src/app/models/DeviceModel.cpp
+++ b/src/app/models/DeviceModel.cpp
@@ -565,6 +565,7 @@ QVariantList DeviceModel::controlDescriptors() const
         QVariantMap entry;
         entry[QStringLiteral("buttonId")]      = ctrl.buttonIndex;
         entry[QStringLiteral("buttonName")]    = ctrl.defaultName;
+        entry[QStringLiteral("displayName")]   = ctrl.displayName;
         entry[QStringLiteral("actionDefault")] = ctrl.defaultActionType;
         entry[QStringLiteral("configurable")]  = ctrl.configurable;
         result.append(entry);
@@ -584,6 +585,7 @@ QVariantList DeviceModel::easySwitchSlotPositions() const
         QVariantMap entry;
         entry[QStringLiteral("xPct")] = pos.xPct;
         entry[QStringLiteral("yPct")] = pos.yPct;
+        entry[QStringLiteral("label")] = pos.label;
         result.append(entry);
     }
     return result;

--- a/src/app/models/DeviceModel.cpp
+++ b/src/app/models/DeviceModel.cpp
@@ -341,6 +341,12 @@ PhysicalDevice *DeviceModel::selectedDevice() const
     return nullptr;
 }
 
+const IDevice *DeviceModel::activeDevice() const
+{
+    auto *s = selectedDevice();
+    return s ? s->descriptor() : nullptr;
+}
+
 // ---------------------------------------------------------------------------
 // Desktop integration
 // ---------------------------------------------------------------------------

--- a/src/app/models/DeviceModel.cpp
+++ b/src/app/models/DeviceModel.cpp
@@ -519,7 +519,7 @@ QVariantList DeviceModel::buttonHotspots() const
 
         auto it = controlMap.find(hs.buttonIndex);
         if (it != controlMap.end()) {
-            entry[QStringLiteral("buttonLabel")]    = it->defaultName;
+            entry[QStringLiteral("buttonLabel")]    = it->displayName.isEmpty() ? it->defaultName : it->displayName;
             entry[QStringLiteral("actionDefault")]  = it->defaultName;
             entry[QStringLiteral("configurable")]   = it->configurable;
         } else {

--- a/src/app/models/DeviceModel.cpp
+++ b/src/app/models/DeviceModel.cpp
@@ -633,11 +633,6 @@ bool DeviceModel::isSlotPaired(int slot) const
 
 void DeviceModel::refreshFromActiveDevice()
 {
-    // The selected IDevice* (a JsonDevice owned by DeviceRegistry) has been
-    // mutated in place by EditorModel. Re-emit selectedChanged so every QML
-    // binding that reads through activeDevice()->descriptor() re-fetches the
-    // updated values (slot positions, button hotspots, scroll hotspots,
-    // control display names, images, etc).
     emit selectedChanged();
 }
 

--- a/src/app/models/DeviceModel.cpp
+++ b/src/app/models/DeviceModel.cpp
@@ -631,6 +631,16 @@ bool DeviceModel::isSlotPaired(int slot) const
     return s->isHostPaired(slot - 1);
 }
 
+void DeviceModel::refreshFromActiveDevice()
+{
+    // The selected IDevice* (a JsonDevice owned by DeviceRegistry) has been
+    // mutated in place by EditorModel. Re-emit selectedChanged so every QML
+    // binding that reads through activeDevice()->descriptor() re-fetches the
+    // updated values (slot positions, button hotspots, scroll hotspots,
+    // control display names, images, etc).
+    emit selectedChanged();
+}
+
 void DeviceModel::setDisplayValues(int dpi, bool smartShiftEnabled, int smartShiftThreshold,
                                     bool scrollHiRes, bool scrollInvert, const QString &thumbWheelMode,
                                     bool thumbWheelInvert)

--- a/src/app/models/DeviceModel.h
+++ b/src/app/models/DeviceModel.h
@@ -87,6 +87,8 @@ public:
     const QList<PhysicalDevice *> &devices() const;
     Q_INVOKABLE void moveDevice(int from, int to);
 
+    const IDevice *activeDevice() const;
+
     void setDesktopIntegration(IDesktopIntegration *desktop);
     Q_INVOKABLE void blockGlobalShortcuts(bool block);
     Q_INVOKABLE QVariantList runningApplications() const;

--- a/src/app/models/DeviceModel.h
+++ b/src/app/models/DeviceModel.h
@@ -145,6 +145,12 @@ public:
                           bool scrollHiRes, bool scrollInvert, const QString &thumbWheelMode,
                           bool thumbWheelInvert = false);
 
+public slots:
+    // Re-emit selectedChanged so QML bindings that read from the active
+    // IDevice* (controls, hotspots, slots, images) re-fetch. Used by
+    // EditorModel after it mutates the underlying JsonDevice in place.
+    void refreshFromActiveDevice();
+
 signals:
     void countChanged();
     void selectedChanged();

--- a/src/app/models/EditCommand.h
+++ b/src/app/models/EditCommand.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <QString>
+#include <QJsonValue>
+
+namespace logitune {
+
+struct EditCommand {
+    enum Kind { SlotMove, HotspotMove, ImageReplace, TextEdit };
+    Kind kind;
+    int index = -1;
+    QString role;
+    QJsonValue before;
+    QJsonValue after;
+};
+
+} // namespace logitune

--- a/src/app/models/EditorModel.cpp
+++ b/src/app/models/EditorModel.cpp
@@ -91,6 +91,44 @@ void EditorModel::updateHotspot(int idx, double xPct, double yPct,
     pushCommand(std::move(cmd));
 }
 
+void EditorModel::updateText(const QString &field, int index, const QString &value) {
+    if (m_activeDevicePath.isEmpty()) return;
+    ensurePending(m_activeDevicePath);
+    QJsonObject &obj = m_pendingEdits[m_activeDevicePath];
+
+    EditCommand cmd;
+    cmd.kind = EditCommand::TextEdit;
+    cmd.role = field;
+    cmd.index = index;
+
+    if (field == QStringLiteral("deviceName")) {
+        cmd.before = obj.value(QStringLiteral("name"));
+        cmd.after = value;
+        obj[QStringLiteral("name")] = value;
+    } else if (field == QStringLiteral("controlDisplayName")) {
+        QJsonArray controls = obj.value(QStringLiteral("controls")).toArray();
+        if (index < 0 || index >= controls.size()) return;
+        QJsonObject c = controls[index].toObject();
+        cmd.before = c.value(QStringLiteral("displayName"));
+        c[QStringLiteral("displayName")] = value;
+        controls[index] = c;
+        obj[QStringLiteral("controls")] = controls;
+        cmd.after = value;
+    } else if (field == QStringLiteral("slotLabel")) {
+        QJsonArray slotsArr = obj.value(QStringLiteral("easySwitchSlots")).toArray();
+        if (index < 0 || index >= slotsArr.size()) return;
+        QJsonObject s = slotsArr[index].toObject();
+        cmd.before = s.value(QStringLiteral("label"));
+        s[QStringLiteral("label")] = value;
+        slotsArr[index] = s;
+        obj[QStringLiteral("easySwitchSlots")] = slotsArr;
+        cmd.after = value;
+    } else {
+        return;
+    }
+    pushCommand(std::move(cmd));
+}
+
 void EditorModel::applyCommand(const EditCommand &cmd, bool reverse) {
     QJsonObject &obj = m_pendingEdits[m_activeDevicePath];
     const QJsonValue &target = reverse ? cmd.before : cmd.after;
@@ -108,6 +146,22 @@ void EditorModel::applyCommand(const EditCommand &cmd, bool reverse) {
         QJsonObject images = obj.value(QStringLiteral("images")).toObject();
         images[cmd.role] = target.toString();
         obj[QStringLiteral("images")] = images;
+    } else if (cmd.kind == EditCommand::TextEdit) {
+        if (cmd.role == QStringLiteral("deviceName")) {
+            obj[QStringLiteral("name")] = target;
+        } else if (cmd.role == QStringLiteral("controlDisplayName")) {
+            QJsonArray controls = obj.value(QStringLiteral("controls")).toArray();
+            QJsonObject c = controls[cmd.index].toObject();
+            c[QStringLiteral("displayName")] = target;
+            controls[cmd.index] = c;
+            obj[QStringLiteral("controls")] = controls;
+        } else if (cmd.role == QStringLiteral("slotLabel")) {
+            QJsonArray slotsArr = obj.value(QStringLiteral("easySwitchSlots")).toArray();
+            QJsonObject s = slotsArr[cmd.index].toObject();
+            s[QStringLiteral("label")] = target;
+            slotsArr[cmd.index] = s;
+            obj[QStringLiteral("easySwitchSlots")] = slotsArr;
+        }
     }
 }
 

--- a/src/app/models/EditorModel.cpp
+++ b/src/app/models/EditorModel.cpp
@@ -216,4 +216,14 @@ void EditorModel::save() {
     emit saved(m_activeDevicePath);
 }
 
+void EditorModel::reset() {
+    if (m_activeDevicePath.isEmpty()) return;
+    m_pendingEdits.remove(m_activeDevicePath);
+    m_undoStacks.remove(m_activeDevicePath);
+    m_redoStacks.remove(m_activeDevicePath);
+    m_dirty.remove(m_activeDevicePath);
+    emit dirtyChanged();
+    emit undoStateChanged();
+}
+
 } // namespace logitune

--- a/src/app/models/EditorModel.cpp
+++ b/src/app/models/EditorModel.cpp
@@ -107,6 +107,7 @@ void EditorModel::updateHotspot(int idx, double xPct, double yPct,
 
     EditCommand cmd;
     cmd.kind = EditCommand::HotspotMove;
+    cmd.role = QStringLiteral("buttons");
     cmd.index = idx;
     cmd.before = buttons[idx];
 
@@ -119,6 +120,34 @@ void EditorModel::updateHotspot(int idx, double xPct, double yPct,
     hotspots[QStringLiteral("buttons")] = buttons;
     obj[QStringLiteral("hotspots")] = hotspots;
     cmd.after = buttons[idx];
+
+    pushCommand(std::move(cmd));
+}
+
+void EditorModel::updateScrollHotspot(int idx, double xPct, double yPct,
+                                       const QString &side, double labelOffsetYPct) {
+    if (m_activeDevicePath.isEmpty()) return;
+    ensurePending(m_activeDevicePath);
+    QJsonObject &obj = m_pendingEdits[m_activeDevicePath];
+    QJsonObject hotspots = obj.value(QStringLiteral("hotspots")).toObject();
+    QJsonArray scroll = hotspots.value(QStringLiteral("scroll")).toArray();
+    if (idx < 0 || idx >= scroll.size()) return;
+
+    EditCommand cmd;
+    cmd.kind = EditCommand::HotspotMove;
+    cmd.role = QStringLiteral("scroll");
+    cmd.index = idx;
+    cmd.before = scroll[idx];
+
+    QJsonObject hs = scroll[idx].toObject();
+    hs[QStringLiteral("xPct")] = xPct;
+    hs[QStringLiteral("yPct")] = yPct;
+    hs[QStringLiteral("side")] = side;
+    hs[QStringLiteral("labelOffsetYPct")] = labelOffsetYPct;
+    scroll[idx] = hs;
+    hotspots[QStringLiteral("scroll")] = scroll;
+    obj[QStringLiteral("hotspots")] = hotspots;
+    cmd.after = scroll[idx];
 
     pushCommand(std::move(cmd));
 }
@@ -170,9 +199,12 @@ void EditorModel::applyCommand(const EditCommand &cmd, bool reverse) {
         obj[QStringLiteral("easySwitchSlots")] = slotsArr;
     } else if (cmd.kind == EditCommand::HotspotMove) {
         QJsonObject hotspots = obj.value(QStringLiteral("hotspots")).toObject();
-        QJsonArray buttons = hotspots.value(QStringLiteral("buttons")).toArray();
-        buttons[cmd.index] = target;
-        hotspots[QStringLiteral("buttons")] = buttons;
+        const QString arrayKey = cmd.role.isEmpty()
+            ? QStringLiteral("buttons")
+            : cmd.role;
+        QJsonArray arr = hotspots.value(arrayKey).toArray();
+        arr[cmd.index] = target;
+        hotspots[arrayKey] = arr;
         obj[QStringLiteral("hotspots")] = hotspots;
     } else if (cmd.kind == EditCommand::ImageReplace) {
         QJsonObject images = obj.value(QStringLiteral("images")).toObject();

--- a/src/app/models/EditorModel.cpp
+++ b/src/app/models/EditorModel.cpp
@@ -41,6 +41,10 @@ void EditorModel::onExternalFileChanged(const QString &filePath) {
         m_registry->reload(canonical);
 }
 
+QVariantMap EditorModel::pendingFor(const QString &path) const {
+    return m_pendingEdits.value(path).toVariantMap();
+}
+
 bool EditorModel::canUndo() const {
     auto it = m_undoStacks.find(m_activeDevicePath);
     return it != m_undoStacks.end() && !it->isEmpty();

--- a/src/app/models/EditorModel.cpp
+++ b/src/app/models/EditorModel.cpp
@@ -64,4 +64,31 @@ void EditorModel::updateSlotPosition(int idx, double xPct, double yPct) {
     pushCommand(std::move(cmd));
 }
 
+void EditorModel::updateHotspot(int idx, double xPct, double yPct,
+                                 const QString &side, double labelOffsetYPct) {
+    if (m_activeDevicePath.isEmpty()) return;
+    ensurePending(m_activeDevicePath);
+    QJsonObject &obj = m_pendingEdits[m_activeDevicePath];
+    QJsonObject hotspots = obj.value(QStringLiteral("hotspots")).toObject();
+    QJsonArray buttons = hotspots.value(QStringLiteral("buttons")).toArray();
+    if (idx < 0 || idx >= buttons.size()) return;
+
+    EditCommand cmd;
+    cmd.kind = EditCommand::HotspotMove;
+    cmd.index = idx;
+    cmd.before = buttons[idx];
+
+    QJsonObject hs = buttons[idx].toObject();
+    hs[QStringLiteral("xPct")] = xPct;
+    hs[QStringLiteral("yPct")] = yPct;
+    hs[QStringLiteral("side")] = side;
+    hs[QStringLiteral("labelOffsetYPct")] = labelOffsetYPct;
+    buttons[idx] = hs;
+    hotspots[QStringLiteral("buttons")] = buttons;
+    obj[QStringLiteral("hotspots")] = hotspots;
+    cmd.after = buttons[idx];
+
+    pushCommand(std::move(cmd));
+}
+
 } // namespace logitune

--- a/src/app/models/EditorModel.cpp
+++ b/src/app/models/EditorModel.cpp
@@ -188,4 +188,32 @@ void EditorModel::redo() {
     emit undoStateChanged();
 }
 
+void EditorModel::save() {
+    if (m_activeDevicePath.isEmpty()) return;
+    if (!m_pendingEdits.contains(m_activeDevicePath)) return;
+
+    m_selfWrittenPaths.insert(m_activeDevicePath);
+
+    QString err;
+    auto result = m_writer.write(m_activeDevicePath,
+                                 m_pendingEdits.value(m_activeDevicePath), &err);
+    if (result != DescriptorWriter::Ok) {
+        m_selfWrittenPaths.remove(m_activeDevicePath);
+        emit saveFailed(m_activeDevicePath, err);
+        return;
+    }
+
+    if (m_registry)
+        m_registry->reload(m_activeDevicePath);
+
+    m_pendingEdits.remove(m_activeDevicePath);
+    m_undoStacks.remove(m_activeDevicePath);
+    m_redoStacks.remove(m_activeDevicePath);
+    m_dirty.remove(m_activeDevicePath);
+
+    emit dirtyChanged();
+    emit undoStateChanged();
+    emit saved(m_activeDevicePath);
+}
+
 } // namespace logitune

--- a/src/app/models/EditorModel.cpp
+++ b/src/app/models/EditorModel.cpp
@@ -1,13 +1,45 @@
 #include "EditorModel.h"
 #include "DeviceRegistry.h"
+#include "devices/JsonDevice.h"
 #include <QFile>
+#include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonArray>
 
 namespace logitune {
 
 EditorModel::EditorModel(DeviceRegistry *registry, bool editing, QObject *parent)
-    : QObject(parent), m_registry(registry), m_editing(editing) {}
+    : QObject(parent), m_registry(registry), m_editing(editing) {
+    m_watcher = new QFileSystemWatcher(this);
+    connect(m_watcher, &QFileSystemWatcher::fileChanged,
+            this, &EditorModel::onExternalFileChanged);
+
+    if (m_registry) {
+        for (const auto &dev : m_registry->devices()) {
+            if (auto *jd = dynamic_cast<const JsonDevice*>(dev.get())) {
+                m_watcher->addPath(jd->sourcePath() + QStringLiteral("/descriptor.json"));
+            }
+        }
+    }
+}
+
+void EditorModel::onExternalFileChanged(const QString &filePath) {
+    const QString devicePath = QFileInfo(filePath).absolutePath();
+    const QString canonical = QFileInfo(devicePath).canonicalFilePath();
+
+    if (m_selfWrittenPaths.contains(canonical)) {
+        m_selfWrittenPaths.remove(canonical);
+        return;
+    }
+
+    if (m_dirty.contains(canonical)) {
+        emit externalChangeDetected(canonical);
+        return;
+    }
+
+    if (m_registry)
+        m_registry->reload(canonical);
+}
 
 bool EditorModel::canUndo() const {
     auto it = m_undoStacks.find(m_activeDevicePath);

--- a/src/app/models/EditorModel.cpp
+++ b/src/app/models/EditorModel.cpp
@@ -216,6 +216,38 @@ void EditorModel::save() {
     emit saved(m_activeDevicePath);
 }
 
+void EditorModel::replaceImage(const QString &role, const QString &sourcePath) {
+    if (m_activeDevicePath.isEmpty()) return;
+    if (role != QStringLiteral("front") && role != QStringLiteral("side") && role != QStringLiteral("back")) return;
+    if (!QFile::exists(sourcePath)) return;
+
+    ensurePending(m_activeDevicePath);
+    QJsonObject &obj = m_pendingEdits[m_activeDevicePath];
+    QJsonObject images = obj.value(QStringLiteral("images")).toObject();
+    const QString prevName = images.value(role).toString();
+    const QString newName = role + QStringLiteral(".png");
+    const QString destPath = m_activeDevicePath + QStringLiteral("/") + newName;
+
+    const QString tmpPath = destPath + QStringLiteral(".tmp");
+    QFile::remove(tmpPath);
+    if (!QFile::copy(sourcePath, tmpPath)) return;
+    QFile::remove(destPath);
+    if (!QFile::rename(tmpPath, destPath)) {
+        QFile::remove(tmpPath);
+        return;
+    }
+
+    EditCommand cmd;
+    cmd.kind = EditCommand::ImageReplace;
+    cmd.role = role;
+    cmd.before = prevName;
+    cmd.after = newName;
+
+    images[role] = newName;
+    obj[QStringLiteral("images")] = images;
+    pushCommand(std::move(cmd));
+}
+
 void EditorModel::reset() {
     if (m_activeDevicePath.isEmpty()) return;
     m_pendingEdits.remove(m_activeDevicePath);

--- a/src/app/models/EditorModel.cpp
+++ b/src/app/models/EditorModel.cpp
@@ -91,4 +91,47 @@ void EditorModel::updateHotspot(int idx, double xPct, double yPct,
     pushCommand(std::move(cmd));
 }
 
+void EditorModel::applyCommand(const EditCommand &cmd, bool reverse) {
+    QJsonObject &obj = m_pendingEdits[m_activeDevicePath];
+    const QJsonValue &target = reverse ? cmd.before : cmd.after;
+    if (cmd.kind == EditCommand::SlotMove) {
+        QJsonArray slotsArr = obj.value(QStringLiteral("easySwitchSlots")).toArray();
+        slotsArr[cmd.index] = target;
+        obj[QStringLiteral("easySwitchSlots")] = slotsArr;
+    } else if (cmd.kind == EditCommand::HotspotMove) {
+        QJsonObject hotspots = obj.value(QStringLiteral("hotspots")).toObject();
+        QJsonArray buttons = hotspots.value(QStringLiteral("buttons")).toArray();
+        buttons[cmd.index] = target;
+        hotspots[QStringLiteral("buttons")] = buttons;
+        obj[QStringLiteral("hotspots")] = hotspots;
+    } else if (cmd.kind == EditCommand::ImageReplace) {
+        QJsonObject images = obj.value(QStringLiteral("images")).toObject();
+        images[cmd.role] = target.toString();
+        obj[QStringLiteral("images")] = images;
+    }
+}
+
+void EditorModel::undo() {
+    auto &stack = m_undoStacks[m_activeDevicePath];
+    if (stack.isEmpty()) return;
+    EditCommand cmd = stack.pop();
+    applyCommand(cmd, true);
+    m_redoStacks[m_activeDevicePath].push(cmd);
+
+    if (stack.isEmpty()) m_dirty.remove(m_activeDevicePath);
+    emit dirtyChanged();
+    emit undoStateChanged();
+}
+
+void EditorModel::redo() {
+    auto &stack = m_redoStacks[m_activeDevicePath];
+    if (stack.isEmpty()) return;
+    EditCommand cmd = stack.pop();
+    applyCommand(cmd, false);
+    m_undoStacks[m_activeDevicePath].push(cmd);
+    m_dirty.insert(m_activeDevicePath);
+    emit dirtyChanged();
+    emit undoStateChanged();
+}
+
 } // namespace logitune

--- a/src/app/models/EditorModel.cpp
+++ b/src/app/models/EditorModel.cpp
@@ -1,5 +1,8 @@
 #include "EditorModel.h"
 #include "DeviceRegistry.h"
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonArray>
 
 namespace logitune {
 
@@ -22,6 +25,43 @@ void EditorModel::setActiveDevicePath(const QString &path) {
     emit activeDevicePathChanged();
     emit dirtyChanged();
     emit undoStateChanged();
+}
+
+void EditorModel::ensurePending(const QString &path) {
+    if (m_pendingEdits.contains(path)) return;
+    QFile f(path + QStringLiteral("/descriptor.json"));
+    if (!f.open(QIODevice::ReadOnly)) return;
+    m_pendingEdits[path] = QJsonDocument::fromJson(f.readAll()).object();
+}
+
+void EditorModel::pushCommand(EditCommand cmd) {
+    m_undoStacks[m_activeDevicePath].push(std::move(cmd));
+    m_redoStacks[m_activeDevicePath].clear();
+    m_dirty.insert(m_activeDevicePath);
+    emit dirtyChanged();
+    emit undoStateChanged();
+}
+
+void EditorModel::updateSlotPosition(int idx, double xPct, double yPct) {
+    if (m_activeDevicePath.isEmpty()) return;
+    ensurePending(m_activeDevicePath);
+    QJsonObject &obj = m_pendingEdits[m_activeDevicePath];
+    QJsonArray slotsArr = obj.value(QStringLiteral("easySwitchSlots")).toArray();
+    if (idx < 0 || idx >= slotsArr.size()) return;
+
+    EditCommand cmd;
+    cmd.kind = EditCommand::SlotMove;
+    cmd.index = idx;
+    cmd.before = slotsArr[idx];
+
+    QJsonObject slot = slotsArr[idx].toObject();
+    slot[QStringLiteral("xPct")] = xPct;
+    slot[QStringLiteral("yPct")] = yPct;
+    slotsArr[idx] = slot;
+    obj[QStringLiteral("easySwitchSlots")] = slotsArr;
+    cmd.after = slotsArr[idx];
+
+    pushCommand(std::move(cmd));
 }
 
 } // namespace logitune

--- a/src/app/models/EditorModel.cpp
+++ b/src/app/models/EditorModel.cpp
@@ -1,0 +1,27 @@
+#include "EditorModel.h"
+#include "DeviceRegistry.h"
+
+namespace logitune {
+
+EditorModel::EditorModel(DeviceRegistry *registry, bool editing, QObject *parent)
+    : QObject(parent), m_registry(registry), m_editing(editing) {}
+
+bool EditorModel::canUndo() const {
+    auto it = m_undoStacks.find(m_activeDevicePath);
+    return it != m_undoStacks.end() && !it->isEmpty();
+}
+
+bool EditorModel::canRedo() const {
+    auto it = m_redoStacks.find(m_activeDevicePath);
+    return it != m_redoStacks.end() && !it->isEmpty();
+}
+
+void EditorModel::setActiveDevicePath(const QString &path) {
+    if (path == m_activeDevicePath) return;
+    m_activeDevicePath = path;
+    emit activeDevicePathChanged();
+    emit dirtyChanged();
+    emit undoStateChanged();
+}
+
+} // namespace logitune

--- a/src/app/models/EditorModel.cpp
+++ b/src/app/models/EditorModel.cpp
@@ -85,10 +85,6 @@ void EditorModel::pushStateToActiveDevice() {
     if (m_activeDevicePath.isEmpty()) return;
     if (!m_pendingEdits.contains(m_activeDevicePath)) return;
 
-    // findBySourcePath returns const IDevice* because the public registry
-    // contract is read-only, but editor mode owns the mutation lifecycle and
-    // we know the concrete type is a JsonDevice that can be refreshed in
-    // place. Const-cast is safe here.
     const IDevice *constDev = m_registry->findBySourcePath(m_activeDevicePath);
     if (!constDev) return;
     auto *jd = const_cast<JsonDevice*>(dynamic_cast<const JsonDevice*>(constDev));

--- a/src/app/models/EditorModel.cpp
+++ b/src/app/models/EditorModel.cpp
@@ -1,4 +1,5 @@
 #include "EditorModel.h"
+#include "DeviceModel.h"
 #include "DeviceRegistry.h"
 #include "devices/JsonDevice.h"
 #include <QFile>
@@ -8,8 +9,9 @@
 
 namespace logitune {
 
-EditorModel::EditorModel(DeviceRegistry *registry, bool editing, QObject *parent)
-    : QObject(parent), m_registry(registry), m_editing(editing) {
+EditorModel::EditorModel(DeviceRegistry *registry, DeviceModel *deviceModel,
+                         bool editing, QObject *parent)
+    : QObject(parent), m_registry(registry), m_deviceModel(deviceModel), m_editing(editing) {
     m_watcher = new QFileSystemWatcher(this);
     connect(m_watcher, &QFileSystemWatcher::fileChanged,
             this, &EditorModel::onExternalFileChanged);
@@ -78,6 +80,26 @@ void EditorModel::pushCommand(EditCommand cmd) {
     emit undoStateChanged();
 }
 
+void EditorModel::pushStateToActiveDevice() {
+    if (!m_registry) return;
+    if (m_activeDevicePath.isEmpty()) return;
+    if (!m_pendingEdits.contains(m_activeDevicePath)) return;
+
+    // findBySourcePath returns const IDevice* because the public registry
+    // contract is read-only, but editor mode owns the mutation lifecycle and
+    // we know the concrete type is a JsonDevice that can be refreshed in
+    // place. Const-cast is safe here.
+    const IDevice *constDev = m_registry->findBySourcePath(m_activeDevicePath);
+    if (!constDev) return;
+    auto *jd = const_cast<JsonDevice*>(dynamic_cast<const JsonDevice*>(constDev));
+    if (!jd) return;
+
+    jd->refreshFromObject(m_pendingEdits.value(m_activeDevicePath));
+
+    if (m_deviceModel)
+        m_deviceModel->refreshFromActiveDevice();
+}
+
 void EditorModel::updateSlotPosition(int idx, double xPct, double yPct) {
     if (m_activeDevicePath.isEmpty()) return;
     ensurePending(m_activeDevicePath);
@@ -98,6 +120,7 @@ void EditorModel::updateSlotPosition(int idx, double xPct, double yPct) {
     cmd.after = slotsArr[idx];
 
     pushCommand(std::move(cmd));
+    pushStateToActiveDevice();
 }
 
 void EditorModel::updateHotspot(int idx, double xPct, double yPct,
@@ -126,6 +149,7 @@ void EditorModel::updateHotspot(int idx, double xPct, double yPct,
     cmd.after = buttons[idx];
 
     pushCommand(std::move(cmd));
+    pushStateToActiveDevice();
 }
 
 void EditorModel::updateScrollHotspot(int idx, double xPct, double yPct,
@@ -154,6 +178,7 @@ void EditorModel::updateScrollHotspot(int idx, double xPct, double yPct,
     cmd.after = scroll[idx];
 
     pushCommand(std::move(cmd));
+    pushStateToActiveDevice();
 }
 
 void EditorModel::updateText(const QString &field, int index, const QString &value) {
@@ -192,6 +217,7 @@ void EditorModel::updateText(const QString &field, int index, const QString &val
         return;
     }
     pushCommand(std::move(cmd));
+    pushStateToActiveDevice();
 }
 
 void EditorModel::applyCommand(const EditCommand &cmd, bool reverse) {
@@ -243,6 +269,7 @@ void EditorModel::undo() {
     if (stack.isEmpty()) m_dirty.remove(m_activeDevicePath);
     emit dirtyChanged();
     emit undoStateChanged();
+    pushStateToActiveDevice();
 }
 
 void EditorModel::redo() {
@@ -254,6 +281,7 @@ void EditorModel::redo() {
     m_dirty.insert(m_activeDevicePath);
     emit dirtyChanged();
     emit undoStateChanged();
+    pushStateToActiveDevice();
 }
 
 void EditorModel::save() {
@@ -278,6 +306,10 @@ void EditorModel::save() {
     m_undoStacks.remove(m_activeDevicePath);
     m_redoStacks.remove(m_activeDevicePath);
     m_dirty.remove(m_activeDevicePath);
+
+    // The JsonDevice now reflects the on-disk state; bump QML bindings.
+    if (m_deviceModel)
+        m_deviceModel->refreshFromActiveDevice();
 
     emit dirtyChanged();
     emit undoStateChanged();
@@ -314,6 +346,7 @@ void EditorModel::replaceImage(const QString &role, const QString &sourcePath) {
     images[role] = newName;
     obj[QStringLiteral("images")] = images;
     pushCommand(std::move(cmd));
+    pushStateToActiveDevice();
 }
 
 void EditorModel::reset() {
@@ -322,6 +355,12 @@ void EditorModel::reset() {
     m_undoStacks.remove(m_activeDevicePath);
     m_redoStacks.remove(m_activeDevicePath);
     m_dirty.remove(m_activeDevicePath);
+    // Any mutations we pushed into the live JsonDevice now need to be
+    // reverted to match the on-disk state.
+    if (m_registry)
+        m_registry->reload(m_activeDevicePath);
+    if (m_deviceModel)
+        m_deviceModel->refreshFromActiveDevice();
     emit dirtyChanged();
     emit undoStateChanged();
 }

--- a/src/app/models/EditorModel.h
+++ b/src/app/models/EditorModel.h
@@ -29,6 +29,8 @@ public:
     bool canRedo() const;
     QString activeDevicePath() const { return m_activeDevicePath; }
 
+    Q_INVOKABLE QVariantMap pendingFor(const QString &path) const;
+
 public slots:
     void setActiveDevicePath(const QString &path);
     Q_INVOKABLE void updateSlotPosition(int idx, double xPct, double yPct);

--- a/src/app/models/EditorModel.h
+++ b/src/app/models/EditorModel.h
@@ -29,6 +29,7 @@ public:
 
 public slots:
     void setActiveDevicePath(const QString &path);
+    Q_INVOKABLE void updateSlotPosition(int idx, double xPct, double yPct);
 
 signals:
     void dirtyChanged();
@@ -36,6 +37,9 @@ signals:
     void activeDevicePathChanged();
 
 private:
+    void ensurePending(const QString &path);
+    void pushCommand(EditCommand cmd);
+
     DeviceRegistry *m_registry;
     bool m_editing;
     QString m_activeDevicePath;

--- a/src/app/models/EditorModel.h
+++ b/src/app/models/EditorModel.h
@@ -6,6 +6,7 @@
 #include <QStack>
 #include <QJsonObject>
 #include "EditCommand.h"
+#include "devices/DescriptorWriter.h"
 
 namespace logitune {
 
@@ -35,11 +36,14 @@ public slots:
     Q_INVOKABLE void updateText(const QString &field, int index, const QString &value);
     Q_INVOKABLE void undo();
     Q_INVOKABLE void redo();
+    Q_INVOKABLE void save();
 
 signals:
     void dirtyChanged();
     void undoStateChanged();
     void activeDevicePathChanged();
+    void saved(const QString &path);
+    void saveFailed(const QString &path, const QString &error);
 
 private:
     void ensurePending(const QString &path);
@@ -53,6 +57,8 @@ private:
     QHash<QString, QStack<EditCommand>> m_undoStacks;
     QHash<QString, QStack<EditCommand>> m_redoStacks;
     QSet<QString> m_dirty;
+    DescriptorWriter m_writer;
+    QSet<QString> m_selfWrittenPaths;
 };
 
 } // namespace logitune

--- a/src/app/models/EditorModel.h
+++ b/src/app/models/EditorModel.h
@@ -38,6 +38,7 @@ public slots:
     Q_INVOKABLE void redo();
     Q_INVOKABLE void save();
     Q_INVOKABLE void reset();
+    Q_INVOKABLE void replaceImage(const QString &role, const QString &sourcePath);
 
 signals:
     void dirtyChanged();

--- a/src/app/models/EditorModel.h
+++ b/src/app/models/EditorModel.h
@@ -32,6 +32,8 @@ public slots:
     Q_INVOKABLE void updateSlotPosition(int idx, double xPct, double yPct);
     Q_INVOKABLE void updateHotspot(int hotspotIndex, double xPct, double yPct,
                                    const QString &side, double labelOffsetYPct);
+    Q_INVOKABLE void undo();
+    Q_INVOKABLE void redo();
 
 signals:
     void dirtyChanged();
@@ -41,6 +43,7 @@ signals:
 private:
     void ensurePending(const QString &path);
     void pushCommand(EditCommand cmd);
+    void applyCommand(const EditCommand &cmd, bool reverse);
 
     DeviceRegistry *m_registry;
     bool m_editing;

--- a/src/app/models/EditorModel.h
+++ b/src/app/models/EditorModel.h
@@ -32,6 +32,7 @@ public slots:
     Q_INVOKABLE void updateSlotPosition(int idx, double xPct, double yPct);
     Q_INVOKABLE void updateHotspot(int hotspotIndex, double xPct, double yPct,
                                    const QString &side, double labelOffsetYPct);
+    Q_INVOKABLE void updateText(const QString &field, int index, const QString &value);
     Q_INVOKABLE void undo();
     Q_INVOKABLE void redo();
 

--- a/src/app/models/EditorModel.h
+++ b/src/app/models/EditorModel.h
@@ -37,6 +37,7 @@ public slots:
     Q_INVOKABLE void undo();
     Q_INVOKABLE void redo();
     Q_INVOKABLE void save();
+    Q_INVOKABLE void reset();
 
 signals:
     void dirtyChanged();

--- a/src/app/models/EditorModel.h
+++ b/src/app/models/EditorModel.h
@@ -5,6 +5,7 @@
 #include <QSet>
 #include <QStack>
 #include <QJsonObject>
+#include <QFileSystemWatcher>
 #include "EditCommand.h"
 #include "devices/DescriptorWriter.h"
 
@@ -39,6 +40,7 @@ public slots:
     Q_INVOKABLE void save();
     Q_INVOKABLE void reset();
     Q_INVOKABLE void replaceImage(const QString &role, const QString &sourcePath);
+    void onExternalFileChanged(const QString &filePath);
 
 signals:
     void dirtyChanged();
@@ -46,6 +48,7 @@ signals:
     void activeDevicePathChanged();
     void saved(const QString &path);
     void saveFailed(const QString &path, const QString &error);
+    void externalChangeDetected(const QString &path);
 
 private:
     void ensurePending(const QString &path);
@@ -61,6 +64,7 @@ private:
     QSet<QString> m_dirty;
     DescriptorWriter m_writer;
     QSet<QString> m_selfWrittenPaths;
+    QFileSystemWatcher *m_watcher = nullptr;
 };
 
 } // namespace logitune

--- a/src/app/models/EditorModel.h
+++ b/src/app/models/EditorModel.h
@@ -30,6 +30,8 @@ public:
 public slots:
     void setActiveDevicePath(const QString &path);
     Q_INVOKABLE void updateSlotPosition(int idx, double xPct, double yPct);
+    Q_INVOKABLE void updateHotspot(int hotspotIndex, double xPct, double yPct,
+                                   const QString &side, double labelOffsetYPct);
 
 signals:
     void dirtyChanged();

--- a/src/app/models/EditorModel.h
+++ b/src/app/models/EditorModel.h
@@ -34,6 +34,8 @@ public slots:
     Q_INVOKABLE void updateSlotPosition(int idx, double xPct, double yPct);
     Q_INVOKABLE void updateHotspot(int hotspotIndex, double xPct, double yPct,
                                    const QString &side, double labelOffsetYPct);
+    Q_INVOKABLE void updateScrollHotspot(int hotspotIndex, double xPct, double yPct,
+                                         const QString &side, double labelOffsetYPct);
     Q_INVOKABLE void updateText(const QString &field, int index, const QString &value);
     Q_INVOKABLE void undo();
     Q_INVOKABLE void redo();

--- a/src/app/models/EditorModel.h
+++ b/src/app/models/EditorModel.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <QObject>
+#include <QString>
+#include <QHash>
+#include <QSet>
+#include <QStack>
+#include <QJsonObject>
+#include "EditCommand.h"
+
+namespace logitune {
+
+class DeviceRegistry;
+
+class EditorModel : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool editing READ editing CONSTANT)
+    Q_PROPERTY(bool hasUnsavedChanges READ hasUnsavedChanges NOTIFY dirtyChanged)
+    Q_PROPERTY(bool canUndo READ canUndo NOTIFY undoStateChanged)
+    Q_PROPERTY(bool canRedo READ canRedo NOTIFY undoStateChanged)
+    Q_PROPERTY(QString activeDevicePath READ activeDevicePath WRITE setActiveDevicePath NOTIFY activeDevicePathChanged)
+public:
+    explicit EditorModel(DeviceRegistry *registry, bool editing, QObject *parent = nullptr);
+
+    bool editing() const { return m_editing; }
+    bool hasUnsavedChanges() const { return m_dirty.contains(m_activeDevicePath); }
+    bool canUndo() const;
+    bool canRedo() const;
+    QString activeDevicePath() const { return m_activeDevicePath; }
+
+public slots:
+    void setActiveDevicePath(const QString &path);
+
+signals:
+    void dirtyChanged();
+    void undoStateChanged();
+    void activeDevicePathChanged();
+
+private:
+    DeviceRegistry *m_registry;
+    bool m_editing;
+    QString m_activeDevicePath;
+    QHash<QString, QJsonObject> m_pendingEdits;
+    QHash<QString, QStack<EditCommand>> m_undoStacks;
+    QHash<QString, QStack<EditCommand>> m_redoStacks;
+    QSet<QString> m_dirty;
+};
+
+} // namespace logitune

--- a/src/app/models/EditorModel.h
+++ b/src/app/models/EditorModel.h
@@ -12,6 +12,7 @@
 namespace logitune {
 
 class DeviceRegistry;
+class DeviceModel;
 
 class EditorModel : public QObject {
     Q_OBJECT
@@ -21,7 +22,8 @@ class EditorModel : public QObject {
     Q_PROPERTY(bool canRedo READ canRedo NOTIFY undoStateChanged)
     Q_PROPERTY(QString activeDevicePath READ activeDevicePath WRITE setActiveDevicePath NOTIFY activeDevicePathChanged)
 public:
-    explicit EditorModel(DeviceRegistry *registry, bool editing, QObject *parent = nullptr);
+    explicit EditorModel(DeviceRegistry *registry, DeviceModel *deviceModel,
+                         bool editing, QObject *parent = nullptr);
 
     bool editing() const { return m_editing; }
     bool hasUnsavedChanges() const { return m_dirty.contains(m_activeDevicePath); }
@@ -58,8 +60,13 @@ private:
     void ensurePending(const QString &path);
     void pushCommand(EditCommand cmd);
     void applyCommand(const EditCommand &cmd, bool reverse);
+    // Push the current pending JSON into the live JsonDevice owned by the
+    // registry and ask DeviceModel to re-emit its property signals so QML
+    // bindings re-fetch. No-op if DeviceModel is null (tests).
+    void pushStateToActiveDevice();
 
     DeviceRegistry *m_registry;
+    DeviceModel *m_deviceModel;
     bool m_editing;
     QString m_activeDevicePath;
     QHash<QString, QJsonObject> m_pendingEdits;

--- a/src/app/qml/Main.qml
+++ b/src/app/qml/Main.qml
@@ -173,9 +173,14 @@ ApplicationWindow {
     }
 
     // ── Content below title bar ─────────────────────────────────────────
+    EditorToolbar {
+        id: editorToolbar
+        anchors { top: titleBar.bottom; left: parent.left; right: parent.right }
+    }
+
     StackView {
         id: mainStack
-        anchors { top: titleBar.bottom; left: parent.left; right: parent.right; bottom: parent.bottom }
+        anchors { top: editorToolbar.bottom; left: parent.left; right: parent.right; bottom: parent.bottom }
         initialItem: homeViewComponent
     }
 

--- a/src/app/qml/Main.qml
+++ b/src/app/qml/Main.qml
@@ -176,6 +176,7 @@ ApplicationWindow {
     EditorToolbar {
         id: editorToolbar
         anchors { top: titleBar.bottom; left: parent.left; right: parent.right }
+        onDevicePage: mainStack.depth > 1
     }
 
     ConflictBanner {

--- a/src/app/qml/Main.qml
+++ b/src/app/qml/Main.qml
@@ -178,9 +178,17 @@ ApplicationWindow {
         anchors { top: titleBar.bottom; left: parent.left; right: parent.right }
     }
 
+    ConflictBanner {
+        id: conflictBanner
+        anchors { top: editorToolbar.bottom; left: parent.left; right: parent.right }
+        onViewDiffRequested: function(path) {
+            console.log("View diff requested for", path)
+        }
+    }
+
     StackView {
         id: mainStack
-        anchors { top: editorToolbar.bottom; left: parent.left; right: parent.right; bottom: parent.bottom }
+        anchors { top: conflictBanner.bottom; left: parent.left; right: parent.right; bottom: parent.bottom }
         initialItem: homeViewComponent
     }
 

--- a/src/app/qml/Main.qml
+++ b/src/app/qml/Main.qml
@@ -182,8 +182,12 @@ ApplicationWindow {
         id: conflictBanner
         anchors { top: editorToolbar.bottom; left: parent.left; right: parent.right }
         onViewDiffRequested: function(path) {
-            console.log("View diff requested for", path)
+            diffModal.open(path)
         }
+    }
+
+    DiffModal {
+        id: diffModal
     }
 
     StackView {

--- a/src/app/qml/components/ButtonCallout.qml
+++ b/src/app/qml/components/ButtonCallout.qml
@@ -29,7 +29,10 @@ Item {
     property real hsLabelOffsetYPct: 0
     property real pageWidth: 0
     property real pageHeight: 0
-    readonly property bool dragging: cardDrag.active
+    // Manual drag flag — cleared AFTER EditorModel update. Gating a Binding
+    // directly on cardDrag.active races DragHandler.onActiveChanged and snaps
+    // the card back to its pre-drag position.
+    property bool dragging: false
 
     readonly property int controlIndex: {
         var ctrls = DeviceModel.controlDescriptors
@@ -184,14 +187,18 @@ Item {
             if (active) {
                 cardDrag.grabOffsetYPct = root.hsLabelOffsetYPct
                 cardDrag.grabY = root.y
-            } else if (root.pageWidth > 0 && root.pageHeight > 0) {
-                var centroidX = root.x + root.width / 2
-                var newSide = centroidX < root.pageWidth / 2 ? "left" : "right"
-                var dy = root.y - cardDrag.grabY
-                var newOffsetY = cardDrag.grabOffsetYPct + (dy / root.pageHeight)
-                EditorModel.updateHotspot(root.hotspotIndex,
-                                           root.hsXPct, root.hsYPct,
-                                           newSide, newOffsetY)
+                root.dragging = true
+            } else {
+                if (root.pageWidth > 0 && root.pageHeight > 0) {
+                    var centroidX = root.x + root.width / 2
+                    var newSide = centroidX < root.pageWidth / 2 ? "left" : "right"
+                    var dy = root.y - cardDrag.grabY
+                    var newOffsetY = cardDrag.grabOffsetYPct + (dy / root.pageHeight)
+                    EditorModel.updateHotspot(root.hotspotIndex,
+                                               root.hsXPct, root.hsYPct,
+                                               newSide, newOffsetY)
+                }
+                root.dragging = false
             }
         }
     }

--- a/src/app/qml/components/ButtonCallout.qml
+++ b/src/app/qml/components/ButtonCallout.qml
@@ -23,12 +23,23 @@ Item {
 
     // Editor-mode drag support (see ButtonsPage wiring)
     property int  hotspotIndex: -1
+    property int  buttonId: -1
     property real hsXPct: 0
     property real hsYPct: 0
     property real hsLabelOffsetYPct: 0
     property real pageWidth: 0
     property real pageHeight: 0
     readonly property bool dragging: cardDrag.active
+
+    readonly property int controlIndex: {
+        var ctrls = DeviceModel.controlDescriptors
+        if (!ctrls) return -1
+        for (var i = 0; i < ctrls.length; ++i) {
+            if (ctrls[i].buttonId === root.buttonId)
+                return i
+        }
+        return -1
+    }
 
     signal clicked()
 
@@ -115,15 +126,18 @@ Item {
             spacing: 2
 
             // Physical button name (primary, bold)
-            Text {
+            EditableText {
+                id: nameLabel
+                width: 156
+                height: 16
                 text: root.buttonName
-                font.pixelSize: 12
-                font.weight: Font.DemiBold
-                color: root.selected ? Theme.activeTabText : (hoverHandler.hovered ? Theme.accent : Theme.text)
-                width: Math.min(implicitWidth, 156)
-                elide: Text.ElideRight
-
-                Behavior on color { ColorAnimation { duration: 150 } }
+                pixelSize: 12
+                fontWeight: Font.DemiBold
+                textColor: root.selected ? Theme.activeTabText : (hoverHandler.hovered ? Theme.accent : Theme.text)
+                onCommit: function(v) {
+                    if (root.controlIndex >= 0)
+                        EditorModel.updateText("controlDisplayName", root.controlIndex, v)
+                }
             }
 
             // Action name (secondary)

--- a/src/app/qml/components/ButtonCallout.qml
+++ b/src/app/qml/components/ButtonCallout.qml
@@ -29,10 +29,10 @@ Item {
     property real hsLabelOffsetYPct: 0
     property real pageWidth: 0
     property real pageHeight: 0
-    // Manual drag flag — cleared AFTER EditorModel update. Gating a Binding
-    // directly on cardDrag.active races DragHandler.onActiveChanged and snaps
-    // the card back to its pre-drag position.
-    property bool dragging: false
+
+    // Target position set by the parent page — survives DragHandler severing x/y.
+    property real targetX: 0
+    property real targetY: 0
 
     readonly property int controlIndex: {
         var ctrls = DeviceModel.controlDescriptors
@@ -43,6 +43,9 @@ Item {
         }
         return -1
     }
+
+    x: targetX
+    y: targetY
 
     signal clicked()
 
@@ -187,7 +190,6 @@ Item {
             if (active) {
                 cardDrag.grabOffsetYPct = root.hsLabelOffsetYPct
                 cardDrag.grabY = root.y
-                root.dragging = true
             } else {
                 if (root.pageWidth > 0 && root.pageHeight > 0) {
                     var centroidX = root.x + root.width / 2
@@ -198,7 +200,8 @@ Item {
                                                root.hsXPct, root.hsYPct,
                                                newSide, newOffsetY)
                 }
-                root.dragging = false
+                root.x = Qt.binding(function() { return root.targetX })
+                root.y = Qt.binding(function() { return root.targetY })
             }
         }
     }

--- a/src/app/qml/components/ButtonCallout.qml
+++ b/src/app/qml/components/ButtonCallout.qml
@@ -176,36 +176,18 @@ Item {
         }
     }
 
-    Connections {
-        target: DeviceModel
-        function onSelectedChanged() {
-            if (!cardDrag.active) {
-                root.x = root.targetX
-                root.y = root.targetY
-            }
-        }
-    }
-
-    // Editor-mode drag: translate root Item freely, on release snap side to the
-    // nearest half-page column and persist labelOffsetYPct as a delta from grab.
     DragHandler {
         id: cardDrag
         enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
         target: root
 
-        property real grabOffsetYPct: 0
-        property real grabY: 0
-
         onActiveChanged: {
-            if (active) {
-                cardDrag.grabOffsetYPct = root.hsLabelOffsetYPct
-                cardDrag.grabY = root.y
-            } else {
+            if (!active) {
                 if (root.pageWidth > 0 && root.pageHeight > 0) {
                     var centroidX = root.x + root.width / 2
                     var newSide = centroidX < root.pageWidth / 2 ? "left" : "right"
-                    var dy = root.y - cardDrag.grabY
-                    var newOffsetY = cardDrag.grabOffsetYPct + (dy / root.pageHeight)
+                    var baseY = root.lineToY - root.height / 2
+                    var newOffsetY = (root.y - baseY) / (root.pageHeight > 0 ? root.pageHeight : 1)
                     EditorModel.updateHotspot(root.hotspotIndex,
                                                root.hsXPct, root.hsYPct,
                                                newSide, newOffsetY)

--- a/src/app/qml/components/ButtonCallout.qml
+++ b/src/app/qml/components/ButtonCallout.qml
@@ -21,6 +21,15 @@ Item {
     // "left" = label is left of hotspot, "right" = label is right of hotspot
     property string lineSide: "right"
 
+    // Editor-mode drag support (see ButtonsPage wiring)
+    property int  hotspotIndex: -1
+    property real hsXPct: 0
+    property real hsYPct: 0
+    property real hsLabelOffsetYPct: 0
+    property real pageWidth: 0
+    property real pageHeight: 0
+    readonly property bool dragging: cardDrag.active
+
     signal clicked()
 
     implicitWidth:  card.implicitWidth
@@ -144,6 +153,32 @@ Item {
             anchors.fill: parent
             cursorShape: Qt.PointingHandCursor
             onClicked: root.clicked()
+        }
+    }
+
+    // Editor-mode drag: translate root Item freely, on release snap side to the
+    // nearest half-page column and persist labelOffsetYPct as a delta from grab.
+    DragHandler {
+        id: cardDrag
+        enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
+        target: root
+
+        property real grabOffsetYPct: 0
+        property real grabY: 0
+
+        onActiveChanged: {
+            if (active) {
+                cardDrag.grabOffsetYPct = root.hsLabelOffsetYPct
+                cardDrag.grabY = root.y
+            } else if (root.pageWidth > 0 && root.pageHeight > 0) {
+                var centroidX = root.x + root.width / 2
+                var newSide = centroidX < root.pageWidth / 2 ? "left" : "right"
+                var dy = root.y - cardDrag.grabY
+                var newOffsetY = cardDrag.grabOffsetYPct + (dy / root.pageHeight)
+                EditorModel.updateHotspot(root.hotspotIndex,
+                                           root.hsXPct, root.hsYPct,
+                                           newSide, newOffsetY)
+            }
         }
     }
 }

--- a/src/app/qml/components/ButtonCallout.qml
+++ b/src/app/qml/components/ButtonCallout.qml
@@ -100,6 +100,8 @@ Item {
             function onSelectedChanged() { lineCanvas.requestPaint() }
             function onXChanged()        { lineCanvas.requestPaint() }
             function onYChanged()        { lineCanvas.requestPaint() }
+            function onLineToXChanged()  { lineCanvas.requestPaint() }
+            function onLineToYChanged()  { lineCanvas.requestPaint() }
         }
     }
 

--- a/src/app/qml/components/ButtonCallout.qml
+++ b/src/app/qml/components/ButtonCallout.qml
@@ -176,6 +176,16 @@ Item {
         }
     }
 
+    Connections {
+        target: DeviceModel
+        function onSelectedChanged() {
+            if (!cardDrag.active) {
+                root.x = root.targetX
+                root.y = root.targetY
+            }
+        }
+    }
+
     // Editor-mode drag: translate root Item freely, on release snap side to the
     // nearest half-page column and persist labelOffsetYPct as a delta from grab.
     DragHandler {
@@ -200,8 +210,6 @@ Item {
                                                root.hsXPct, root.hsYPct,
                                                newSide, newOffsetY)
                 }
-                root.x = Qt.binding(function() { return root.targetX })
-                root.y = Qt.binding(function() { return root.targetY })
             }
         }
     }

--- a/src/app/qml/components/ConflictBanner.qml
+++ b/src/app/qml/components/ConflictBanner.qml
@@ -1,0 +1,56 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Logitune
+
+Rectangle {
+    id: root
+    property string conflictPath: ""
+
+    signal viewDiffRequested(string path)
+
+    visible: conflictPath.length > 0
+    height: visible ? 40 : 0
+    color: "#FFF3CD"
+    border.color: "#FFEEBA"
+    border.width: visible ? 1 : 0
+
+    Connections {
+        target: typeof EditorModel !== 'undefined' ? EditorModel : null
+        function onExternalChangeDetected(path) {
+            root.conflictPath = path
+        }
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.leftMargin: 12
+        anchors.rightMargin: 12
+        spacing: 8
+
+        Text {
+            text: "This file was changed on disk."
+            font.pixelSize: 12
+            color: "#856404"
+            Layout.fillWidth: true
+        }
+
+        Button {
+            text: "Keep my edits"
+            onClicked: root.conflictPath = ""
+        }
+        Button {
+            text: "Load disk version"
+            onClicked: {
+                if (typeof EditorModel !== 'undefined') {
+                    EditorModel.reset()
+                }
+                root.conflictPath = ""
+            }
+        }
+        Button {
+            text: "View diff"
+            onClicked: root.viewDiffRequested(root.conflictPath)
+        }
+    }
+}

--- a/src/app/qml/components/DeviceRender.qml
+++ b/src/app/qml/components/DeviceRender.qml
@@ -17,10 +17,10 @@ Item {
     property string imageRole: "side"
 
     // Painted-rect properties — actual rendered area after PreserveAspectFit
-    readonly property real paintedX: (width - mouseImage.paintedWidth) / 2
-    readonly property real paintedY: (height - mouseImage.paintedHeight) / 2
-    readonly property real paintedW: mouseImage.paintedWidth
-    readonly property real paintedH: mouseImage.paintedHeight
+    readonly property real paintedX: mouseImage.paintedWidth > 0 ? (width - mouseImage.paintedWidth) / 2 : 0
+    readonly property real paintedY: mouseImage.paintedHeight > 0 ? (height - mouseImage.paintedHeight) / 2 : 0
+    readonly property real paintedW: mouseImage.paintedWidth > 0 ? mouseImage.paintedWidth : width
+    readonly property real paintedH: mouseImage.paintedHeight > 0 ? mouseImage.paintedHeight : height
 
     Image {
         id: mouseImage
@@ -48,7 +48,7 @@ Item {
         }
     }
 
-    Button {
+    Rectangle {
         id: replaceDeviceImageButton
         visible: typeof EditorModel !== 'undefined' && EditorModel.editing
         anchors {
@@ -56,8 +56,28 @@ Item {
             right: mouseImage.right
             margins: 4
         }
-        text: "Replace image"
-        onClicked: deviceImageDialog.open()
+        width: 32; height: 28
+        radius: 4
+        color: replaceHover.hovered ? Theme.hoverBg : Theme.inputBg
+        Behavior on color { ColorAnimation { duration: 150 } }
+
+        Text {
+            anchors.centerIn: parent
+            text: "\uD83D\uDDBC"
+            font.pixelSize: 16
+            color: Theme.text
+        }
+
+        HoverHandler { id: replaceHover }
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.PointingHandCursor
+            onClicked: deviceImageDialog.open()
+            hoverEnabled: true
+            ToolTip.visible: replaceHover.hovered
+            ToolTip.text: "Replace image"
+            ToolTip.delay: 500
+        }
     }
 
     FileDialog {

--- a/src/app/qml/components/DeviceRender.qml
+++ b/src/app/qml/components/DeviceRender.qml
@@ -89,25 +89,14 @@ Item {
             // Skip non-configurable buttons
             visible: hp.configurable
 
-            // Manual drag flag — cleared AFTER EditorModel update so the Binding
-            // below reactivates with the refreshed targetX/targetY. Gating directly
-            // on `drag.active` races DragHandler.onActiveChanged.
-            property bool dragging: false
-
             // Target dot centre in root coordinates
             readonly property real targetX: root.paintedX + hp.hotspotXPct * root.paintedW
             readonly property real targetY: root.paintedY + hp.hotspotYPct * root.paintedH
 
             // 24x24 hit area — follows drag in editor mode, otherwise snaps to target.
             width: 24; height: 24
-            Binding on x {
-                value: markerItem.targetX - markerItem.width / 2
-                when: !markerItem.dragging
-            }
-            Binding on y {
-                value: markerItem.targetY - markerItem.height / 2
-                when: !markerItem.dragging
-            }
+            x: targetX - width / 2
+            y: targetY - height / 2
 
             // Invisible click hit zone centred on dot (for button selection, non-edit mode)
             MouseArea {
@@ -147,9 +136,7 @@ Item {
                 enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
                 target: parent
                 onActiveChanged: {
-                    if (active) {
-                        markerItem.dragging = true
-                    } else {
+                    if (!active) {
                         var cx = markerItem.x + markerItem.width / 2
                         var cy = markerItem.y + markerItem.height / 2
                         var xPct = (cx - root.paintedX) / root.paintedW
@@ -160,7 +147,8 @@ Item {
                                                    xPct, yPct,
                                                    markerItem.hp.side,
                                                    markerItem.hp.labelOffsetYPct)
-                        markerItem.dragging = false
+                        markerItem.x = Qt.binding(function() { return markerItem.targetX - markerItem.width / 2 })
+                        markerItem.y = Qt.binding(function() { return markerItem.targetY - markerItem.height / 2 })
                     }
                 }
             }

--- a/src/app/qml/components/DeviceRender.qml
+++ b/src/app/qml/components/DeviceRender.qml
@@ -89,21 +89,24 @@ Item {
             // Skip non-configurable buttons
             visible: hp.configurable
 
+            // Manual drag flag — cleared AFTER EditorModel update so the Binding
+            // below reactivates with the refreshed targetX/targetY. Gating directly
+            // on `drag.active` races DragHandler.onActiveChanged.
+            property bool dragging: false
+
             // Target dot centre in root coordinates
             readonly property real targetX: root.paintedX + hp.hotspotXPct * root.paintedW
             readonly property real targetY: root.paintedY + hp.hotspotYPct * root.paintedH
 
             // 24x24 hit area — follows drag in editor mode, otherwise snaps to target.
             width: 24; height: 24
-            // Conditional binding: active except while DragHandler is mutating x/y.
-            // A self-referencing ternary here would sever the binding after first drag.
             Binding on x {
                 value: markerItem.targetX - markerItem.width / 2
-                when: !drag.active
+                when: !markerItem.dragging
             }
             Binding on y {
                 value: markerItem.targetY - markerItem.height / 2
-                when: !drag.active
+                when: !markerItem.dragging
             }
 
             // Invisible click hit zone centred on dot (for button selection, non-edit mode)
@@ -144,7 +147,9 @@ Item {
                 enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
                 target: parent
                 onActiveChanged: {
-                    if (!active) {
+                    if (active) {
+                        markerItem.dragging = true
+                    } else {
                         var cx = markerItem.x + markerItem.width / 2
                         var cy = markerItem.y + markerItem.height / 2
                         var xPct = (cx - root.paintedX) / root.paintedW
@@ -155,6 +160,7 @@ Item {
                                                    xPct, yPct,
                                                    markerItem.hp.side,
                                                    markerItem.hp.labelOffsetYPct)
+                        markerItem.dragging = false
                     }
                 }
             }

--- a/src/app/qml/components/DeviceRender.qml
+++ b/src/app/qml/components/DeviceRender.qml
@@ -130,16 +130,6 @@ Item {
                 }
             }
 
-            Connections {
-                target: DeviceModel
-                function onSelectedChanged() {
-                    if (!drag.active) {
-                        markerItem.x = markerItem.targetX - markerItem.width / 2
-                        markerItem.y = markerItem.targetY - markerItem.height / 2
-                    }
-                }
-            }
-
             // Editor-mode drag handler — disabled (and effectively absent) in production.
             DragHandler {
                 id: drag

--- a/src/app/qml/components/DeviceRender.qml
+++ b/src/app/qml/components/DeviceRender.qml
@@ -40,6 +40,7 @@ Item {
         model: root.showHotspots ? DeviceModel.buttonHotspots.length : 0
 
         Item {
+            id: markerItem
             required property int modelData
 
             readonly property var hp: DeviceModel.buttonHotspots[modelData]
@@ -47,24 +48,28 @@ Item {
             // Skip non-configurable buttons
             visible: hp.configurable
 
-            // Dot centre in item coordinates
-            readonly property real dotCX: root.paintedX + hp.hotspotXPct * root.paintedW
-            readonly property real dotCY: root.paintedY + hp.hotspotYPct * root.paintedH
+            // Target dot centre in root coordinates
+            readonly property real targetX: root.paintedX + hp.hotspotXPct * root.paintedW
+            readonly property real targetY: root.paintedY + hp.hotspotYPct * root.paintedH
 
-            // Invisible hit zone centred on dot
+            // 24x24 hit area — follows drag in editor mode, otherwise snaps to target.
+            width: 24; height: 24
+            x: drag.active ? x : targetX - width / 2
+            y: drag.active ? y : targetY - height / 2
+
+            // Invisible click hit zone centred on dot (for button selection, non-edit mode)
             MouseArea {
-                x: dotCX - root.zoneHalfW * root.paintedW
-                y: dotCY - root.zoneHalfH * root.paintedH
+                anchors.centerIn: parent
                 width: root.zoneHalfW * root.paintedW * 2
                 height: root.zoneHalfH * root.paintedH * 2
                 cursorShape: Qt.PointingHandCursor
-                onClicked: root.buttonClicked(hp.buttonId)
+                enabled: !drag.enabled
+                onClicked: root.buttonClicked(markerItem.hp.buttonId)
             }
 
             // 18x18 hotspot circle — white for dark background
             Rectangle {
-                x: dotCX - 9
-                y: dotCY - 9
+                anchors.centerIn: parent
                 width: 18; height: 18
                 radius: 9
                 color: "transparent"
@@ -81,6 +86,27 @@ Item {
                     radius: 3
                     color: Theme.accent
                     opacity: 0.6
+                }
+            }
+
+            // Editor-mode drag handler — disabled (and effectively absent) in production.
+            DragHandler {
+                id: drag
+                enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
+                target: parent
+                onActiveChanged: {
+                    if (!active) {
+                        var cx = markerItem.x + markerItem.width / 2
+                        var cy = markerItem.y + markerItem.height / 2
+                        var xPct = (cx - root.paintedX) / root.paintedW
+                        var yPct = (cy - root.paintedY) / root.paintedH
+                        xPct = Math.max(0, Math.min(1, xPct))
+                        yPct = Math.max(0, Math.min(1, yPct))
+                        EditorModel.updateHotspot(markerItem.modelData,
+                                                   xPct, yPct,
+                                                   markerItem.hp.side,
+                                                   markerItem.hp.labelOffsetYPct)
+                    }
                 }
             }
         }

--- a/src/app/qml/components/DeviceRender.qml
+++ b/src/app/qml/components/DeviceRender.qml
@@ -1,4 +1,6 @@
 import QtQuick
+import QtQuick.Controls
+import QtQuick.Dialogs
 import Logitune
 
 // Mouse device render — MX Master 3S PNG with invisible clickable button zones overlaid.
@@ -14,6 +16,8 @@ Item {
     // Allow parent to override the image source per page
     property string imageSource: "qrc:/Logitune/qml/assets/mx-master-3s.png"
     property bool showHotspots: true  // set false on Point & Scroll page
+    // Role used for EditorModel.replaceImage — matches the "images" key in the descriptor JSON
+    property string imageRole: "side"
 
     // Painted-rect properties — actual rendered area after PreserveAspectFit
     readonly property real paintedX: (width - mouseImage.paintedWidth) / 2
@@ -34,6 +38,43 @@ Item {
         fillMode: Image.PreserveAspectFit
         smooth: true
         mipmap: true
+    }
+
+    DropArea {
+        id: deviceImageDrop
+        anchors.fill: mouseImage
+        enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
+        onDropped: function(drop) {
+            if (drop.hasUrls && drop.urls.length > 0) {
+                var url = drop.urls[0].toString()
+                if (url.toLowerCase().endsWith(".png")) {
+                    var path = url.replace(/^file:\/\//, "")
+                    EditorModel.replaceImage(root.imageRole, path)
+                }
+            }
+        }
+    }
+
+    Button {
+        id: replaceDeviceImageButton
+        visible: typeof EditorModel !== 'undefined' && EditorModel.editing
+        anchors {
+            top: mouseImage.top
+            right: mouseImage.right
+            margins: 4
+        }
+        text: "Replace image"
+        onClicked: deviceImageDialog.open()
+    }
+
+    FileDialog {
+        id: deviceImageDialog
+        nameFilters: ["PNG (*.png)"]
+        onAccepted: {
+            var url = selectedFile.toString()
+            var path = url.replace(/^file:\/\//, "")
+            EditorModel.replaceImage(root.imageRole, path)
+        }
     }
 
     Repeater {

--- a/src/app/qml/components/DeviceRender.qml
+++ b/src/app/qml/components/DeviceRender.qml
@@ -3,19 +3,16 @@ import QtQuick.Controls
 import QtQuick.Dialogs
 import Logitune
 
-// Mouse device render — MX Master 3S PNG with invisible clickable button zones overlaid.
-// White hotspot circles on configurable buttons (no left/right click zones shown).
+// Mouse device render — MX Master 3S PNG with image-replacement support.
+// Hotspot markers are now owned by HotspotControl (ButtonsPage) or inline (PointScrollPage).
 Item {
     id: root
 
     implicitWidth:  280
     implicitHeight: 414
 
-    signal buttonClicked(int buttonId)
-
     // Allow parent to override the image source per page
     property string imageSource: "qrc:/Logitune/qml/assets/mx-master-3s.png"
-    property bool showHotspots: true  // set false on Point & Scroll page
     // Role used for EditorModel.replaceImage — matches the "images" key in the descriptor JSON
     property string imageRole: "side"
 
@@ -24,10 +21,6 @@ Item {
     readonly property real paintedY: (height - mouseImage.paintedHeight) / 2
     readonly property real paintedW: mouseImage.paintedWidth
     readonly property real paintedH: mouseImage.paintedHeight
-
-    // ── Half-extents for the invisible hit zone around each hotspot dot ──────
-    readonly property real zoneHalfW: 0.11   // fraction of paintedW
-    readonly property real zoneHalfH: 0.07   // fraction of paintedH
 
     Image {
         id: mouseImage
@@ -77,79 +70,4 @@ Item {
         }
     }
 
-    Repeater {
-        model: root.showHotspots ? DeviceModel.buttonHotspots.length : 0
-
-        Item {
-            id: markerItem
-            required property int modelData
-
-            readonly property var hp: DeviceModel.buttonHotspots[modelData]
-
-            // Skip non-configurable buttons
-            visible: hp.configurable
-
-            // Target dot centre in root coordinates
-            readonly property real targetX: root.paintedX + hp.hotspotXPct * root.paintedW
-            readonly property real targetY: root.paintedY + hp.hotspotYPct * root.paintedH
-
-            // 24x24 hit area — follows drag in editor mode, otherwise snaps to target.
-            width: 24; height: 24
-            x: targetX - width / 2
-            y: targetY - height / 2
-
-            // Invisible click hit zone centred on dot (for button selection, non-edit mode)
-            MouseArea {
-                anchors.centerIn: parent
-                width: root.zoneHalfW * root.paintedW * 2
-                height: root.zoneHalfH * root.paintedH * 2
-                cursorShape: Qt.PointingHandCursor
-                enabled: !drag.enabled
-                onClicked: root.buttonClicked(markerItem.hp.buttonId)
-            }
-
-            // 18x18 hotspot circle — white for dark background
-            Rectangle {
-                anchors.centerIn: parent
-                width: 18; height: 18
-                radius: 9
-                color: "transparent"
-                border.color: Theme.accent
-                border.width: 2
-                opacity: 0.7
-
-                Behavior on opacity { NumberAnimation { duration: 200 } }
-
-                // Inner dot
-                Rectangle {
-                    anchors.centerIn: parent
-                    width: 6; height: 6
-                    radius: 3
-                    color: Theme.accent
-                    opacity: 0.6
-                }
-            }
-
-            // Editor-mode drag handler — disabled (and effectively absent) in production.
-            DragHandler {
-                id: drag
-                enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
-                target: parent
-                onActiveChanged: {
-                    if (!active) {
-                        var cx = markerItem.x + markerItem.width / 2
-                        var cy = markerItem.y + markerItem.height / 2
-                        var xPct = (cx - root.paintedX) / root.paintedW
-                        var yPct = (cy - root.paintedY) / root.paintedH
-                        xPct = Math.max(0, Math.min(1, xPct))
-                        yPct = Math.max(0, Math.min(1, yPct))
-                        EditorModel.updateHotspot(markerItem.modelData,
-                                                   xPct, yPct,
-                                                   markerItem.hp.side,
-                                                   markerItem.hp.labelOffsetYPct)
-                    }
-                }
-            }
-        }
-    }
 }

--- a/src/app/qml/components/DeviceRender.qml
+++ b/src/app/qml/components/DeviceRender.qml
@@ -95,8 +95,16 @@ Item {
 
             // 24x24 hit area — follows drag in editor mode, otherwise snaps to target.
             width: 24; height: 24
-            x: drag.active ? x : targetX - width / 2
-            y: drag.active ? y : targetY - height / 2
+            // Conditional binding: active except while DragHandler is mutating x/y.
+            // A self-referencing ternary here would sever the binding after first drag.
+            Binding on x {
+                value: markerItem.targetX - markerItem.width / 2
+                when: !drag.active
+            }
+            Binding on y {
+                value: markerItem.targetY - markerItem.height / 2
+                when: !drag.active
+            }
 
             // Invisible click hit zone centred on dot (for button selection, non-edit mode)
             MouseArea {

--- a/src/app/qml/components/DeviceRender.qml
+++ b/src/app/qml/components/DeviceRender.qml
@@ -130,6 +130,16 @@ Item {
                 }
             }
 
+            Connections {
+                target: DeviceModel
+                function onSelectedChanged() {
+                    if (!drag.active) {
+                        markerItem.x = markerItem.targetX - markerItem.width / 2
+                        markerItem.y = markerItem.targetY - markerItem.height / 2
+                    }
+                }
+            }
+
             // Editor-mode drag handler — disabled (and effectively absent) in production.
             DragHandler {
                 id: drag
@@ -147,8 +157,6 @@ Item {
                                                    xPct, yPct,
                                                    markerItem.hp.side,
                                                    markerItem.hp.labelOffsetYPct)
-                        markerItem.x = Qt.binding(function() { return markerItem.targetX - markerItem.width / 2 })
-                        markerItem.y = Qt.binding(function() { return markerItem.targetY - markerItem.height / 2 })
                     }
                 }
             }

--- a/src/app/qml/components/DiffModal.qml
+++ b/src/app/qml/components/DiffModal.qml
@@ -1,0 +1,100 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Logitune
+
+Dialog {
+    id: root
+    modal: true
+    width: Math.min(900, parent ? parent.width - 40 : 900)
+    height: Math.min(640, parent ? parent.height - 40 : 640)
+    anchors.centerIn: parent
+    title: "External change diff"
+    standardButtons: Dialog.Close
+
+    property string diskText: ""
+    property string memoryText: ""
+
+    function open(path) {
+        diskText = readFile(path + "/descriptor.json")
+        if (typeof EditorModel !== 'undefined') {
+            var pending = EditorModel.pendingFor(path)
+            memoryText = JSON.stringify(pending, null, 2)
+        } else {
+            memoryText = "(EditorModel not registered)"
+        }
+        visible = true
+    }
+
+    function readFile(p) {
+        var xhr = new XMLHttpRequest()
+        try {
+            xhr.open("GET", "file://" + p, false)
+            xhr.send(null)
+            return xhr.responseText
+        } catch (e) {
+            return "(failed to read " + p + ": " + e + ")"
+        }
+    }
+
+    contentItem: ColumnLayout {
+        spacing: 8
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 0
+            Text {
+                text: "On disk"
+                font.bold: true
+                font.pixelSize: 12
+                color: Theme.text
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignHCenter
+            }
+            Text {
+                text: "In memory"
+                font.bold: true
+                font.pixelSize: 12
+                color: Theme.text
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignHCenter
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: 8
+
+            Flickable {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                contentWidth: leftText.implicitWidth
+                contentHeight: leftText.implicitHeight
+                clip: true
+                Text {
+                    id: leftText
+                    text: root.diskText
+                    font.family: "monospace"
+                    font.pixelSize: 11
+                    color: Theme.text
+                }
+            }
+
+            Flickable {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                contentWidth: rightText.implicitWidth
+                contentHeight: rightText.implicitHeight
+                clip: true
+                Text {
+                    id: rightText
+                    text: root.memoryText
+                    font.family: "monospace"
+                    font.pixelSize: 11
+                    color: Theme.text
+                }
+            }
+        }
+    }
+}

--- a/src/app/qml/components/EditableText.qml
+++ b/src/app/qml/components/EditableText.qml
@@ -1,0 +1,82 @@
+import QtQuick
+import QtQuick.Controls
+import Logitune
+
+Item {
+    id: root
+
+    property string text: ""
+    property color textColor: Theme.text
+    property int pixelSize: 14
+    property bool textBold: false
+    property int fontWeight: Font.Normal
+    property int horizontalAlignment: Text.AlignLeft
+    readonly property bool editable: typeof EditorModel !== 'undefined' && EditorModel.editing
+
+    signal commit(string newValue)
+
+    implicitWidth: txt.implicitWidth
+    implicitHeight: Math.max(txt.implicitHeight, field.implicitHeight)
+
+    Text {
+        id: txt
+        anchors.fill: parent
+        text: root.text
+        color: root.textColor
+        font.pixelSize: root.pixelSize
+        font.bold: root.textBold
+        font.weight: root.fontWeight
+        verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: root.horizontalAlignment
+        elide: Text.ElideRight
+        visible: !field.visible
+        Behavior on color { ColorAnimation { duration: 150 } }
+    }
+
+    TextField {
+        id: field
+        anchors.fill: parent
+        text: root.text
+        font.pixelSize: root.pixelSize
+        font.bold: root.textBold
+        font.weight: root.fontWeight
+        visible: false
+        padding: 0
+        background: Rectangle {
+            color: Theme.inputBg
+            border.color: Theme.accent
+            border.width: 1
+            radius: 3
+        }
+        onAccepted: {
+            root.commit(text)
+            visible = false
+        }
+        Keys.onEscapePressed: {
+            text = root.text
+            visible = false
+        }
+        onActiveFocusChanged: {
+            if (!activeFocus && visible) {
+                root.commit(text)
+                visible = false
+            }
+        }
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        enabled: root.editable && !field.visible
+        cursorShape: enabled ? Qt.IBeamCursor : Qt.ArrowCursor
+        acceptedButtons: Qt.LeftButton
+        propagateComposedEvents: true
+        onDoubleClicked: {
+            field.text = root.text
+            field.visible = true
+            field.forceActiveFocus()
+            field.selectAll()
+        }
+        onPressed: function(mouse) { mouse.accepted = root.editable }
+        onClicked: function(mouse) { mouse.accepted = false }
+    }
+}

--- a/src/app/qml/components/EditorToolbar.qml
+++ b/src/app/qml/components/EditorToolbar.qml
@@ -5,162 +5,105 @@ import Logitune
 
 Rectangle {
     id: root
-    visible: typeof EditorModel !== 'undefined' && EditorModel.editing
+    property bool onDevicePage: false
+    visible: typeof EditorModel !== 'undefined' && EditorModel.editing && onDevicePage
     height: visible ? 36 : 0
     color: Theme.cardBg
     border.color: Theme.border
     border.width: visible ? 1 : 0
 
+    component ToolBtn : Rectangle {
+        id: btn
+        property bool btnEnabled: true
+        property bool primary: false
+        property string icon: ""
+        property string tooltip: ""
+        signal pressed()
+
+        implicitWidth: 32
+        implicitHeight: 28
+        radius: 4
+        opacity: btnEnabled ? 1.0 : 0.4
+        color: primary && btnEnabled
+            ? (btnHover.hovered ? Theme.accentHover : Theme.accent)
+            : (btnHover.hovered && btnEnabled ? Theme.hoverBg : Theme.inputBg)
+        Behavior on color { ColorAnimation { duration: 150 } }
+        Layout.alignment: Qt.AlignVCenter
+
+        Text {
+            anchors.centerIn: parent
+            text: btn.icon
+            font.pixelSize: 16
+            color: btn.primary && btn.btnEnabled ? Theme.activeTabText : Theme.text
+        }
+
+        HoverHandler { id: btnHover }
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: btn.btnEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+            onClicked: if (btn.btnEnabled) btn.pressed()
+            hoverEnabled: true
+            ToolTip.visible: btnHover.hovered && btn.tooltip
+            ToolTip.text: btn.tooltip
+            ToolTip.delay: 500
+        }
+    }
+
     RowLayout {
         anchors.fill: parent
         anchors.leftMargin: 12
         anchors.rightMargin: 12
-        spacing: 6
+        spacing: 4
 
-        // Path breadcrumb
+        ToolBtn {
+            icon: "\u2713"
+            tooltip: "Save"
+            primary: true
+            btnEnabled: root.visible && EditorModel.hasUnsavedChanges
+            onPressed: EditorModel.save()
+        }
+        ToolBtn {
+            icon: "\u21BA"
+            tooltip: "Reset"
+            btnEnabled: root.visible && EditorModel.hasUnsavedChanges
+            onPressed: EditorModel.reset()
+        }
+        ToolBtn {
+            icon: "\u21B6"
+            tooltip: "Undo"
+            btnEnabled: root.visible && EditorModel.canUndo
+            onPressed: EditorModel.undo()
+        }
+        ToolBtn {
+            icon: "\u21B7"
+            tooltip: "Redo"
+            btnEnabled: root.visible && EditorModel.canRedo
+            onPressed: EditorModel.redo()
+        }
+
+        Item { Layout.fillWidth: true }
+
         Text {
-            id: pathLabel
+            visible: root.visible && EditorModel.activeDevicePath
             text: root.visible && EditorModel.activeDevicePath
                   ? "\u2026/" + EditorModel.activeDevicePath.split("/").slice(-2).join("/")
                   : ""
             font.pixelSize: 11
             color: Theme.textSecondary
             elide: Text.ElideLeft
-            Layout.fillWidth: true
         }
 
-        // Unsaved-changes indicator
         Rectangle {
             visible: root.visible && EditorModel.hasUnsavedChanges
             width: 6; height: 6; radius: 3
             color: Theme.accent
+            Layout.leftMargin: 4
         }
         Text {
             visible: root.visible && EditorModel.hasUnsavedChanges
-            text: "Unsaved changes"
+            text: "Unsaved"
             font.pixelSize: 10
             color: Theme.accent
-        }
-
-        // --- Action buttons ---
-
-        // Undo
-        Rectangle {
-            id: undoBtn
-            property bool btnEnabled: root.visible && EditorModel.canUndo
-            implicitWidth: undoRow.implicitWidth + 16
-            implicitHeight: 28
-            radius: 4
-            opacity: btnEnabled ? 1.0 : 0.4
-            color: undoHover.hovered && btnEnabled ? Theme.hoverBg : Theme.inputBg
-            Behavior on color { ColorAnimation { duration: 150 } }
-            Layout.alignment: Qt.AlignVCenter
-
-            Row {
-                id: undoRow
-                anchors.centerIn: parent
-                spacing: 4
-                Text { text: "\u21B6"; font.pixelSize: 14; color: Theme.text }
-                Text { text: "Undo"; font.pixelSize: 11; font.bold: true; color: Theme.text }
-            }
-            HoverHandler { id: undoHover }
-            MouseArea {
-                anchors.fill: parent
-                cursorShape: parent.btnEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                onClicked: if (parent.btnEnabled) EditorModel.undo()
-            }
-        }
-
-        // Redo
-        Rectangle {
-            id: redoBtn
-            property bool btnEnabled: root.visible && EditorModel.canRedo
-            implicitWidth: redoRow.implicitWidth + 16
-            implicitHeight: 28
-            radius: 4
-            opacity: btnEnabled ? 1.0 : 0.4
-            color: redoHover.hovered && btnEnabled ? Theme.hoverBg : Theme.inputBg
-            Behavior on color { ColorAnimation { duration: 150 } }
-            Layout.alignment: Qt.AlignVCenter
-
-            Row {
-                id: redoRow
-                anchors.centerIn: parent
-                spacing: 4
-                Text { text: "\u21B7"; font.pixelSize: 14; color: Theme.text }
-                Text { text: "Redo"; font.pixelSize: 11; font.bold: true; color: Theme.text }
-            }
-            HoverHandler { id: redoHover }
-            MouseArea {
-                anchors.fill: parent
-                cursorShape: parent.btnEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                onClicked: if (parent.btnEnabled) EditorModel.redo()
-            }
-        }
-
-        // Reset
-        Rectangle {
-            id: resetBtn
-            property bool btnEnabled: root.visible && EditorModel.hasUnsavedChanges
-            implicitWidth: resetRow.implicitWidth + 16
-            implicitHeight: 28
-            radius: 4
-            opacity: btnEnabled ? 1.0 : 0.4
-            color: resetHover.hovered && btnEnabled ? Theme.hoverBg : Theme.inputBg
-            Behavior on color { ColorAnimation { duration: 150 } }
-            Layout.alignment: Qt.AlignVCenter
-
-            Row {
-                id: resetRow
-                anchors.centerIn: parent
-                spacing: 4
-                Text { text: "\u21BA"; font.pixelSize: 14; color: Theme.text }
-                Text { text: "Reset"; font.pixelSize: 11; font.bold: true; color: Theme.text }
-            }
-            HoverHandler { id: resetHover }
-            MouseArea {
-                anchors.fill: parent
-                cursorShape: parent.btnEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                onClicked: if (parent.btnEnabled) EditorModel.reset()
-            }
-        }
-
-        // Save (primary action — accent color)
-        Rectangle {
-            id: saveBtn
-            property bool btnEnabled: root.visible && EditorModel.hasUnsavedChanges
-            implicitWidth: saveRow.implicitWidth + 16
-            implicitHeight: 28
-            radius: 4
-            opacity: btnEnabled ? 1.0 : 0.4
-            color: btnEnabled
-                ? (saveHover.hovered ? Theme.accentHover : Theme.accent)
-                : Theme.inputBg
-            Behavior on color { ColorAnimation { duration: 150 } }
-            Layout.alignment: Qt.AlignVCenter
-
-            Row {
-                id: saveRow
-                anchors.centerIn: parent
-                spacing: 4
-                Text {
-                    text: "\u2713"
-                    font.pixelSize: 14
-                    color: saveBtn.btnEnabled ? Theme.activeTabText : Theme.text
-                }
-                Text {
-                    text: "Save"
-                    font.pixelSize: 11
-                    font.bold: true
-                    color: saveBtn.btnEnabled ? Theme.activeTabText : Theme.text
-                }
-            }
-            HoverHandler { id: saveHover }
-            MouseArea {
-                anchors.fill: parent
-                cursorShape: parent.btnEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                onClicked: if (parent.btnEnabled) EditorModel.save()
-            }
         }
     }
 }

--- a/src/app/qml/components/EditorToolbar.qml
+++ b/src/app/qml/components/EditorToolbar.qml
@@ -1,0 +1,65 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Logitune
+
+Rectangle {
+    id: root
+    visible: typeof EditorModel !== 'undefined' && EditorModel.editing
+    height: visible ? 36 : 0
+    color: Theme.background
+    border.color: Theme.border
+    border.width: visible ? 1 : 0
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.leftMargin: 12
+        anchors.rightMargin: 12
+        spacing: 8
+
+        Text {
+            id: pathLabel
+            text: root.visible && EditorModel.activeDevicePath
+                  ? "\u2026/" + EditorModel.activeDevicePath.split("/").slice(-2).join("/")
+                  : ""
+            font.pixelSize: 11
+            color: Theme.textSecondary
+            elide: Text.ElideLeft
+            Layout.fillWidth: true
+        }
+
+        Rectangle {
+            id: dirtyDot
+            visible: root.visible && EditorModel.hasUnsavedChanges
+            width: 8; height: 8; radius: 4
+            color: Theme.accent
+        }
+        Text {
+            visible: root.visible && EditorModel.hasUnsavedChanges
+            text: "Unsaved changes"
+            font.pixelSize: 11
+            color: Theme.text
+        }
+
+        Button {
+            text: "Undo"
+            enabled: root.visible && EditorModel.canUndo
+            onClicked: EditorModel.undo()
+        }
+        Button {
+            text: "Redo"
+            enabled: root.visible && EditorModel.canRedo
+            onClicked: EditorModel.redo()
+        }
+        Button {
+            text: "Reset"
+            enabled: root.visible && EditorModel.hasUnsavedChanges
+            onClicked: EditorModel.reset()
+        }
+        Button {
+            text: "Save"
+            enabled: root.visible && EditorModel.hasUnsavedChanges
+            onClicked: EditorModel.save()
+        }
+    }
+}

--- a/src/app/qml/components/EditorToolbar.qml
+++ b/src/app/qml/components/EditorToolbar.qml
@@ -7,7 +7,7 @@ Rectangle {
     id: root
     visible: typeof EditorModel !== 'undefined' && EditorModel.editing
     height: visible ? 36 : 0
-    color: Theme.background
+    color: Theme.cardBg
     border.color: Theme.border
     border.width: visible ? 1 : 0
 
@@ -15,8 +15,9 @@ Rectangle {
         anchors.fill: parent
         anchors.leftMargin: 12
         anchors.rightMargin: 12
-        spacing: 8
+        spacing: 6
 
+        // Path breadcrumb
         Text {
             id: pathLabel
             text: root.visible && EditorModel.activeDevicePath
@@ -28,38 +29,138 @@ Rectangle {
             Layout.fillWidth: true
         }
 
+        // Unsaved-changes indicator
         Rectangle {
-            id: dirtyDot
             visible: root.visible && EditorModel.hasUnsavedChanges
-            width: 8; height: 8; radius: 4
+            width: 6; height: 6; radius: 3
             color: Theme.accent
         }
         Text {
             visible: root.visible && EditorModel.hasUnsavedChanges
             text: "Unsaved changes"
-            font.pixelSize: 11
-            color: Theme.text
+            font.pixelSize: 10
+            color: Theme.accent
         }
 
-        Button {
-            text: "Undo"
-            enabled: root.visible && EditorModel.canUndo
-            onClicked: EditorModel.undo()
+        // --- Action buttons ---
+
+        // Undo
+        Rectangle {
+            id: undoBtn
+            property bool btnEnabled: root.visible && EditorModel.canUndo
+            implicitWidth: undoRow.implicitWidth + 16
+            implicitHeight: 28
+            radius: 4
+            opacity: btnEnabled ? 1.0 : 0.4
+            color: undoHover.hovered && btnEnabled ? Theme.hoverBg : Theme.inputBg
+            Behavior on color { ColorAnimation { duration: 150 } }
+            Layout.alignment: Qt.AlignVCenter
+
+            Row {
+                id: undoRow
+                anchors.centerIn: parent
+                spacing: 4
+                Text { text: "\u21B6"; font.pixelSize: 14; color: Theme.text }
+                Text { text: "Undo"; font.pixelSize: 11; font.bold: true; color: Theme.text }
+            }
+            HoverHandler { id: undoHover }
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: parent.btnEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                onClicked: if (parent.btnEnabled) EditorModel.undo()
+            }
         }
-        Button {
-            text: "Redo"
-            enabled: root.visible && EditorModel.canRedo
-            onClicked: EditorModel.redo()
+
+        // Redo
+        Rectangle {
+            id: redoBtn
+            property bool btnEnabled: root.visible && EditorModel.canRedo
+            implicitWidth: redoRow.implicitWidth + 16
+            implicitHeight: 28
+            radius: 4
+            opacity: btnEnabled ? 1.0 : 0.4
+            color: redoHover.hovered && btnEnabled ? Theme.hoverBg : Theme.inputBg
+            Behavior on color { ColorAnimation { duration: 150 } }
+            Layout.alignment: Qt.AlignVCenter
+
+            Row {
+                id: redoRow
+                anchors.centerIn: parent
+                spacing: 4
+                Text { text: "\u21B7"; font.pixelSize: 14; color: Theme.text }
+                Text { text: "Redo"; font.pixelSize: 11; font.bold: true; color: Theme.text }
+            }
+            HoverHandler { id: redoHover }
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: parent.btnEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                onClicked: if (parent.btnEnabled) EditorModel.redo()
+            }
         }
-        Button {
-            text: "Reset"
-            enabled: root.visible && EditorModel.hasUnsavedChanges
-            onClicked: EditorModel.reset()
+
+        // Reset
+        Rectangle {
+            id: resetBtn
+            property bool btnEnabled: root.visible && EditorModel.hasUnsavedChanges
+            implicitWidth: resetRow.implicitWidth + 16
+            implicitHeight: 28
+            radius: 4
+            opacity: btnEnabled ? 1.0 : 0.4
+            color: resetHover.hovered && btnEnabled ? Theme.hoverBg : Theme.inputBg
+            Behavior on color { ColorAnimation { duration: 150 } }
+            Layout.alignment: Qt.AlignVCenter
+
+            Row {
+                id: resetRow
+                anchors.centerIn: parent
+                spacing: 4
+                Text { text: "\u21BA"; font.pixelSize: 14; color: Theme.text }
+                Text { text: "Reset"; font.pixelSize: 11; font.bold: true; color: Theme.text }
+            }
+            HoverHandler { id: resetHover }
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: parent.btnEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                onClicked: if (parent.btnEnabled) EditorModel.reset()
+            }
         }
-        Button {
-            text: "Save"
-            enabled: root.visible && EditorModel.hasUnsavedChanges
-            onClicked: EditorModel.save()
+
+        // Save (primary action — accent color)
+        Rectangle {
+            id: saveBtn
+            property bool btnEnabled: root.visible && EditorModel.hasUnsavedChanges
+            implicitWidth: saveRow.implicitWidth + 16
+            implicitHeight: 28
+            radius: 4
+            opacity: btnEnabled ? 1.0 : 0.4
+            color: btnEnabled
+                ? (saveHover.hovered ? Theme.accentHover : Theme.accent)
+                : Theme.inputBg
+            Behavior on color { ColorAnimation { duration: 150 } }
+            Layout.alignment: Qt.AlignVCenter
+
+            Row {
+                id: saveRow
+                anchors.centerIn: parent
+                spacing: 4
+                Text {
+                    text: "\u2713"
+                    font.pixelSize: 14
+                    color: saveBtn.btnEnabled ? Theme.activeTabText : Theme.text
+                }
+                Text {
+                    text: "Save"
+                    font.pixelSize: 11
+                    font.bold: true
+                    color: saveBtn.btnEnabled ? Theme.activeTabText : Theme.text
+                }
+            }
+            HoverHandler { id: saveHover }
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: parent.btnEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                onClicked: if (parent.btnEnabled) EditorModel.save()
+            }
         }
     }
 }

--- a/src/app/qml/components/HotspotControl.qml
+++ b/src/app/qml/components/HotspotControl.qml
@@ -255,7 +255,9 @@ Item {
             MouseArea {
                 anchors.fill: parent
                 cursorShape: Qt.PointingHandCursor
+                propagateComposedEvents: true
                 onClicked: root.clicked()
+                onDoubleClicked: function(mouse) { mouse.accepted = false }
             }
         }
 

--- a/src/app/qml/components/HotspotControl.qml
+++ b/src/app/qml/components/HotspotControl.qml
@@ -171,9 +171,17 @@ Item {
         width: cardRect.implicitWidth
         height: cardRect.implicitHeight
 
-        x: root.cardTargetX
-        y: root.cardTargetY
-
+        Connections {
+            target: root
+            function onCardTargetXChanged() {
+                if (!cardDrag.active && !markerDrag.active)
+                    cardItem.x = root.cardTargetX
+            }
+            function onCardTargetYChanged() {
+                if (!cardDrag.active && !markerDrag.active)
+                    cardItem.y = root.cardTargetY
+            }
+        }
 
         Rectangle {
             id: cardRect
@@ -265,6 +273,10 @@ Item {
                     EditorModel.updateHotspot(root.hotspotIndex,
                         root.hotspotXPct, root.hotspotYPct,
                         newSide, newOffsetY)
+                    Qt.callLater(function() {
+                        cardItem.x = root.cardTargetX
+                        cardItem.y = root.cardTargetY
+                    })
                 }
             }
         }

--- a/src/app/qml/components/HotspotControl.qml
+++ b/src/app/qml/components/HotspotControl.qml
@@ -83,12 +83,14 @@ Item {
         }
 
         Connections {
-            target: DeviceModel
-            function onSelectedChanged() {
-                if (!markerDrag.active) {
+            target: root
+            function onMarkerCenterXChanged() {
+                if (!markerDrag.active)
                     marker.x = root.markerCenterX - marker.width / 2
+            }
+            function onMarkerCenterYChanged() {
+                if (!markerDrag.active)
                     marker.y = root.markerCenterY - marker.height / 2
-                }
             }
         }
 
@@ -172,15 +174,6 @@ Item {
         x: root.cardTargetX
         y: root.cardTargetY
 
-        Connections {
-            target: DeviceModel
-            function onSelectedChanged() {
-                if (!cardDrag.active) {
-                    cardItem.x = root.cardTargetX
-                    cardItem.y = root.cardTargetY
-                }
-            }
-        }
 
         Rectangle {
             id: cardRect

--- a/src/app/qml/components/HotspotControl.qml
+++ b/src/app/qml/components/HotspotControl.qml
@@ -1,0 +1,279 @@
+import QtQuick
+import QtQuick.Controls
+import Logitune
+
+// Unified hotspot control — owns the marker circle, connector line, and callout card
+// for a single button hotspot. Used in both production and editor modes.
+//
+// In production mode: everything positions from model data; DragHandlers disabled.
+// In editor mode: marker and card are independently draggable; line tracks live.
+Item {
+    id: root
+
+    // ── Input properties (set by parent page) ──
+    property real imageX: 0
+    property real imageY: 0
+    property real imageW: 1
+    property real imageH: 1
+
+    property real hotspotXPct: 0
+    property real hotspotYPct: 0
+    property string side: "right"
+    property real labelOffsetYPct: 0
+    property bool configurable: true
+
+    property string buttonName: ""
+    property string actionName: ""
+    property bool selected: false
+    property int buttonId: -1
+    property int hotspotIndex: -1
+
+    property real pageWidth: 0
+    property real pageHeight: 0
+
+    signal clicked()
+
+    visible: root.configurable
+
+    // ── Computed marker centre ──
+    readonly property real markerCenterX: imageX + hotspotXPct * imageW
+    readonly property real markerCenterY: imageY + hotspotYPct * imageH
+
+    // ── Computed card target ──
+    readonly property real cardTargetX: side === "left"
+        ? markerCenterX - cardItem.width - 24
+        : markerCenterX + 24
+    readonly property real cardTargetY: markerCenterY - cardItem.height / 2
+        + labelOffsetYPct * imageH
+
+    // ══════════════════════════════════════════════════════════════════════
+    // MARKER
+    // ══════════════════════════════════════════════════════════════════════
+    Item {
+        id: marker
+        width: 24; height: 24
+        x: root.markerCenterX - width / 2
+        y: root.markerCenterY - height / 2
+
+        Rectangle {
+            anchors.centerIn: parent
+            width: 18; height: 18; radius: 9
+            color: "transparent"
+            border.color: Theme.accent
+            border.width: 2
+            opacity: 0.7
+
+            Behavior on opacity { NumberAnimation { duration: 200 } }
+
+            Rectangle {
+                anchors.centerIn: parent
+                width: 6; height: 6; radius: 3
+                color: Theme.accent
+                opacity: 0.6
+            }
+        }
+
+        MouseArea {
+            anchors.centerIn: parent
+            width: 0.22 * root.imageW
+            height: 0.14 * root.imageH
+            cursorShape: Qt.PointingHandCursor
+            enabled: !markerDrag.enabled
+            onClicked: root.clicked()
+        }
+
+        Connections {
+            target: DeviceModel
+            function onSelectedChanged() {
+                if (!markerDrag.active) {
+                    marker.x = root.markerCenterX - marker.width / 2
+                    marker.y = root.markerCenterY - marker.height / 2
+                }
+            }
+        }
+
+        DragHandler {
+            id: markerDrag
+            enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
+            target: parent
+            onActiveChanged: {
+                if (!active) {
+                    var cx = marker.x + marker.width / 2
+                    var cy = marker.y + marker.height / 2
+                    var xPct = (cx - root.imageX) / root.imageW
+                    var yPct = (cy - root.imageY) / root.imageH
+                    xPct = Math.max(0, Math.min(1, xPct))
+                    yPct = Math.max(0, Math.min(1, yPct))
+                    EditorModel.updateHotspot(root.hotspotIndex,
+                        xPct, yPct, root.side, root.labelOffsetYPct)
+                }
+            }
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // CONNECTOR LINE
+    // ══════════════════════════════════════════════════════════════════════
+    Canvas {
+        id: lineCanvas
+        anchors.fill: parent
+
+        onPaint: {
+            var ctx = getContext("2d")
+            ctx.clearRect(0, 0, width, height)
+
+            if (!root.visible) return
+
+            var mx = marker.x + marker.width / 2
+            var my = marker.y + marker.height / 2
+
+            var cardEdgeX, cardEdgeY
+            if (cardItem.x + cardItem.width / 2 < mx) {
+                cardEdgeX = cardItem.x + cardItem.width
+            } else {
+                cardEdgeX = cardItem.x
+            }
+            cardEdgeY = cardItem.y + cardItem.height / 2
+
+            ctx.beginPath()
+            ctx.moveTo(cardEdgeX, cardEdgeY)
+            ctx.lineTo(mx, my)
+            ctx.strokeStyle = root.selected ? Theme.accent : "#BBBBBB"
+            ctx.lineWidth = 2
+            ctx.setLineDash([])
+            ctx.stroke()
+        }
+
+        Connections {
+            target: marker
+            function onXChanged() { lineCanvas.requestPaint() }
+            function onYChanged() { lineCanvas.requestPaint() }
+        }
+        Connections {
+            target: cardItem
+            function onXChanged() { lineCanvas.requestPaint() }
+            function onYChanged() { lineCanvas.requestPaint() }
+        }
+        Connections {
+            target: root
+            function onSelectedChanged() { lineCanvas.requestPaint() }
+            function onVisibleChanged() { lineCanvas.requestPaint() }
+        }
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // CARD
+    // ══════════════════════════════════════════════════════════════════════
+    Item {
+        id: cardItem
+        width: cardRect.implicitWidth
+        height: cardRect.implicitHeight
+
+        x: root.cardTargetX
+        y: root.cardTargetY
+
+        Connections {
+            target: DeviceModel
+            function onSelectedChanged() {
+                if (!cardDrag.active) {
+                    cardItem.x = root.cardTargetX
+                    cardItem.y = root.cardTargetY
+                }
+            }
+        }
+
+        Rectangle {
+            id: cardRect
+            implicitWidth: Math.min(contentCol.implicitWidth + 24, 180)
+            implicitHeight: contentCol.implicitHeight + 18
+            radius: 8
+            color: root.selected ? Theme.accent : Theme.cardBg
+            border.color: root.selected ? Theme.accentHover : Theme.cardBorder
+            border.width: 1
+
+            Behavior on color { ColorAnimation { duration: 150 } }
+            Behavior on border.color { ColorAnimation { duration: 150 } }
+
+            // Drop shadow
+            Rectangle {
+                x: 4; y: 4
+                width: parent.width; height: parent.height
+                radius: parent.radius
+                color: Qt.rgba(0, 0, 0, 0.1)
+                z: -1
+            }
+
+            Column {
+                id: contentCol
+                x: 12; y: 9
+                spacing: 2
+
+                // Physical button name (primary, bold)
+                EditableText {
+                    id: nameLabel
+                    width: 156; height: 16
+                    text: root.buttonName
+                    pixelSize: 12
+                    fontWeight: Font.DemiBold
+                    textColor: root.selected ? Theme.activeTabText
+                        : (hoverHandler.hovered ? Theme.accent : Theme.text)
+                    onCommit: function(v) {
+                        var ctrls = DeviceModel.controlDescriptors
+                        if (!ctrls) return
+                        for (var i = 0; i < ctrls.length; ++i) {
+                            if (ctrls[i].buttonId === root.buttonId) {
+                                EditorModel.updateText("controlDisplayName", i, v)
+                                return
+                            }
+                        }
+                    }
+                }
+
+                // Action name (secondary)
+                Text {
+                    text: root.actionName
+                    font.pixelSize: 10
+                    color: root.selected ? Qt.rgba(1,1,1,0.75) : "#999999"
+                    width: Math.min(implicitWidth, 156)
+                    elide: Text.ElideRight
+                    Behavior on color { ColorAnimation { duration: 150 } }
+                }
+            }
+
+            // Hover overlay
+            Rectangle {
+                anchors.fill: parent
+                radius: cardRect.radius
+                color: hoverHandler.hovered && !root.selected
+                    ? Qt.rgba(0, 0, 0, 0.04) : "transparent"
+                Behavior on color { ColorAnimation { duration: 100 } }
+            }
+
+            HoverHandler { id: hoverHandler }
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: root.clicked()
+            }
+        }
+
+        DragHandler {
+            id: cardDrag
+            enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
+            target: parent
+            onActiveChanged: {
+                if (!active) {
+                    var centroidX = cardItem.x + cardItem.width / 2
+                    var newSide = centroidX < root.pageWidth / 2 ? "left" : "right"
+                    var my = marker.y + marker.height / 2
+                    var baseY = my - cardItem.height / 2
+                    var newOffsetY = (cardItem.y - baseY) / (root.imageH > 0 ? root.imageH : 1)
+                    EditorModel.updateHotspot(root.hotspotIndex,
+                        root.hotspotXPct, root.hotspotYPct,
+                        newSide, newOffsetY)
+                }
+            }
+        }
+    }
+}

--- a/src/app/qml/components/InfoCallout.qml
+++ b/src/app/qml/components/InfoCallout.qml
@@ -19,7 +19,10 @@ Item {
     property real hsLabelOffsetYPct: 0
     property real pageWidth: 0
     property real pageHeight: 0
-    readonly property bool dragging: cardDrag.active
+    // Manual drag flag — cleared AFTER EditorModel update. Gating a Binding
+    // directly on cardDrag.active races DragHandler.onActiveChanged and snaps
+    // the card back to its pre-drag position.
+    property bool dragging: false
 
     signal calloutClicked(string type)
 
@@ -107,14 +110,18 @@ Item {
             if (active) {
                 cardDrag.grabOffsetYPct = root.hsLabelOffsetYPct
                 cardDrag.grabY = root.y
-            } else if (root.pageWidth > 0 && root.pageHeight > 0) {
-                var centroidX = root.x + root.width / 2
-                var newSide = centroidX < root.pageWidth / 2 ? "left" : "right"
-                var dy = root.y - cardDrag.grabY
-                var newOffsetY = cardDrag.grabOffsetYPct + (dy / root.pageHeight)
-                EditorModel.updateScrollHotspot(root.hotspotIndex,
-                                                 root.hsXPct, root.hsYPct,
-                                                 newSide, newOffsetY)
+                root.dragging = true
+            } else {
+                if (root.pageWidth > 0 && root.pageHeight > 0) {
+                    var centroidX = root.x + root.width / 2
+                    var newSide = centroidX < root.pageWidth / 2 ? "left" : "right"
+                    var dy = root.y - cardDrag.grabY
+                    var newOffsetY = cardDrag.grabOffsetYPct + (dy / root.pageHeight)
+                    EditorModel.updateScrollHotspot(root.hotspotIndex,
+                                                     root.hsXPct, root.hsYPct,
+                                                     newSide, newOffsetY)
+                }
+                root.dragging = false
             }
         }
     }

--- a/src/app/qml/components/InfoCallout.qml
+++ b/src/app/qml/components/InfoCallout.qml
@@ -12,6 +12,15 @@ Item {
     property var    settings: []     // list of strings shown as lines
     property string calloutType: ""  // "scrollwheel" | "thumbwheel" | "pointerspeed"
 
+    // Editor-mode drag support (see PointScrollPage wiring)
+    property int  hotspotIndex: -1
+    property real hsXPct: 0
+    property real hsYPct: 0
+    property real hsLabelOffsetYPct: 0
+    property real pageWidth: 0
+    property real pageHeight: 0
+    readonly property bool dragging: cardDrag.active
+
     signal calloutClicked(string type)
 
     implicitWidth:  card.implicitWidth
@@ -81,6 +90,32 @@ Item {
             anchors.fill: parent
             cursorShape: Qt.PointingHandCursor
             onClicked: root.calloutClicked(root.calloutType)
+        }
+    }
+
+    // Editor-mode drag: translate root Item freely, on release snap side to the
+    // nearest half-page column and persist labelOffsetYPct as a delta from grab.
+    DragHandler {
+        id: cardDrag
+        enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
+        target: root
+
+        property real grabOffsetYPct: 0
+        property real grabY: 0
+
+        onActiveChanged: {
+            if (active) {
+                cardDrag.grabOffsetYPct = root.hsLabelOffsetYPct
+                cardDrag.grabY = root.y
+            } else if (root.pageWidth > 0 && root.pageHeight > 0) {
+                var centroidX = root.x + root.width / 2
+                var newSide = centroidX < root.pageWidth / 2 ? "left" : "right"
+                var dy = root.y - cardDrag.grabY
+                var newOffsetY = cardDrag.grabOffsetYPct + (dy / root.pageHeight)
+                EditorModel.updateScrollHotspot(root.hotspotIndex,
+                                                 root.hsXPct, root.hsYPct,
+                                                 newSide, newOffsetY)
+            }
         }
     }
 }

--- a/src/app/qml/components/InfoCallout.qml
+++ b/src/app/qml/components/InfoCallout.qml
@@ -99,36 +99,18 @@ Item {
         }
     }
 
-    Connections {
-        target: DeviceModel
-        function onSelectedChanged() {
-            if (!cardDrag.active) {
-                root.x = root.targetX
-                root.y = root.targetY
-            }
-        }
-    }
-
-    // Editor-mode drag: translate root Item freely, on release snap side to the
-    // nearest half-page column and persist labelOffsetYPct as a delta from grab.
+    // Editor-mode drag: translate root Item freely, on release persist position.
     DragHandler {
         id: cardDrag
         enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
         target: root
 
-        property real grabOffsetYPct: 0
-        property real grabY: 0
-
         onActiveChanged: {
-            if (active) {
-                cardDrag.grabOffsetYPct = root.hsLabelOffsetYPct
-                cardDrag.grabY = root.y
-            } else {
+            if (!active) {
                 if (root.pageWidth > 0 && root.pageHeight > 0) {
                     var centroidX = root.x + root.width / 2
                     var newSide = centroidX < root.pageWidth / 2 ? "left" : "right"
-                    var dy = root.y - cardDrag.grabY
-                    var newOffsetY = cardDrag.grabOffsetYPct + (dy / root.pageHeight)
+                    var newOffsetY = root.hsLabelOffsetYPct
                     EditorModel.updateScrollHotspot(root.hotspotIndex,
                                                      root.hsXPct, root.hsYPct,
                                                      newSide, newOffsetY)

--- a/src/app/qml/components/InfoCallout.qml
+++ b/src/app/qml/components/InfoCallout.qml
@@ -19,10 +19,13 @@ Item {
     property real hsLabelOffsetYPct: 0
     property real pageWidth: 0
     property real pageHeight: 0
-    // Manual drag flag — cleared AFTER EditorModel update. Gating a Binding
-    // directly on cardDrag.active races DragHandler.onActiveChanged and snaps
-    // the card back to its pre-drag position.
-    property bool dragging: false
+
+    // Target position set by the parent page — survives DragHandler severing x/y.
+    property real targetX: 0
+    property real targetY: 0
+
+    x: targetX
+    y: targetY
 
     signal calloutClicked(string type)
 
@@ -110,7 +113,6 @@ Item {
             if (active) {
                 cardDrag.grabOffsetYPct = root.hsLabelOffsetYPct
                 cardDrag.grabY = root.y
-                root.dragging = true
             } else {
                 if (root.pageWidth > 0 && root.pageHeight > 0) {
                     var centroidX = root.x + root.width / 2
@@ -121,7 +123,8 @@ Item {
                                                      root.hsXPct, root.hsYPct,
                                                      newSide, newOffsetY)
                 }
-                root.dragging = false
+                root.x = Qt.binding(function() { return root.targetX })
+                root.y = Qt.binding(function() { return root.targetY })
             }
         }
     }

--- a/src/app/qml/components/InfoCallout.qml
+++ b/src/app/qml/components/InfoCallout.qml
@@ -20,12 +20,28 @@ Item {
     property real pageWidth: 0
     property real pageHeight: 0
 
-    // Target position set by the parent page — survives DragHandler severing x/y.
+    // Target position set by the parent page.
+    // No x/y binding — DragHandler severs bindings on first drag.
+    // Connections below imperatively sync position when target changes.
     property real targetX: 0
     property real targetY: 0
 
-    x: targetX
-    y: targetY
+    Connections {
+        target: root
+        function onTargetXChanged() {
+            if (!cardDrag.active)
+                root.x = root.targetX
+        }
+        function onTargetYChanged() {
+            if (!cardDrag.active)
+                root.y = root.targetY
+        }
+    }
+
+    Component.onCompleted: {
+        root.x = root.targetX
+        root.y = root.targetY
+    }
 
     signal calloutClicked(string type)
 
@@ -114,6 +130,10 @@ Item {
                     EditorModel.updateScrollHotspot(root.hotspotIndex,
                                                      root.hsXPct, root.hsYPct,
                                                      newSide, newOffsetY)
+                    Qt.callLater(function() {
+                        root.x = root.targetX
+                        root.y = root.targetY
+                    })
                 }
             }
         }

--- a/src/app/qml/components/InfoCallout.qml
+++ b/src/app/qml/components/InfoCallout.qml
@@ -99,6 +99,16 @@ Item {
         }
     }
 
+    Connections {
+        target: DeviceModel
+        function onSelectedChanged() {
+            if (!cardDrag.active) {
+                root.x = root.targetX
+                root.y = root.targetY
+            }
+        }
+    }
+
     // Editor-mode drag: translate root Item freely, on release snap side to the
     // nearest half-page column and persist labelOffsetYPct as a delta from grab.
     DragHandler {
@@ -123,8 +133,6 @@ Item {
                                                      root.hsXPct, root.hsYPct,
                                                      newSide, newOffsetY)
                 }
-                root.x = Qt.binding(function() { return root.targetX })
-                root.y = Qt.binding(function() { return root.targetY })
             }
         }
     }

--- a/src/app/qml/components/SideNav.qml
+++ b/src/app/qml/components/SideNav.qml
@@ -156,4 +156,18 @@ Rectangle {
             visible: DeviceModel.deviceConnected && DeviceModel.batteryLevel > 0
         }
     }
+
+    // Edit-mode indicator stripe along the left edge, gated on EditorModel.editing
+    Rectangle {
+        id: editStripe
+        objectName: "editStripe"
+        anchors {
+            left: parent.left
+            top: parent.top
+            bottom: parent.bottom
+        }
+        width: 4
+        color: "#F5A623"
+        visible: typeof EditorModel !== 'undefined' && EditorModel.editing
+    }
 }

--- a/src/app/qml/components/SideNav.qml
+++ b/src/app/qml/components/SideNav.qml
@@ -43,13 +43,14 @@ Rectangle {
             Layout.rightMargin: 16
             spacing: 8
 
-            Text {
+            EditableText {
                 text: DeviceModel.deviceName || "MX Master 3S"
-                font.pixelSize: 13
-                font.bold: true
-                color: Theme.text
-                elide: Text.ElideRight
+                pixelSize: 13
+                textBold: true
+                textColor: Theme.text
                 Layout.fillWidth: true
+                Layout.preferredHeight: 18
+                onCommit: function(v) { EditorModel.updateText("deviceName", -1, v) }
             }
         }
 

--- a/src/app/qml/pages/ButtonsPage.qml
+++ b/src/app/qml/pages/ButtonsPage.qml
@@ -130,6 +130,7 @@ Item {
 
                     // Editor drag wiring
                     hotspotIndex: modelData
+                    buttonId: btnId
                     hsXPct: cdata.hotspotXPct
                     hsYPct: cdata.hotspotYPct
                     hsLabelOffsetYPct: cdata.labelOffsetYPct || 0

--- a/src/app/qml/pages/ButtonsPage.qml
+++ b/src/app/qml/pages/ButtonsPage.qml
@@ -112,19 +112,11 @@ Item {
                     // Label offset (some labels need to shift to avoid overlap)
                     readonly property real labelOffY: (cdata.labelOffsetYPct || 0) * deviceRender.paintedH
 
-                    // Position: left-side labels to the left, right-side to the right.
-                    // Conditional binding: active except while DragHandler is mutating x/y.
-                    // A self-referencing ternary here would sever the binding after first drag.
-                    Binding on x {
-                        value: cdata.side === "left"
-                               ? callout.hotX - callout.width - 24
-                               : callout.hotX + 24
-                        when: !callout.dragging
-                    }
-                    Binding on y {
-                        value: callout.hotY - callout.height / 2 + callout.labelOffY
-                        when: !callout.dragging
-                    }
+                    // Target position: left-side labels to the left, right-side to the right.
+                    targetX: cdata.side === "left"
+                             ? callout.hotX - callout.width - 24
+                             : callout.hotX + 24
+                    targetY: callout.hotY - callout.height / 2 + callout.labelOffY
 
                     // Connector line endpoint (the hotspot dot)
                     lineToX: hotX

--- a/src/app/qml/pages/ButtonsPage.qml
+++ b/src/app/qml/pages/ButtonsPage.qml
@@ -99,6 +99,7 @@ Item {
                 model: root.calloutData.length
 
                 ButtonCallout {
+                    id: callout
                     required property int modelData
 
                     readonly property var cdata: root.calloutData[modelData]
@@ -111,16 +112,29 @@ Item {
                     // Label offset (some labels need to shift to avoid overlap)
                     readonly property real labelOffY: (cdata.labelOffsetYPct || 0) * deviceRender.paintedH
 
-                    // Position: left-side labels to the left, right-side to the right
-                    x: cdata.side === "left"
-                       ? hotX - width - 24
-                       : hotX + 24
-                    y: hotY - height / 2 + labelOffY
+                    // Position: left-side labels to the left, right-side to the right.
+                    // During editor drag, freeze the binding so DragHandler assignments stick.
+                    x: callout.dragging
+                       ? callout.x
+                       : (cdata.side === "left"
+                          ? hotX - width - 24
+                          : hotX + 24)
+                    y: callout.dragging
+                       ? callout.y
+                       : hotY - height / 2 + labelOffY
 
                     // Connector line endpoint (the hotspot dot)
                     lineToX: hotX
                     lineToY: hotY
                     lineSide: cdata.side
+
+                    // Editor drag wiring
+                    hotspotIndex: modelData
+                    hsXPct: cdata.hotspotXPct
+                    hsYPct: cdata.hotspotYPct
+                    hsLabelOffsetYPct: cdata.labelOffsetYPct || 0
+                    pageWidth: mouseContainer.width
+                    pageHeight: mouseContainer.height
 
                     actionName: {
                         var an = ButtonModel.actionNameForButton(btnId)

--- a/src/app/qml/pages/ButtonsPage.qml
+++ b/src/app/qml/pages/ButtonsPage.qml
@@ -113,15 +113,18 @@ Item {
                     readonly property real labelOffY: (cdata.labelOffsetYPct || 0) * deviceRender.paintedH
 
                     // Position: left-side labels to the left, right-side to the right.
-                    // During editor drag, freeze the binding so DragHandler assignments stick.
-                    x: callout.dragging
-                       ? callout.x
-                       : (cdata.side === "left"
-                          ? hotX - width - 24
-                          : hotX + 24)
-                    y: callout.dragging
-                       ? callout.y
-                       : hotY - height / 2 + labelOffY
+                    // Conditional binding: active except while DragHandler is mutating x/y.
+                    // A self-referencing ternary here would sever the binding after first drag.
+                    Binding on x {
+                        value: cdata.side === "left"
+                               ? callout.hotX - callout.width - 24
+                               : callout.hotX + 24
+                        when: !callout.dragging
+                    }
+                    Binding on y {
+                        value: callout.hotY - callout.height / 2 + callout.labelOffY
+                        when: !callout.dragging
+                    }
 
                     // Connector line endpoint (the hotspot dot)
                     lineToX: hotX

--- a/src/app/qml/pages/ButtonsPage.qml
+++ b/src/app/qml/pages/ButtonsPage.qml
@@ -6,7 +6,7 @@ import Logitune
 // ButtonsPage — main button-remapping screen (Options+ dark style).
 //
 // Layout:
-//   Centre: mouseContainer (DeviceRender + ButtonCallout cards, move together)
+//   Centre: mouseContainer (DeviceRender + HotspotControl cards, move together)
 //   Right:  ActionsPanel (slides in when a button is selected)
 // ─────────────────────────────────────────────────────────────────────────────
 Item {
@@ -88,56 +88,46 @@ Item {
                 implicitWidth:  280
                 implicitHeight: 414
                 imageSource: DeviceModel.sideImage
-
-                onButtonClicked: function(buttonId) {
-                    selectButton(buttonId)
-                }
             }
 
-            // ── Callout cards (children of mouseContainer) ───────────────────
+            // ── Unified hotspot controls (marker + line + card) ─────────────
             Repeater {
                 model: root.calloutData.length
 
-                ButtonCallout {
-                    id: callout
+                HotspotControl {
                     required property int modelData
 
                     readonly property var cdata: root.calloutData[modelData]
                     readonly property int btnId: cdata.buttonId
 
-                    // Hotspot position in mouseContainer coordinates (using painted rect)
-                    readonly property real hotX: deviceRender.x + deviceRender.paintedX + cdata.hotspotXPct * deviceRender.paintedW
-                    readonly property real hotY: deviceRender.y + deviceRender.paintedY + cdata.hotspotYPct * deviceRender.paintedH
+                    // Fill mouseContainer so marker + card can position freely
+                    anchors.fill: parent
 
-                    // Label offset (some labels need to shift to avoid overlap)
-                    readonly property real labelOffY: (cdata.labelOffsetYPct || 0) * deviceRender.paintedH
+                    // Device image bounds
+                    imageX: deviceRender.x + deviceRender.paintedX
+                    imageY: deviceRender.y + deviceRender.paintedY
+                    imageW: deviceRender.paintedW
+                    imageH: deviceRender.paintedH
 
-                    // Target position: left-side labels to the left, right-side to the right.
-                    targetX: cdata.side === "left"
-                             ? callout.hotX - callout.width - 24
-                             : callout.hotX + 24
-                    targetY: callout.hotY - callout.height / 2 + callout.labelOffY
+                    // Hotspot data
+                    hotspotXPct: cdata.hotspotXPct
+                    hotspotYPct: cdata.hotspotYPct
+                    side: cdata.side
+                    labelOffsetYPct: cdata.labelOffsetYPct || 0
+                    configurable: cdata.configurable
 
-                    // Connector line endpoint (the hotspot dot)
-                    lineToX: hotX
-                    lineToY: hotY
-                    lineSide: cdata.side
-
-                    // Editor drag wiring
-                    hotspotIndex: modelData
-                    buttonId: btnId
-                    hsXPct: cdata.hotspotXPct
-                    hsYPct: cdata.hotspotYPct
-                    hsLabelOffsetYPct: cdata.labelOffsetYPct || 0
-                    pageWidth: mouseContainer.width
-                    pageHeight: mouseContainer.height
-
+                    // Card data
+                    buttonName: cdata.buttonLabel
                     actionName: {
                         var an = ButtonModel.actionNameForButton(btnId)
                         return an.length > 0 ? an : cdata.actionDefault
                     }
-                    buttonName: cdata.buttonLabel
-                    selected:   root.selectedButton === btnId
+                    selected: root.selectedButton === btnId
+                    buttonId: btnId
+                    hotspotIndex: modelData
+
+                    pageWidth: mouseContainer.width
+                    pageHeight: mouseContainer.height
 
                     onClicked: selectButton(btnId)
 

--- a/src/app/qml/pages/EasySwitchPage.qml
+++ b/src/app/qml/pages/EasySwitchPage.qml
@@ -100,20 +100,24 @@ Item {
                         readonly property var pos: index < imageContainer.slotPositions.length
                             ? imageContainer.slotPositions[index] : { xPct: 0.5, yPct: 0.65 }
 
+                        // Manual drag flag — cleared AFTER EditorModel update so the
+                        // Binding below sees the refreshed targetX/targetY on reactivation.
+                        // A plain `when: !drag.active` races DragHandler.onActiveChanged
+                        // and snaps the item back to the pre-drag position.
+                        property bool dragging: false
+
                         width: 24; height: 24
 
                         readonly property real targetX: imageContainer.imgX + imageContainer.imgW * pos.xPct
                         readonly property real targetY: imageContainer.imgY + imageContainer.imgH * pos.yPct
 
-                        // Conditional binding: active except while DragHandler is mutating x/y.
-                        // A self-referencing ternary here would sever the binding after first drag.
                         Binding on x {
                             value: slotItem.targetX - slotItem.width / 2
-                            when: !drag.active
+                            when: !slotItem.dragging
                         }
                         Binding on y {
                             value: slotItem.targetY - slotItem.height / 2
-                            when: !drag.active
+                            when: !slotItem.dragging
                         }
 
                         Rectangle {
@@ -136,7 +140,9 @@ Item {
                             enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
                             target: parent
                             onActiveChanged: {
-                                if (!active) {
+                                if (active) {
+                                    slotItem.dragging = true
+                                } else {
                                     var cx = slotItem.x + slotItem.width / 2
                                     var cy = slotItem.y + slotItem.height / 2
                                     var xPct = (cx - imageContainer.imgX) / imageContainer.imgW
@@ -144,6 +150,7 @@ Item {
                                     xPct = Math.max(0, Math.min(1, xPct))
                                     yPct = Math.max(0, Math.min(1, yPct))
                                     EditorModel.updateSlotPosition(slotItem.index, xPct, yPct)
+                                    slotItem.dragging = false
                                 }
                             }
                         }

--- a/src/app/qml/pages/EasySwitchPage.qml
+++ b/src/app/qml/pages/EasySwitchPage.qml
@@ -55,24 +55,51 @@ Item {
 
                 Repeater {
                     model: imageContainer.slotPositions.length
-                    Rectangle {
+                    Item {
+                        id: slotItem
                         required property int index
                         readonly property bool isActive: (index + 1) === DeviceModel.activeSlot
                         readonly property var pos: index < imageContainer.slotPositions.length
                             ? imageContainer.slotPositions[index] : { xPct: 0.5, yPct: 0.65 }
 
-                        x: imageContainer.imgX + imageContainer.imgW * pos.xPct - width / 2
-                        y: imageContainer.imgY + imageContainer.imgH * pos.yPct - height / 2
-                        width: 9; height: 9; radius: 4.5
-                        color: isActive ? Theme.accent : "transparent"
-                        border.color: Theme.accent
-                        border.width: isActive ? 0 : 1.5
+                        width: 24; height: 24
 
-                        SequentialAnimation on opacity {
-                            running: isActive
-                            loops: Animation.Infinite
-                            NumberAnimation { to: 0.3; duration: 800; easing.type: Easing.InOutSine }
-                            NumberAnimation { to: 1.0; duration: 800; easing.type: Easing.InOutSine }
+                        readonly property real targetX: imageContainer.imgX + imageContainer.imgW * pos.xPct
+                        readonly property real targetY: imageContainer.imgY + imageContainer.imgH * pos.yPct
+
+                        x: drag.active ? x : targetX - width / 2
+                        y: drag.active ? y : targetY - height / 2
+
+                        Rectangle {
+                            anchors.centerIn: parent
+                            width: 9; height: 9; radius: 4.5
+                            color: slotItem.isActive ? Theme.accent : "transparent"
+                            border.color: Theme.accent
+                            border.width: slotItem.isActive ? 0 : 1.5
+
+                            SequentialAnimation on opacity {
+                                running: slotItem.isActive
+                                loops: Animation.Infinite
+                                NumberAnimation { to: 0.3; duration: 800; easing.type: Easing.InOutSine }
+                                NumberAnimation { to: 1.0; duration: 800; easing.type: Easing.InOutSine }
+                            }
+                        }
+
+                        DragHandler {
+                            id: drag
+                            enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
+                            target: parent
+                            onActiveChanged: {
+                                if (!active) {
+                                    var cx = slotItem.x + slotItem.width / 2
+                                    var cy = slotItem.y + slotItem.height / 2
+                                    var xPct = (cx - imageContainer.imgX) / imageContainer.imgW
+                                    var yPct = (cy - imageContainer.imgY) / imageContainer.imgH
+                                    xPct = Math.max(0, Math.min(1, xPct))
+                                    yPct = Math.max(0, Math.min(1, yPct))
+                                    EditorModel.updateSlotPosition(slotItem.index, xPct, yPct)
+                                }
+                            }
                         }
                     }
                 }

--- a/src/app/qml/pages/EasySwitchPage.qml
+++ b/src/app/qml/pages/EasySwitchPage.qml
@@ -62,7 +62,7 @@ Item {
                     }
                 }
 
-                Button {
+                Rectangle {
                     id: replaceBackButton
                     visible: typeof EditorModel !== 'undefined' && EditorModel.editing
                     anchors {
@@ -70,8 +70,28 @@ Item {
                         right: deviceImage.right
                         margins: 4
                     }
-                    text: "Replace image"
-                    onClicked: backImageDialog.open()
+                    width: 32; height: 28
+                    radius: 4
+                    color: replaceBackHover.hovered ? Theme.hoverBg : Theme.inputBg
+                    Behavior on color { ColorAnimation { duration: 150 } }
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: "\uD83D\uDDBC"
+                        font.pixelSize: 16
+                        color: Theme.text
+                    }
+
+                    HoverHandler { id: replaceBackHover }
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: backImageDialog.open()
+                        hoverEnabled: true
+                        ToolTip.visible: replaceBackHover.hovered
+                        ToolTip.text: "Replace image"
+                        ToolTip.delay: 500
+                    }
                 }
 
                 FileDialog {
@@ -120,10 +140,18 @@ Item {
 
                         Rectangle {
                             anchors.centerIn: parent
-                            width: 9; height: 9; radius: 4.5
+                            width: 16; height: 16; radius: 8
                             color: slotItem.isActive ? Theme.accent : "transparent"
                             border.color: Theme.accent
                             border.width: slotItem.isActive ? 0 : 1.5
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: (slotItem.index + 1).toString()
+                                font.pixelSize: 9
+                                font.bold: true
+                                color: slotItem.isActive ? Theme.activeTabText : Theme.accent
+                            }
 
                             SequentialAnimation on opacity {
                                 running: slotItem.isActive

--- a/src/app/qml/pages/EasySwitchPage.qml
+++ b/src/app/qml/pages/EasySwitchPage.qml
@@ -63,9 +63,10 @@ Item {
 
                         x: imageContainer.imgX + imageContainer.imgW * pos.xPct - width / 2
                         y: imageContainer.imgY + imageContainer.imgH * pos.yPct - height / 2
-                        width: 7; height: 7; radius: 3.5
+                        width: 9; height: 9; radius: 4.5
                         color: isActive ? Theme.accent : "transparent"
-                        visible: isActive
+                        border.color: Theme.accent
+                        border.width: isActive ? 0 : 1.5
 
                         SequentialAnimation on opacity {
                             running: isActive

--- a/src/app/qml/pages/EasySwitchPage.qml
+++ b/src/app/qml/pages/EasySwitchPage.qml
@@ -136,6 +136,10 @@ Item {
                     delegate: Rectangle {
                         required property int index
                         readonly property bool isActive: (index + 1) === DeviceModel.activeSlot
+                        readonly property var slotData: DeviceModel.easySwitchSlotPositions[index] || ({})
+                        readonly property string slotLabel: (slotData.label && slotData.label.length > 0)
+                            ? slotData.label
+                            : (isActive ? DeviceModel.connectionType : "Available")
 
                         width: parent.width
                         height: 56
@@ -168,10 +172,14 @@ Item {
                                 anchors.verticalCenter: parent.verticalCenter
                                 spacing: 2
 
-                                Text {
-                                    text: isActive ? DeviceModel.connectionType : "Available"
-                                    font { pixelSize: 14; bold: isActive }
-                                    color: isActive ? Theme.text : Theme.textSecondary
+                                EditableText {
+                                    width: 260
+                                    height: 20
+                                    text: slotLabel
+                                    pixelSize: 14
+                                    textBold: isActive
+                                    textColor: isActive ? Theme.text : Theme.textSecondary
+                                    onCommit: function(v) { EditorModel.updateText("slotLabel", index, v) }
                                 }
                                 Text {
                                     text: isActive ? "Connected" : ""

--- a/src/app/qml/pages/EasySwitchPage.qml
+++ b/src/app/qml/pages/EasySwitchPage.qml
@@ -105,8 +105,16 @@ Item {
                         readonly property real targetX: imageContainer.imgX + imageContainer.imgW * pos.xPct
                         readonly property real targetY: imageContainer.imgY + imageContainer.imgH * pos.yPct
 
-                        x: drag.active ? x : targetX - width / 2
-                        y: drag.active ? y : targetY - height / 2
+                        // Conditional binding: active except while DragHandler is mutating x/y.
+                        // A self-referencing ternary here would sever the binding after first drag.
+                        Binding on x {
+                            value: slotItem.targetX - slotItem.width / 2
+                            when: !drag.active
+                        }
+                        Binding on y {
+                            value: slotItem.targetY - slotItem.height / 2
+                            when: !drag.active
+                        }
 
                         Rectangle {
                             anchors.centerIn: parent

--- a/src/app/qml/pages/EasySwitchPage.qml
+++ b/src/app/qml/pages/EasySwitchPage.qml
@@ -100,24 +100,22 @@ Item {
                         readonly property var pos: index < imageContainer.slotPositions.length
                             ? imageContainer.slotPositions[index] : { xPct: 0.5, yPct: 0.65 }
 
-                        // Manual drag flag — cleared AFTER EditorModel update so the
-                        // Binding below sees the refreshed targetX/targetY on reactivation.
-                        // A plain `when: !drag.active` races DragHandler.onActiveChanged
-                        // and snaps the item back to the pre-drag position.
-                        property bool dragging: false
-
                         width: 24; height: 24
 
                         readonly property real targetX: imageContainer.imgX + imageContainer.imgW * pos.xPct
                         readonly property real targetY: imageContainer.imgY + imageContainer.imgH * pos.yPct
 
-                        Binding on x {
-                            value: slotItem.targetX - slotItem.width / 2
-                            when: !slotItem.dragging
-                        }
-                        Binding on y {
-                            value: slotItem.targetY - slotItem.height / 2
-                            when: !slotItem.dragging
+                        x: targetX - width / 2
+                        y: targetY - height / 2
+
+                        Connections {
+                            target: DeviceModel
+                            function onSelectedChanged() {
+                                if (!drag.active) {
+                                    slotItem.x = slotItem.targetX - slotItem.width / 2
+                                    slotItem.y = slotItem.targetY - slotItem.height / 2
+                                }
+                            }
                         }
 
                         Rectangle {
@@ -140,9 +138,7 @@ Item {
                             enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
                             target: parent
                             onActiveChanged: {
-                                if (active) {
-                                    slotItem.dragging = true
-                                } else {
+                                if (!active) {
                                     var cx = slotItem.x + slotItem.width / 2
                                     var cy = slotItem.y + slotItem.height / 2
                                     var xPct = (cx - imageContainer.imgX) / imageContainer.imgW
@@ -150,7 +146,6 @@ Item {
                                     xPct = Math.max(0, Math.min(1, xPct))
                                     yPct = Math.max(0, Math.min(1, yPct))
                                     EditorModel.updateSlotPosition(slotItem.index, xPct, yPct)
-                                    slotItem.dragging = false
                                 }
                             }
                         }

--- a/src/app/qml/pages/EasySwitchPage.qml
+++ b/src/app/qml/pages/EasySwitchPage.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Dialogs
 import Logitune
 
 Item {
@@ -44,6 +45,43 @@ Item {
                     fillMode: Image.PreserveAspectFit
                     smooth: true
                     mipmap: true
+                }
+
+                DropArea {
+                    id: backImageDrop
+                    anchors.fill: deviceImage
+                    enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
+                    onDropped: function(drop) {
+                        if (drop.hasUrls && drop.urls.length > 0) {
+                            var url = drop.urls[0].toString()
+                            if (url.toLowerCase().endsWith(".png")) {
+                                var path = url.replace(/^file:\/\//, "")
+                                EditorModel.replaceImage("back", path)
+                            }
+                        }
+                    }
+                }
+
+                Button {
+                    id: replaceBackButton
+                    visible: typeof EditorModel !== 'undefined' && EditorModel.editing
+                    anchors {
+                        top: deviceImage.top
+                        right: deviceImage.right
+                        margins: 4
+                    }
+                    text: "Replace image"
+                    onClicked: backImageDialog.open()
+                }
+
+                FileDialog {
+                    id: backImageDialog
+                    nameFilters: ["PNG (*.png)"]
+                    onAccepted: {
+                        var url = selectedFile.toString()
+                        var path = url.replace(/^file:\/\//, "")
+                        EditorModel.replaceImage("back", path)
+                    }
                 }
 
                 readonly property real imgX: (width - deviceImage.paintedWidth) / 2

--- a/src/app/qml/pages/PointScrollPage.qml
+++ b/src/app/qml/pages/PointScrollPage.qml
@@ -100,19 +100,21 @@ Item {
                     required property int index
                     required property var modelData
 
+                    // Manual drag flag — cleared AFTER EditorModel update so the
+                    // Binding reactivates with the refreshed targetX/targetY.
+                    property bool dragging: false
+
                     readonly property real targetX: mouseRender.x + mouseRender.paintedX + modelData.xPct * mouseRender.paintedW
                     readonly property real targetY: mouseRender.y + mouseRender.paintedY + modelData.yPct * mouseRender.paintedH
 
                     width: 24; height: 24
-                    // Conditional binding: active except while DragHandler is mutating x/y.
-                    // A self-referencing ternary here would sever the binding after first drag.
                     Binding on x {
                         value: scrollMarker.targetX - scrollMarker.width / 2
-                        when: !scrollMarkerDrag.active
+                        when: !scrollMarker.dragging
                     }
                     Binding on y {
                         value: scrollMarker.targetY - scrollMarker.height / 2
-                        when: !scrollMarkerDrag.active
+                        when: !scrollMarker.dragging
                     }
 
                     Rectangle {
@@ -129,7 +131,9 @@ Item {
                         enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
                         target: parent
                         onActiveChanged: {
-                            if (!active) {
+                            if (active) {
+                                scrollMarker.dragging = true
+                            } else {
                                 var cx = scrollMarker.x + scrollMarker.width / 2
                                 var cy = scrollMarker.y + scrollMarker.height / 2
                                 var xPct = (cx - mouseRender.x - mouseRender.paintedX) / mouseRender.paintedW
@@ -140,6 +144,7 @@ Item {
                                                                  xPct, yPct,
                                                                  scrollMarker.modelData.side,
                                                                  scrollMarker.modelData.labelOffsetYPct)
+                                scrollMarker.dragging = false
                             }
                         }
                     }

--- a/src/app/qml/pages/PointScrollPage.qml
+++ b/src/app/qml/pages/PointScrollPage.qml
@@ -100,22 +100,12 @@ Item {
                     required property int index
                     required property var modelData
 
-                    // Manual drag flag — cleared AFTER EditorModel update so the
-                    // Binding reactivates with the refreshed targetX/targetY.
-                    property bool dragging: false
-
                     readonly property real targetX: mouseRender.x + mouseRender.paintedX + modelData.xPct * mouseRender.paintedW
                     readonly property real targetY: mouseRender.y + mouseRender.paintedY + modelData.yPct * mouseRender.paintedH
 
                     width: 24; height: 24
-                    Binding on x {
-                        value: scrollMarker.targetX - scrollMarker.width / 2
-                        when: !scrollMarker.dragging
-                    }
-                    Binding on y {
-                        value: scrollMarker.targetY - scrollMarker.height / 2
-                        when: !scrollMarker.dragging
-                    }
+                    x: targetX - width / 2
+                    y: targetY - height / 2
 
                     Rectangle {
                         anchors.centerIn: parent
@@ -131,9 +121,7 @@ Item {
                         enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
                         target: parent
                         onActiveChanged: {
-                            if (active) {
-                                scrollMarker.dragging = true
-                            } else {
+                            if (!active) {
                                 var cx = scrollMarker.x + scrollMarker.width / 2
                                 var cy = scrollMarker.y + scrollMarker.height / 2
                                 var xPct = (cx - mouseRender.x - mouseRender.paintedX) / mouseRender.paintedW
@@ -144,7 +132,8 @@ Item {
                                                                  xPct, yPct,
                                                                  scrollMarker.modelData.side,
                                                                  scrollMarker.modelData.labelOffsetYPct)
-                                scrollMarker.dragging = false
+                                scrollMarker.x = Qt.binding(function() { return scrollMarker.targetX - scrollMarker.width / 2 })
+                                scrollMarker.y = Qt.binding(function() { return scrollMarker.targetY - scrollMarker.height / 2 })
                             }
                         }
                     }
@@ -159,14 +148,8 @@ Item {
                 readonly property real hsX: hs ? hs.xPct : 0.73
                 readonly property real hsY: hs ? hs.yPct : 0.16
                 readonly property real hsOffY: hs ? hs.labelOffsetYPct : 0
-                Binding on x {
-                    value: mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * scrollCallout.hsX + 16
-                    when: !scrollCallout.dragging
-                }
-                Binding on y {
-                    value: mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * scrollCallout.hsY - scrollCallout.height / 2
-                    when: !scrollCallout.dragging
-                }
+                targetX: mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * scrollCallout.hsX + 16
+                targetY: mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * scrollCallout.hsY - scrollCallout.height / 2
 
                 hotspotIndex: hsIdx
                 hsXPct: hsX
@@ -200,14 +183,8 @@ Item {
                 readonly property real hsX: hs ? hs.xPct : 0.55
                 readonly property real hsY: hs ? hs.yPct : 0.51
                 readonly property real hsOffY: hs ? hs.labelOffsetYPct : 0
-                Binding on x {
-                    value: mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * thumbCallout.hsX - thumbCallout.width - 16
-                    when: !thumbCallout.dragging
-                }
-                Binding on y {
-                    value: mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * thumbCallout.hsY - thumbCallout.height / 2
-                    when: !thumbCallout.dragging
-                }
+                targetX: mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * thumbCallout.hsX - thumbCallout.width - 16
+                targetY: mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * thumbCallout.hsY - thumbCallout.height / 2
 
                 hotspotIndex: hsIdx
                 hsXPct: hsX
@@ -236,14 +213,8 @@ Item {
                 readonly property real hsX: hs ? hs.xPct : 0.83
                 readonly property real hsY: hs ? hs.yPct : 0.54
                 readonly property real hsOffY: hs ? hs.labelOffsetYPct : 0
-                Binding on x {
-                    value: mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * pointerCallout.hsX + 16
-                    when: !pointerCallout.dragging
-                }
-                Binding on y {
-                    value: mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * pointerCallout.hsY - pointerCallout.height / 2
-                    when: !pointerCallout.dragging
-                }
+                targetX: mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * pointerCallout.hsX + 16
+                targetY: mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * pointerCallout.hsY - pointerCallout.height / 2
 
                 hotspotIndex: hsIdx
                 hsXPct: hsX

--- a/src/app/qml/pages/PointScrollPage.qml
+++ b/src/app/qml/pages/PointScrollPage.qml
@@ -151,8 +151,20 @@ Item {
             // ── Scroll wheel callout — positioned from descriptor hotspot [0]
             InfoCallout {
                 id: scrollCallout
-                readonly property var hs: renderGroup.hotspotByKind("scrollwheel", 0)
-                readonly property int hsIdx: renderGroup.hotspotIndexByKind("scrollwheel", 0)
+                readonly property var hs: {
+                    var d = renderGroup.scrollHotspotsData
+                    if (!d) return null
+                    for (var i = 0; i < d.length; i++)
+                        if (d[i].kind === "scrollwheel") return d[i]
+                    return d.length > 0 ? d[0] : null
+                }
+                readonly property int hsIdx: {
+                    var d = renderGroup.scrollHotspotsData
+                    if (!d) return -1
+                    for (var i = 0; i < d.length; i++)
+                        if (d[i].kind === "scrollwheel") return i
+                    return d.length > 0 ? 0 : -1
+                }
                 readonly property real hsX: hs ? hs.xPct : 0.73
                 readonly property real hsY: hs ? hs.yPct : 0.16
                 readonly property real hsOffY: hs ? hs.labelOffsetYPct : 0
@@ -186,8 +198,20 @@ Item {
             // ── Thumb wheel callout — positioned from descriptor hotspot [1]
             InfoCallout {
                 id: thumbCallout
-                readonly property var hs: renderGroup.hotspotByKind("thumbwheel", 1)
-                readonly property int hsIdx: renderGroup.hotspotIndexByKind("thumbwheel", 1)
+                readonly property var hs: {
+                    var d = renderGroup.scrollHotspotsData
+                    if (!d) return null
+                    for (var i = 0; i < d.length; i++)
+                        if (d[i].kind === "thumbwheel") return d[i]
+                    return d.length > 1 ? d[1] : null
+                }
+                readonly property int hsIdx: {
+                    var d = renderGroup.scrollHotspotsData
+                    if (!d) return -1
+                    for (var i = 0; i < d.length; i++)
+                        if (d[i].kind === "thumbwheel") return i
+                    return d.length > 1 ? 1 : -1
+                }
                 readonly property real hsX: hs ? hs.xPct : 0.55
                 readonly property real hsY: hs ? hs.yPct : 0.51
                 readonly property real hsOffY: hs ? hs.labelOffsetYPct : 0
@@ -216,8 +240,20 @@ Item {
             // ── Pointer speed callout — positioned from descriptor hotspot [2]
             InfoCallout {
                 id: pointerCallout
-                readonly property var hs: renderGroup.hotspotByKind("pointer", 2)
-                readonly property int hsIdx: renderGroup.hotspotIndexByKind("pointer", 2)
+                readonly property var hs: {
+                    var d = renderGroup.scrollHotspotsData
+                    if (!d) return null
+                    for (var i = 0; i < d.length; i++)
+                        if (d[i].kind === "pointer") return d[i]
+                    return d.length > 2 ? d[2] : null
+                }
+                readonly property int hsIdx: {
+                    var d = renderGroup.scrollHotspotsData
+                    if (!d) return -1
+                    for (var i = 0; i < d.length; i++)
+                        if (d[i].kind === "pointer") return i
+                    return d.length > 2 ? 2 : -1
+                }
                 readonly property real hsX: hs ? hs.xPct : 0.83
                 readonly property real hsY: hs ? hs.yPct : 0.54
                 readonly property real hsOffY: hs ? hs.labelOffsetYPct : 0

--- a/src/app/qml/pages/PointScrollPage.qml
+++ b/src/app/qml/pages/PointScrollPage.qml
@@ -116,16 +116,6 @@ Item {
                         opacity: 0.7
                     }
 
-                    Connections {
-                        target: DeviceModel
-                        function onSelectedChanged() {
-                            if (!scrollMarkerDrag.active) {
-                                scrollMarker.x = scrollMarker.targetX - scrollMarker.width / 2
-                                scrollMarker.y = scrollMarker.targetY - scrollMarker.height / 2
-                            }
-                        }
-                    }
-
                     DragHandler {
                         id: scrollMarkerDrag
                         enabled: typeof EditorModel !== 'undefined' && EditorModel.editing

--- a/src/app/qml/pages/PointScrollPage.qml
+++ b/src/app/qml/pages/PointScrollPage.qml
@@ -84,17 +84,57 @@ Item {
                     : null;
             }
 
+            function hotspotIndexByKind(kind, fallbackIdx) {
+                for (var i = 0; i < scrollHotspotsData.length; i++) {
+                    if (scrollHotspotsData[i].kind === kind)
+                        return i;
+                }
+                return scrollHotspotsData.length > fallbackIdx ? fallbackIdx : -1;
+            }
+
             // ── Point & Scroll hotspot circles — driven by descriptor ────────
             Repeater {
                 model: renderGroup.scrollHotspotsData
-                Rectangle {
-                    x: mouseRender.x + mouseRender.paintedX + modelData.xPct * mouseRender.paintedW - 9
-                    y: mouseRender.y + mouseRender.paintedY + modelData.yPct * mouseRender.paintedH - 9
-                    width: 18; height: 18; radius: 9
-                    color: "transparent"
-                    border.color: Theme.accent
-                    border.width: 2
-                    opacity: 0.7
+                Item {
+                    id: scrollMarker
+                    required property int index
+                    required property var modelData
+
+                    readonly property real targetX: mouseRender.x + mouseRender.paintedX + modelData.xPct * mouseRender.paintedW
+                    readonly property real targetY: mouseRender.y + mouseRender.paintedY + modelData.yPct * mouseRender.paintedH
+
+                    width: 24; height: 24
+                    x: scrollMarkerDrag.active ? x : targetX - width / 2
+                    y: scrollMarkerDrag.active ? y : targetY - height / 2
+
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: 18; height: 18; radius: 9
+                        color: "transparent"
+                        border.color: Theme.accent
+                        border.width: 2
+                        opacity: 0.7
+                    }
+
+                    DragHandler {
+                        id: scrollMarkerDrag
+                        enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
+                        target: parent
+                        onActiveChanged: {
+                            if (!active) {
+                                var cx = scrollMarker.x + scrollMarker.width / 2
+                                var cy = scrollMarker.y + scrollMarker.height / 2
+                                var xPct = (cx - mouseRender.x - mouseRender.paintedX) / mouseRender.paintedW
+                                var yPct = (cy - mouseRender.y - mouseRender.paintedY) / mouseRender.paintedH
+                                xPct = Math.max(0, Math.min(1, xPct))
+                                yPct = Math.max(0, Math.min(1, yPct))
+                                EditorModel.updateScrollHotspot(scrollMarker.index,
+                                                                 xPct, yPct,
+                                                                 scrollMarker.modelData.side,
+                                                                 scrollMarker.modelData.labelOffsetYPct)
+                            }
+                        }
+                    }
                 }
             }
 
@@ -102,10 +142,23 @@ Item {
             InfoCallout {
                 id: scrollCallout
                 readonly property var hs: renderGroup.hotspotByKind("scrollwheel", 0)
+                readonly property int hsIdx: renderGroup.hotspotIndexByKind("scrollwheel", 0)
                 readonly property real hsX: hs ? hs.xPct : 0.73
                 readonly property real hsY: hs ? hs.yPct : 0.16
-                x: mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * hsX + 16
-                y: mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * hsY - height / 2
+                readonly property real hsOffY: hs ? hs.labelOffsetYPct : 0
+                x: scrollCallout.dragging
+                    ? x
+                    : mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * hsX + 16
+                y: scrollCallout.dragging
+                    ? y
+                    : mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * hsY - height / 2
+
+                hotspotIndex: hsIdx
+                hsXPct: hsX
+                hsYPct: hsY
+                hsLabelOffsetYPct: hsOffY
+                pageWidth: renderGroup.width
+                pageHeight: renderGroup.height
 
                 calloutType: "scrollwheel"
                 title: "Scroll wheel"
@@ -128,10 +181,23 @@ Item {
             InfoCallout {
                 id: thumbCallout
                 readonly property var hs: renderGroup.hotspotByKind("thumbwheel", 1)
+                readonly property int hsIdx: renderGroup.hotspotIndexByKind("thumbwheel", 1)
                 readonly property real hsX: hs ? hs.xPct : 0.55
                 readonly property real hsY: hs ? hs.yPct : 0.51
-                x: mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * hsX - width - 16
-                y: mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * hsY - height / 2
+                readonly property real hsOffY: hs ? hs.labelOffsetYPct : 0
+                x: thumbCallout.dragging
+                    ? x
+                    : mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * hsX - width - 16
+                y: thumbCallout.dragging
+                    ? y
+                    : mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * hsY - height / 2
+
+                hotspotIndex: hsIdx
+                hsXPct: hsX
+                hsYPct: hsY
+                hsLabelOffsetYPct: hsOffY
+                pageWidth: renderGroup.width
+                pageHeight: renderGroup.height
 
                 calloutType: "thumbwheel"
                 title: "Thumb wheel"
@@ -149,10 +215,23 @@ Item {
             InfoCallout {
                 id: pointerCallout
                 readonly property var hs: renderGroup.hotspotByKind("pointer", 2)
+                readonly property int hsIdx: renderGroup.hotspotIndexByKind("pointer", 2)
                 readonly property real hsX: hs ? hs.xPct : 0.83
                 readonly property real hsY: hs ? hs.yPct : 0.54
-                x: mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * hsX + 16
-                y: mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * hsY - height / 2
+                readonly property real hsOffY: hs ? hs.labelOffsetYPct : 0
+                x: pointerCallout.dragging
+                    ? x
+                    : mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * hsX + 16
+                y: pointerCallout.dragging
+                    ? y
+                    : mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * hsY - height / 2
+
+                hotspotIndex: hsIdx
+                hsXPct: hsX
+                hsYPct: hsY
+                hsLabelOffsetYPct: hsOffY
+                pageWidth: renderGroup.width
+                pageHeight: renderGroup.height
 
                 calloutType: "pointerspeed"
                 title: "Pointer speed"

--- a/src/app/qml/pages/PointScrollPage.qml
+++ b/src/app/qml/pages/PointScrollPage.qml
@@ -65,7 +65,6 @@ Item {
             DeviceRender {
                 id: mouseRender
                 imageSource: DeviceModel.sideImage
-                showHotspots: false
                 implicitWidth: 280
                 implicitHeight: 414
                 anchors.centerIn: parent
@@ -114,6 +113,16 @@ Item {
                         border.color: Theme.accent
                         border.width: 2
                         opacity: 0.7
+                    }
+
+                    Connections {
+                        target: DeviceModel
+                        function onSelectedChanged() {
+                            if (!scrollMarkerDrag.active) {
+                                scrollMarker.x = scrollMarker.targetX - scrollMarker.width / 2
+                                scrollMarker.y = scrollMarker.targetY - scrollMarker.height / 2
+                            }
+                        }
                     }
 
                     DragHandler {

--- a/src/app/qml/pages/PointScrollPage.qml
+++ b/src/app/qml/pages/PointScrollPage.qml
@@ -116,6 +116,16 @@ Item {
                         opacity: 0.7
                     }
 
+                    Connections {
+                        target: DeviceModel
+                        function onSelectedChanged() {
+                            if (!scrollMarkerDrag.active) {
+                                scrollMarker.x = scrollMarker.targetX - scrollMarker.width / 2
+                                scrollMarker.y = scrollMarker.targetY - scrollMarker.height / 2
+                            }
+                        }
+                    }
+
                     DragHandler {
                         id: scrollMarkerDrag
                         enabled: typeof EditorModel !== 'undefined' && EditorModel.editing
@@ -132,8 +142,6 @@ Item {
                                                                  xPct, yPct,
                                                                  scrollMarker.modelData.side,
                                                                  scrollMarker.modelData.labelOffsetYPct)
-                                scrollMarker.x = Qt.binding(function() { return scrollMarker.targetX - scrollMarker.width / 2 })
-                                scrollMarker.y = Qt.binding(function() { return scrollMarker.targetY - scrollMarker.height / 2 })
                             }
                         }
                     }

--- a/src/app/qml/pages/PointScrollPage.qml
+++ b/src/app/qml/pages/PointScrollPage.qml
@@ -93,14 +93,15 @@ Item {
 
             // ── Point & Scroll hotspot circles — driven by descriptor ────────
             Repeater {
-                model: renderGroup.scrollHotspotsData
+                model: renderGroup.scrollHotspotsData.length
                 Item {
                     id: scrollMarker
                     required property int index
-                    required property var modelData
 
-                    readonly property real targetX: mouseRender.x + mouseRender.paintedX + modelData.xPct * mouseRender.paintedW
-                    readonly property real targetY: mouseRender.y + mouseRender.paintedY + modelData.yPct * mouseRender.paintedH
+                    // Read hotspot data from the live array by index — not stale modelData.
+                    readonly property var hsData: DeviceModel.scrollHotspots[scrollMarker.index]
+                    readonly property real targetX: mouseRender.x + mouseRender.paintedX + (hsData ? hsData.xPct : 0) * mouseRender.paintedW
+                    readonly property real targetY: mouseRender.y + mouseRender.paintedY + (hsData ? hsData.yPct : 0) * mouseRender.paintedH
 
                     width: 24; height: 24
                     x: targetX - width / 2
@@ -139,8 +140,8 @@ Item {
                                 yPct = Math.max(0, Math.min(1, yPct))
                                 EditorModel.updateScrollHotspot(scrollMarker.index,
                                                                  xPct, yPct,
-                                                                 scrollMarker.modelData.side,
-                                                                 scrollMarker.modelData.labelOffsetYPct)
+                                                                 scrollMarker.hsData ? scrollMarker.hsData.side : "right",
+                                                                 scrollMarker.hsData ? scrollMarker.hsData.labelOffsetYPct : 0)
                             }
                         }
                     }

--- a/src/app/qml/pages/PointScrollPage.qml
+++ b/src/app/qml/pages/PointScrollPage.qml
@@ -104,8 +104,16 @@ Item {
                     readonly property real targetY: mouseRender.y + mouseRender.paintedY + modelData.yPct * mouseRender.paintedH
 
                     width: 24; height: 24
-                    x: scrollMarkerDrag.active ? x : targetX - width / 2
-                    y: scrollMarkerDrag.active ? y : targetY - height / 2
+                    // Conditional binding: active except while DragHandler is mutating x/y.
+                    // A self-referencing ternary here would sever the binding after first drag.
+                    Binding on x {
+                        value: scrollMarker.targetX - scrollMarker.width / 2
+                        when: !scrollMarkerDrag.active
+                    }
+                    Binding on y {
+                        value: scrollMarker.targetY - scrollMarker.height / 2
+                        when: !scrollMarkerDrag.active
+                    }
 
                     Rectangle {
                         anchors.centerIn: parent
@@ -146,12 +154,14 @@ Item {
                 readonly property real hsX: hs ? hs.xPct : 0.73
                 readonly property real hsY: hs ? hs.yPct : 0.16
                 readonly property real hsOffY: hs ? hs.labelOffsetYPct : 0
-                x: scrollCallout.dragging
-                    ? x
-                    : mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * hsX + 16
-                y: scrollCallout.dragging
-                    ? y
-                    : mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * hsY - height / 2
+                Binding on x {
+                    value: mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * scrollCallout.hsX + 16
+                    when: !scrollCallout.dragging
+                }
+                Binding on y {
+                    value: mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * scrollCallout.hsY - scrollCallout.height / 2
+                    when: !scrollCallout.dragging
+                }
 
                 hotspotIndex: hsIdx
                 hsXPct: hsX
@@ -185,12 +195,14 @@ Item {
                 readonly property real hsX: hs ? hs.xPct : 0.55
                 readonly property real hsY: hs ? hs.yPct : 0.51
                 readonly property real hsOffY: hs ? hs.labelOffsetYPct : 0
-                x: thumbCallout.dragging
-                    ? x
-                    : mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * hsX - width - 16
-                y: thumbCallout.dragging
-                    ? y
-                    : mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * hsY - height / 2
+                Binding on x {
+                    value: mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * thumbCallout.hsX - thumbCallout.width - 16
+                    when: !thumbCallout.dragging
+                }
+                Binding on y {
+                    value: mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * thumbCallout.hsY - thumbCallout.height / 2
+                    when: !thumbCallout.dragging
+                }
 
                 hotspotIndex: hsIdx
                 hsXPct: hsX
@@ -219,12 +231,14 @@ Item {
                 readonly property real hsX: hs ? hs.xPct : 0.83
                 readonly property real hsY: hs ? hs.yPct : 0.54
                 readonly property real hsOffY: hs ? hs.labelOffsetYPct : 0
-                x: pointerCallout.dragging
-                    ? x
-                    : mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * hsX + 16
-                y: pointerCallout.dragging
-                    ? y
-                    : mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * hsY - height / 2
+                Binding on x {
+                    value: mouseRender.x + mouseRender.paintedX + mouseRender.paintedW * pointerCallout.hsX + 16
+                    when: !pointerCallout.dragging
+                }
+                Binding on y {
+                    value: mouseRender.y + mouseRender.paintedY + mouseRender.paintedH * pointerCallout.hsY - pointerCallout.height / 2
+                    when: !pointerCallout.dragging
+                }
 
                 hotspotIndex: hsIdx
                 hsXPct: hsX

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(logitune-core PRIVATE
     ProfileEngine.cpp
     ActionExecutor.cpp
     DeviceRegistry.cpp
+    devices/DescriptorWriter.cpp
     devices/JsonDevice.cpp
     interfaces/IDesktopIntegration.cpp
     interfaces/IInputInjector.cpp

--- a/src/core/DeviceManager.cpp
+++ b/src/core/DeviceManager.cpp
@@ -123,6 +123,54 @@ const IDevice* DeviceManager::activeDevice() const
 }
 
 // ---------------------------------------------------------------------------
+// simulateAllFromRegistry() — --simulate-all CLI flag
+// ---------------------------------------------------------------------------
+
+void DeviceManager::simulateAllFromRegistry()
+{
+    if (!m_registry) {
+        qCWarning(lcDevice) << "simulateAllFromRegistry: no registry";
+        return;
+    }
+
+    const auto &descriptors = m_registry->devices();
+    qCInfo(lcDevice) << "simulateAllFromRegistry: seeding"
+                     << descriptors.size() << "devices from registry";
+
+    int idx = 0;
+    for (const auto &dev : descriptors) {
+        const IDevice *descriptor = dev.get();
+        if (!descriptor)
+            continue;
+
+        // Stable fake serial so duplicate calls would coalesce the same way
+        // real hardware does. Use the slot index so each descriptor gets a
+        // unique row in m_physicalDevices.
+        const QString fakeSerial = QStringLiteral("sim-%1-%2")
+            .arg(idx++, 3, 10, QLatin1Char('0'))
+            .arg(descriptor->deviceName());
+
+        auto hidraw = std::make_unique<hidpp::HidrawDevice>(QStringLiteral("/dev/null"));
+        auto session = std::make_unique<DeviceSession>(
+            std::move(hidraw),
+            DeviceManager::deviceIndexForDirect(),
+            QStringLiteral("Simulated"),
+            m_registry,
+            this);
+        session->applySimulation(descriptor, fakeSerial);
+
+        DeviceSession *sessionPtr = session.get();
+        m_sessions.push_back(std::move(session));
+
+        auto pd = std::make_unique<PhysicalDevice>(fakeSerial, this);
+        pd->attachTransport(sessionPtr);
+        PhysicalDevice *pdPtr = pd.get();
+        m_physicalDevices.emplace(fakeSerial, std::move(pd));
+        emit physicalDeviceAdded(pdPtr);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // start()
 // ---------------------------------------------------------------------------
 

--- a/src/core/DeviceManager.h
+++ b/src/core/DeviceManager.h
@@ -25,6 +25,13 @@ public:
 
     void start();
 
+    // --simulate-all CLI flag entry point — synthesizes a
+    // PhysicalDevice + DeviceSession for every descriptor currently
+    // loaded in DeviceRegistry. Bypasses udev, HID++ probing, and
+    // hardware I/O. Emits physicalDeviceAdded for each so the UI
+    // populates its carousel. Never called from production code.
+    void simulateAllFromRegistry();
+
     // Static helpers
     static bool isReceiver(uint16_t pid);
     static uint8_t deviceIndexForDirect();

--- a/src/core/DeviceRegistry.cpp
+++ b/src/core/DeviceRegistry.cpp
@@ -3,6 +3,7 @@
 #include "logging/LogManager.h"
 #include <QCoreApplication>
 #include <QDir>
+#include <QFileInfo>
 #include <QStandardPaths>
 
 namespace logitune {
@@ -85,6 +86,27 @@ QString DeviceRegistry::cacheDevicesDir() {
 QString DeviceRegistry::userDevicesDir() {
     return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
            + "/logitune/devices";
+}
+
+const IDevice* DeviceRegistry::findBySourcePath(const QString &dirPath) const {
+    const QString canonical = QFileInfo(dirPath).canonicalFilePath();
+    for (const auto &dev : m_devices) {
+        if (auto *jd = dynamic_cast<const JsonDevice*>(dev.get()))
+            if (jd->sourcePath() == canonical)
+                return dev.get();
+    }
+    return nullptr;
+}
+
+bool DeviceRegistry::reload(const QString &dirPath) {
+    const QString canonical = QFileInfo(dirPath).canonicalFilePath();
+    for (auto &dev : m_devices) {
+        if (auto *jd = dynamic_cast<JsonDevice*>(dev.get())) {
+            if (jd->sourcePath() == canonical)
+                return jd->refresh();
+        }
+    }
+    return false;
 }
 
 } // namespace logitune

--- a/src/core/DeviceRegistry.h
+++ b/src/core/DeviceRegistry.h
@@ -15,6 +15,8 @@ public:
     void registerDevice(std::unique_ptr<IDevice> device);
     const std::vector<std::unique_ptr<IDevice>>& devices() const;
     void reloadAll();
+    const IDevice* findBySourcePath(const QString &dirPath) const;
+    bool reload(const QString &dirPath);
 
     static QString systemDevicesDir();
     static QString cacheDevicesDir();

--- a/src/core/DeviceSession.cpp
+++ b/src/core/DeviceSession.cpp
@@ -418,6 +418,29 @@ void DeviceSession::enumerateAndSetup()
 }
 
 // ---------------------------------------------------------------------------
+// applySimulation() — --simulate-all entry point
+// ---------------------------------------------------------------------------
+
+void DeviceSession::applySimulation(const IDevice *dev, const QString &fakeSerial)
+{
+    m_activeDevice = dev;
+    m_deviceName = dev ? dev->deviceName() : QStringLiteral("Simulated");
+    m_deviceSerial = fakeSerial;
+    m_connected = true;
+
+    // Populate a few visible-in-UI fields with plausible stubs so the
+    // cards render without empty regions. These never hit real hardware.
+    m_batteryLevel = 85;
+    m_batteryCharging = false;
+    if (dev) {
+        m_minDPI = dev->minDpi();
+        m_maxDPI = dev->maxDpi();
+        m_dpiStep = dev->dpiStep();
+        m_currentDPI = (m_minDPI + m_maxDPI) / 2;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // disconnectCleanup()
 // ---------------------------------------------------------------------------
 

--- a/src/core/DeviceSession.h
+++ b/src/core/DeviceSession.h
@@ -88,6 +88,12 @@ public:
     void setConnectedForTest(bool v) { m_connected = v; }
     void setDeviceNameForTest(const QString &n) { m_deviceName = n; }
 
+    // --simulate-all CLI flag entry point — wires a DeviceSession
+    // into a "fake connected" state against a registry descriptor so
+    // the UI renders its card without real hardware. Bypasses all
+    // HID++ probing. Never called from production code paths.
+    void applySimulation(const IDevice *dev, const QString &fakeSerial);
+
 signals:
     void setupComplete();
     void disconnected();

--- a/src/core/devices/DescriptorWriter.cpp
+++ b/src/core/devices/DescriptorWriter.cpp
@@ -1,0 +1,39 @@
+#include "DescriptorWriter.h"
+#include <QSaveFile>
+#include <QJsonDocument>
+#include <QDir>
+
+namespace logitune {
+
+DescriptorWriter::Result DescriptorWriter::write(
+    const QString &dirPath, const QJsonObject &obj, QString *errorOut) {
+    if (errorOut) errorOut->clear();
+
+    if (!QDir(dirPath).exists()) {
+        if (errorOut) *errorOut = QStringLiteral("Directory does not exist: ") + dirPath;
+        return IoError;
+    }
+
+    const QString filePath = QDir(dirPath).absoluteFilePath(QStringLiteral("descriptor.json"));
+    QSaveFile file(filePath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        if (errorOut) *errorOut = file.errorString();
+        return IoError;
+    }
+
+    const QJsonDocument doc(obj);
+    const QByteArray bytes = doc.toJson(QJsonDocument::Indented);
+    if (file.write(bytes) != bytes.size()) {
+        file.cancelWriting();
+        if (errorOut) *errorOut = QStringLiteral("short write");
+        return IoError;
+    }
+
+    if (!file.commit()) {
+        if (errorOut) *errorOut = file.errorString();
+        return IoError;
+    }
+    return Ok;
+}
+
+} // namespace logitune

--- a/src/core/devices/DescriptorWriter.h
+++ b/src/core/devices/DescriptorWriter.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <QString>
+#include <QJsonObject>
+
+namespace logitune {
+
+class DescriptorWriter {
+public:
+    enum Result { Ok, IoError, JsonError };
+
+    Result write(const QString &dirPath, const QJsonObject &obj, QString *errorOut = nullptr);
+};
+
+} // namespace logitune

--- a/src/core/devices/JsonDevice.cpp
+++ b/src/core/devices/JsonDevice.cpp
@@ -135,7 +135,7 @@ static QMap<QString, ButtonAction> parseDefaultGestures(const QJsonObject& obj)
     return result;
 }
 
-std::unique_ptr<JsonDevice> JsonDevice::load(const QString& dirPath)
+bool JsonDevice::parseFromDir(const QString& dirPath)
 {
     const QDir dir(dirPath);
     const QString filePath = dir.absoluteFilePath(QStringLiteral("descriptor.json"));
@@ -143,7 +143,7 @@ std::unique_ptr<JsonDevice> JsonDevice::load(const QString& dirPath)
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly)) {
         qCWarning(lcDevice) << "JsonDevice: cannot open" << filePath;
-        return nullptr;
+        return false;
     }
 
     QJsonParseError parseError;
@@ -151,20 +151,14 @@ std::unique_ptr<JsonDevice> JsonDevice::load(const QString& dirPath)
     if (parseError.error != QJsonParseError::NoError) {
         qCWarning(lcDevice) << "JsonDevice: parse error in" << filePath
                             << ":" << parseError.errorString();
-        return nullptr;
+        return false;
     }
 
     const QJsonObject root = doc.object();
 
-    auto dev = std::unique_ptr<JsonDevice>(new JsonDevice());
+    m_status = parseStatus(root.value(QStringLiteral("status")).toString());
+    m_name = root.value(QStringLiteral("name")).toString();
 
-    // Status
-    dev->m_status = parseStatus(root.value(QStringLiteral("status")).toString());
-
-    // Name
-    dev->m_name = root.value(QStringLiteral("name")).toString();
-
-    // Product IDs
     const QJsonArray pidArr = root.value(QStringLiteral("productIds")).toArray();
     for (const auto& v : pidArr) {
         bool ok = false;
@@ -173,89 +167,112 @@ std::unique_ptr<JsonDevice> JsonDevice::load(const QString& dirPath)
             qCWarning(lcDevice) << "JsonDevice: invalid PID hex:" << v.toString();
             continue;
         }
-        dev->m_pids.push_back(pid);
+        m_pids.push_back(pid);
     }
 
-    // Features
-    dev->m_features = parseFeatures(root.value(QStringLiteral("features")).toObject());
+    m_features = parseFeatures(root.value(QStringLiteral("features")).toObject());
 
-    // DPI
     const QJsonObject dpiObj = root.value(QStringLiteral("dpi")).toObject();
     if (!dpiObj.isEmpty()) {
-        dev->m_minDpi = dpiObj.value(QStringLiteral("min")).toInt(200);
-        dev->m_maxDpi = dpiObj.value(QStringLiteral("max")).toInt(8000);
-        dev->m_dpiStep = dpiObj.value(QStringLiteral("step")).toInt(50);
+        m_minDpi = dpiObj.value(QStringLiteral("min")).toInt(200);
+        m_maxDpi = dpiObj.value(QStringLiteral("max")).toInt(8000);
+        m_dpiStep = dpiObj.value(QStringLiteral("step")).toInt(50);
     }
 
-    // Controls
-    dev->m_controls = parseControls(root.value(QStringLiteral("controls")).toArray());
+    m_controls = parseControls(root.value(QStringLiteral("controls")).toArray());
 
-    // Hotspots
     const QJsonObject hotspotsObj = root.value(QStringLiteral("hotspots")).toObject();
-    dev->m_buttonHotspots = parseHotspots(hotspotsObj.value(QStringLiteral("buttons")).toArray());
-    dev->m_scrollHotspots = parseHotspots(hotspotsObj.value(QStringLiteral("scroll")).toArray());
+    m_buttonHotspots = parseHotspots(hotspotsObj.value(QStringLiteral("buttons")).toArray());
+    m_scrollHotspots = parseHotspots(hotspotsObj.value(QStringLiteral("scroll")).toArray());
 
-    // Images — resolve relative paths against dirPath
     const QJsonObject imagesObj = root.value(QStringLiteral("images")).toObject();
     const QString front = imagesObj.value(QStringLiteral("front")).toString();
     const QString side  = imagesObj.value(QStringLiteral("side")).toString();
     const QString back  = imagesObj.value(QStringLiteral("back")).toString();
     if (!front.isEmpty())
-        dev->m_frontImage = dir.absoluteFilePath(front);
+        m_frontImage = dir.absoluteFilePath(front);
     if (!side.isEmpty())
-        dev->m_sideImage = dir.absoluteFilePath(side);
+        m_sideImage = dir.absoluteFilePath(side);
     if (!back.isEmpty())
-        dev->m_backImage = dir.absoluteFilePath(back);
+        m_backImage = dir.absoluteFilePath(back);
 
-    // Easy Switch Slots
     const QJsonArray slotsArr = root.value(QStringLiteral("easySwitchSlots")).toArray();
     for (const auto& v : slotsArr) {
         const QJsonObject slotObj = v.toObject();
-        dev->m_easySwitchSlots.append({
+        m_easySwitchSlots.append({
             slotObj.value(QStringLiteral("xPct")).toDouble(),
             slotObj.value(QStringLiteral("yPct")).toDouble(),
             slotObj.value(QStringLiteral("label")).toString()
         });
     }
 
-    // Default Gestures
-    dev->m_defaultGestures = parseDefaultGestures(
+    m_defaultGestures = parseDefaultGestures(
         root.value(QStringLiteral("defaultGestures")).toObject());
 
-    // Validation
-    const bool strict = (dev->m_status == Status::Implemented
-                         || dev->m_status == Status::CommunityVerified);
+    const bool strict = (m_status == Status::Implemented
+                         || m_status == Status::CommunityVerified);
 
-    if (dev->m_name.isEmpty()) {
+    if (m_name.isEmpty()) {
         qCWarning(lcDevice) << "JsonDevice: missing name in" << filePath;
-        return nullptr;
+        return false;
     }
 
-    if (dev->m_pids.empty()) {
+    if (m_pids.empty()) {
         qCWarning(lcDevice) << "JsonDevice: no productIds in" << filePath;
-        return nullptr;
+        return false;
     }
 
     if (strict) {
-        if (dev->m_controls.isEmpty()) {
+        if (m_controls.isEmpty()) {
             qCWarning(lcDevice) << "JsonDevice: implemented device has no controls in" << filePath;
-            return nullptr;
+            return false;
         }
-        if (dev->m_buttonHotspots.isEmpty()) {
+        if (m_buttonHotspots.isEmpty()) {
             qCWarning(lcDevice) << "JsonDevice: implemented device has no button hotspots in" << filePath;
-            return nullptr;
+            return false;
         }
-        if (!QFileInfo::exists(dev->m_frontImage)) {
-            qCWarning(lcDevice) << "JsonDevice: front image not found:" << dev->m_frontImage;
-            return nullptr;
+        if (!QFileInfo::exists(m_frontImage)) {
+            qCWarning(lcDevice) << "JsonDevice: front image not found:" << m_frontImage;
+            return false;
         }
     }
 
-    dev->m_sourcePath = QFileInfo(dirPath).canonicalFilePath();
-    dev->m_loadedMtime = QFileInfo(filePath).lastModified().toSecsSinceEpoch();
+    m_sourcePath = QFileInfo(dirPath).canonicalFilePath();
+    m_loadedMtime = QFileInfo(filePath).lastModified().toSecsSinceEpoch();
 
-    qCDebug(lcDevice) << "JsonDevice: loaded" << dev->m_name << "from" << dirPath;
+    qCDebug(lcDevice) << "JsonDevice: loaded" << m_name << "from" << dirPath;
+    return true;
+}
+
+std::unique_ptr<JsonDevice> JsonDevice::load(const QString& dirPath)
+{
+    auto dev = std::unique_ptr<JsonDevice>(new JsonDevice());
+    if (!dev->parseFromDir(dirPath))
+        return nullptr;
     return dev;
+}
+
+bool JsonDevice::refresh()
+{
+    if (m_sourcePath.isEmpty())
+        return false;
+    const QString src = m_sourcePath;
+    m_pids.clear();
+    m_controls.clear();
+    m_buttonHotspots.clear();
+    m_scrollHotspots.clear();
+    m_easySwitchSlots.clear();
+    m_defaultGestures.clear();
+    m_frontImage.clear();
+    m_sideImage.clear();
+    m_backImage.clear();
+    m_features = FeatureSupport{};
+    m_name.clear();
+    m_status = Status::Placeholder;
+    m_minDpi = 200;
+    m_maxDpi = 8000;
+    m_dpiStep = 50;
+    return parseFromDir(src);
 }
 
 } // namespace logitune

--- a/src/core/devices/JsonDevice.cpp
+++ b/src/core/devices/JsonDevice.cpp
@@ -99,6 +99,7 @@ static QList<ControlDescriptor> parseControls(const QJsonArray& arr)
         cd.defaultName = obj.value(QStringLiteral("defaultName")).toString();
         cd.defaultActionType = obj.value(QStringLiteral("defaultActionType")).toString();
         cd.configurable = obj.value(QStringLiteral("configurable")).toBool(false);
+        cd.displayName = obj.value(QStringLiteral("displayName")).toString();
         result.append(cd);
     }
     return result;
@@ -212,7 +213,8 @@ std::unique_ptr<JsonDevice> JsonDevice::load(const QString& dirPath)
         const QJsonObject slotObj = v.toObject();
         dev->m_easySwitchSlots.append({
             slotObj.value(QStringLiteral("xPct")).toDouble(),
-            slotObj.value(QStringLiteral("yPct")).toDouble()
+            slotObj.value(QStringLiteral("yPct")).toDouble(),
+            slotObj.value(QStringLiteral("label")).toString()
         });
     }
 

--- a/src/core/devices/JsonDevice.cpp
+++ b/src/core/devices/JsonDevice.cpp
@@ -249,6 +249,9 @@ std::unique_ptr<JsonDevice> JsonDevice::load(const QString& dirPath)
         }
     }
 
+    dev->m_sourcePath = QFileInfo(dirPath).canonicalFilePath();
+    dev->m_loadedMtime = QFileInfo(filePath).lastModified().toSecsSinceEpoch();
+
     qCDebug(lcDevice) << "JsonDevice: loaded" << dev->m_name << "from" << dirPath;
     return dev;
 }

--- a/src/core/devices/JsonDevice.cpp
+++ b/src/core/devices/JsonDevice.cpp
@@ -154,7 +154,17 @@ bool JsonDevice::parseFromDir(const QString& dirPath)
         return false;
     }
 
-    const QJsonObject root = doc.object();
+    if (!parseFromObject(doc.object(), dirPath, /*strict=*/true))
+        return false;
+
+    m_loadedMtime = QFileInfo(filePath).lastModified().toSecsSinceEpoch();
+    return true;
+}
+
+bool JsonDevice::parseFromObject(const QJsonObject& root, const QString& dirPath, bool strict)
+{
+    const QDir dir(dirPath);
+    const QString filePath = dir.absoluteFilePath(QStringLiteral("descriptor.json"));
 
     m_status = parseStatus(root.value(QStringLiteral("status")).toString());
     m_name = root.value(QStringLiteral("name")).toString();
@@ -209,20 +219,20 @@ bool JsonDevice::parseFromDir(const QString& dirPath)
     m_defaultGestures = parseDefaultGestures(
         root.value(QStringLiteral("defaultGestures")).toObject());
 
-    const bool strict = (m_status == Status::Implemented
-                         || m_status == Status::CommunityVerified);
+    const bool strictGate = strict && (m_status == Status::Implemented
+                                       || m_status == Status::CommunityVerified);
 
-    if (m_name.isEmpty()) {
+    if (strict && m_name.isEmpty()) {
         qCWarning(lcDevice) << "JsonDevice: missing name in" << filePath;
         return false;
     }
 
-    if (m_pids.empty()) {
+    if (strict && m_pids.empty()) {
         qCWarning(lcDevice) << "JsonDevice: no productIds in" << filePath;
         return false;
     }
 
-    if (strict) {
+    if (strictGate) {
         if (m_controls.isEmpty()) {
             qCWarning(lcDevice) << "JsonDevice: implemented device has no controls in" << filePath;
             return false;
@@ -238,9 +248,9 @@ bool JsonDevice::parseFromDir(const QString& dirPath)
     }
 
     m_sourcePath = QFileInfo(dirPath).canonicalFilePath();
-    m_loadedMtime = QFileInfo(filePath).lastModified().toSecsSinceEpoch();
 
-    qCDebug(lcDevice) << "JsonDevice: loaded" << m_name << "from" << dirPath;
+    qCDebug(lcDevice) << "JsonDevice: parsed" << m_name << "from" << dirPath
+                      << (strict ? "(strict)" : "(relaxed)");
     return true;
 }
 
@@ -273,6 +283,30 @@ bool JsonDevice::refresh()
     m_maxDpi = 8000;
     m_dpiStep = 50;
     return parseFromDir(src);
+}
+
+bool JsonDevice::refreshFromObject(const QJsonObject &root)
+{
+    if (m_sourcePath.isEmpty())
+        return false;
+    const QString src = m_sourcePath;
+    // Clear mutable parsed state (mirrors refresh())
+    m_pids.clear();
+    m_controls.clear();
+    m_buttonHotspots.clear();
+    m_scrollHotspots.clear();
+    m_easySwitchSlots.clear();
+    m_defaultGestures.clear();
+    m_frontImage.clear();
+    m_sideImage.clear();
+    m_backImage.clear();
+    m_features = FeatureSupport{};
+    m_name.clear();
+    m_status = Status::Placeholder;
+    m_minDpi = 200;
+    m_maxDpi = 8000;
+    m_dpiStep = 50;
+    return parseFromObject(root, src, /*strict=*/false);
 }
 
 } // namespace logitune

--- a/src/core/devices/JsonDevice.h
+++ b/src/core/devices/JsonDevice.h
@@ -12,6 +12,8 @@ public:
     static std::unique_ptr<JsonDevice> load(const QString& dirPath);
 
     Status status() const { return m_status; }
+    QString sourcePath() const { return m_sourcePath; }
+    qint64 loadedMtime() const { return m_loadedMtime; }
 
     QString deviceName() const override { return m_name; }
     std::vector<uint16_t> productIds() const override { return m_pids; }
@@ -43,6 +45,8 @@ private:
     QString m_frontImage, m_sideImage, m_backImage;
     QList<EasySwitchSlotPosition> m_easySwitchSlots;
     QMap<QString, ButtonAction> m_defaultGestures;
+    QString m_sourcePath;
+    qint64 m_loadedMtime = 0;
 };
 
 } // namespace logitune

--- a/src/core/devices/JsonDevice.h
+++ b/src/core/devices/JsonDevice.h
@@ -11,6 +11,8 @@ public:
 
     static std::unique_ptr<JsonDevice> load(const QString& dirPath);
 
+    bool refresh();
+
     Status status() const { return m_status; }
     QString sourcePath() const { return m_sourcePath; }
     qint64 loadedMtime() const { return m_loadedMtime; }
@@ -33,6 +35,7 @@ public:
 
 private:
     JsonDevice() = default;
+    bool parseFromDir(const QString& dirPath);
 
     Status m_status = Status::Placeholder;
     QString m_name;

--- a/src/core/devices/JsonDevice.h
+++ b/src/core/devices/JsonDevice.h
@@ -2,6 +2,7 @@
 #include "interfaces/IDevice.h"
 #include <memory>
 #include <QString>
+#include <QJsonObject>
 
 namespace logitune {
 
@@ -12,6 +13,7 @@ public:
     static std::unique_ptr<JsonDevice> load(const QString& dirPath);
 
     bool refresh();
+    bool refreshFromObject(const QJsonObject &root);
 
     Status status() const { return m_status; }
     QString sourcePath() const { return m_sourcePath; }
@@ -36,6 +38,7 @@ public:
 private:
     JsonDevice() = default;
     bool parseFromDir(const QString& dirPath);
+    bool parseFromObject(const QJsonObject& root, const QString& dirPath, bool strict = true);
 
     Status m_status = Status::Placeholder;
     QString m_name;

--- a/src/core/interfaces/IDevice.h
+++ b/src/core/interfaces/IDevice.h
@@ -14,6 +14,7 @@ struct ControlDescriptor {
     QString defaultName;
     QString defaultActionType;
     bool configurable;
+    QString displayName;
 };
 
 struct HotspotDescriptor {
@@ -58,6 +59,7 @@ struct FeatureSupport {
 struct EasySwitchSlotPosition {
     double xPct;
     double yPct;
+    QString label;
 };
 
 class IDevice {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(logitune-tests
     test_device_discovery.cpp
     test_action_executor.cpp
     test_device_registry.cpp
+    test_descriptor_writer.cpp
     test_smoke_mocks.cpp
     mocks/MockDesktop.cpp
     mocks/MockInjector.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(logitune-tests
     test_action_executor.cpp
     test_device_registry.cpp
     test_descriptor_writer.cpp
+    test_editor_model.cpp
     test_smoke_mocks.cpp
     mocks/MockDesktop.cpp
     mocks/MockInjector.cpp

--- a/tests/qml/tst_EasySwitchPageEdit.qml
+++ b/tests/qml/tst_EasySwitchPageEdit.qml
@@ -1,0 +1,38 @@
+import QtQuick
+import QtTest
+
+Item {
+    width: 800; height: 600
+
+    property real imgX: 100
+    property real imgY: 50
+    property real imgW: 600
+    property real imgH: 400
+
+    function inverseDragMath(centroidX, centroidY) {
+        var xPct = (centroidX - imgX) / imgW
+        var yPct = (centroidY - imgY) / imgH
+        return [Math.max(0, Math.min(1, xPct)),
+                Math.max(0, Math.min(1, yPct))]
+    }
+
+    TestCase {
+        name: "EasySwitchDragMath"
+
+        function test_centerOfImageIsHalfHalf() {
+            var r = inverseDragMath(imgX + imgW / 2, imgY + imgH / 2)
+            verify(Math.abs(r[0] - 0.5) < 1e-6)
+            verify(Math.abs(r[1] - 0.5) < 1e-6)
+        }
+        function test_topLeftCornerIsZeroZero() {
+            var r = inverseDragMath(imgX, imgY)
+            compare(r[0], 0)
+            compare(r[1], 0)
+        }
+        function test_outsideClampsToRange() {
+            var r = inverseDragMath(imgX - 999, imgY + imgH + 999)
+            compare(r[0], 0)
+            compare(r[1], 1)
+        }
+    }
+}

--- a/tests/qml/tst_EditorToolbar.qml
+++ b/tests/qml/tst_EditorToolbar.qml
@@ -1,0 +1,22 @@
+import QtQuick
+import QtTest
+import Logitune
+
+Item {
+    width: 600; height: 100
+
+    EditorToolbar {
+        id: bar
+        width: parent.width
+    }
+
+    TestCase {
+        name: "EditorToolbar"
+        when: windowShown
+
+        function test_invisibleWhenEditorModelNotRegistered() {
+            compare(bar.visible, false)
+            compare(bar.height, 0)
+        }
+    }
+}

--- a/tests/qml/tst_SideNav.qml
+++ b/tests/qml/tst_SideNav.qml
@@ -60,6 +60,23 @@ Item {
             compare(nav.currentPage, "pointscroll", "clicking point & scroll should update currentPage")
         }
 
+        function findByObjectName(root, name) {
+            if (root.objectName === name)
+                return root
+            for (var i = 0; i < root.children.length; i++) {
+                var found = findByObjectName(root.children[i], name)
+                if (found !== null)
+                    return found
+            }
+            return null
+        }
+
+        function test_amberStripeInvisibleByDefault() {
+            var stripe = findByObjectName(nav, "editStripe")
+            verify(stripe !== null, "editStripe should exist")
+            compare(stripe.visible, false, "editStripe should be hidden when EditorModel is undefined")
+        }
+
         // Flow section removed — no longer part of the app
     }
 }

--- a/tests/test_descriptor_writer.cpp
+++ b/tests/test_descriptor_writer.cpp
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include "devices/DescriptorWriter.h"
+
+TEST(DescriptorWriter, WritesValidJsonAtomically) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    QJsonObject obj;
+    obj[QStringLiteral("name")] = QStringLiteral("Test");
+    obj[QStringLiteral("status")] = QStringLiteral("community-local");
+
+    logitune::DescriptorWriter w;
+    QString err;
+    EXPECT_EQ(w.write(tmp.path(), obj, &err), logitune::DescriptorWriter::Ok);
+    EXPECT_TRUE(err.isEmpty());
+
+    QFile f(tmp.path() + QStringLiteral("/descriptor.json"));
+    ASSERT_TRUE(f.open(QIODevice::ReadOnly));
+    auto doc = QJsonDocument::fromJson(f.readAll());
+    ASSERT_FALSE(doc.isNull());
+    EXPECT_EQ(doc.object()[QStringLiteral("name")].toString(), QStringLiteral("Test"));
+}
+
+TEST(DescriptorWriter, ReturnsIoErrorOnUnwritableDir) {
+    logitune::DescriptorWriter w;
+    QString err;
+    QJsonObject obj;
+    obj[QStringLiteral("name")] = QStringLiteral("x");
+    EXPECT_EQ(w.write(QStringLiteral("/proc/nonexistent-do-not-create"), obj, &err),
+              logitune::DescriptorWriter::IoError);
+    EXPECT_FALSE(err.isEmpty());
+}

--- a/tests/test_descriptor_writer.cpp
+++ b/tests/test_descriptor_writer.cpp
@@ -33,3 +33,25 @@ TEST(DescriptorWriter, ReturnsIoErrorOnUnwritableDir) {
               logitune::DescriptorWriter::IoError);
     EXPECT_FALSE(err.isEmpty());
 }
+
+TEST(DescriptorWriter, PreservesUnknownFieldsOnRoundTrip) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    QJsonObject obj;
+    obj[QStringLiteral("name")] = QStringLiteral("Test");
+    obj[QStringLiteral("__future_field")] = QStringLiteral("will it survive?");
+    QJsonObject nested;
+    nested[QStringLiteral("__nested_future")] = 42;
+    obj[QStringLiteral("nested")] = nested;
+
+    logitune::DescriptorWriter w;
+    ASSERT_EQ(w.write(tmp.path(), obj, nullptr), logitune::DescriptorWriter::Ok);
+
+    QFile f(tmp.path() + QStringLiteral("/descriptor.json"));
+    ASSERT_TRUE(f.open(QIODevice::ReadOnly));
+    auto roundTripped = QJsonDocument::fromJson(f.readAll()).object();
+
+    EXPECT_EQ(roundTripped[QStringLiteral("__future_field")].toString(),
+              QStringLiteral("will it survive?"));
+    EXPECT_EQ(roundTripped[QStringLiteral("nested")].toObject()[QStringLiteral("__nested_future")].toInt(), 42);
+}

--- a/tests/test_device_registry.cpp
+++ b/tests/test_device_registry.cpp
@@ -1,5 +1,9 @@
 #include <gtest/gtest.h>
 #include "DeviceRegistry.h"
+#include "devices/JsonDevice.h"
+#include <QTemporaryDir>
+#include <QFile>
+#include <QFileInfo>
 using namespace logitune;
 
 struct DeviceSpec {
@@ -145,4 +149,42 @@ TEST(DeviceRegistry, ReturnsNullForUnknownPid) {
     DeviceRegistry reg;
     EXPECT_EQ(reg.findByPid(0x0000), nullptr);
     EXPECT_EQ(reg.findByPid(0xFFFF), nullptr);
+}
+
+TEST(DeviceRegistry, ReloadByPathRefreshesSingleDevice) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    qputenv("XDG_DATA_HOME", tmp.path().toUtf8());
+    QDir().mkpath(tmp.path() + QStringLiteral("/logitune/devices/test"));
+    const QString descPath = tmp.path() + QStringLiteral("/logitune/devices/test/descriptor.json");
+
+    auto write = [&](const QString &name) {
+        QFile f(descPath);
+        if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
+            return false;
+        f.write(QStringLiteral(R"({"name":"%1","status":"community-local","productIds":["0xffff"],"features":{},"controls":[],"hotspots":{"buttons":[],"scroll":[]},"images":{},"easySwitchSlots":[]})").arg(name).toUtf8());
+        f.close();
+        return true;
+    };
+    ASSERT_TRUE(write(QStringLiteral("Original")));
+
+    logitune::DeviceRegistry reg;
+    const auto *dev = reg.findByName(QStringLiteral("Original"));
+    ASSERT_NE(dev, nullptr);
+    const auto *jdev = dynamic_cast<const logitune::JsonDevice*>(dev);
+    ASSERT_NE(jdev, nullptr);
+    const QString srcPath = jdev->sourcePath();
+
+    ASSERT_TRUE(write(QStringLiteral("Mutated")));
+    ASSERT_TRUE(reg.reload(srcPath));
+
+    EXPECT_EQ(jdev->deviceName(), QStringLiteral("Mutated"));
+    EXPECT_EQ(reg.findBySourcePath(srcPath), dev);
+
+    qunsetenv("XDG_DATA_HOME");
+}
+
+TEST(DeviceRegistry, ReloadUnknownPathReturnsFalse) {
+    logitune::DeviceRegistry reg;
+    EXPECT_FALSE(reg.reload(QStringLiteral("/nonexistent/path/that/does/not/exist")));
 }

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -1,7 +1,35 @@
 #include <gtest/gtest.h>
 #include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QDir>
+#include <QJsonDocument>
 #include "EditorModel.h"
 #include "DeviceRegistry.h"
+
+namespace {
+QString writeMinimalDescriptor(const QString &dir) {
+    QDir().mkpath(dir);
+    QFile f(dir + QStringLiteral("/descriptor.json"));
+    f.open(QIODevice::WriteOnly | QIODevice::Truncate);
+    f.write(R"({
+  "name": "Tester",
+  "status": "community-local",
+  "productIds": ["0xffff"],
+  "features": {},
+  "controls": [],
+  "hotspots": {"buttons": [], "scroll": []},
+  "images": {},
+  "easySwitchSlots": [
+    {"xPct": 0.10, "yPct": 0.20},
+    {"xPct": 0.30, "yPct": 0.40}
+  ]
+})");
+    f.close();
+    return QFileInfo(dir).canonicalFilePath();
+}
+}
 
 TEST(EditorModel, EditingFlagAndInitialState) {
     logitune::DeviceRegistry reg;
@@ -22,4 +50,25 @@ TEST(EditorModel, ActiveDevicePathSetterEmitsSignals) {
     EXPECT_EQ(pathSpy.count(), 1);
     EXPECT_EQ(dirtySpy.count(), 1);
     EXPECT_EQ(m.activeDevicePath(), QStringLiteral("/tmp/foo"));
+}
+
+TEST(EditorModel, UpdateSlotPositionMutatesPendingAndPushesUndo) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
+
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+    m.setActiveDevicePath(path);
+
+    QSignalSpy dirtySpy(&m, &logitune::EditorModel::dirtyChanged);
+    QSignalSpy undoSpy(&m, &logitune::EditorModel::undoStateChanged);
+
+    m.updateSlotPosition(1, 0.50, 0.60);
+
+    EXPECT_TRUE(m.hasUnsavedChanges());
+    EXPECT_TRUE(m.canUndo());
+    EXPECT_FALSE(m.canRedo());
+    EXPECT_GE(dirtySpy.count(), 1);
+    EXPECT_GE(undoSpy.count(), 1);
 }

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -250,3 +250,24 @@ TEST(EditorModel, ResetDiscardsPendingAndClearsStacks) {
     auto obj = QJsonDocument::fromJson(f.readAll()).object();
     EXPECT_DOUBLE_EQ(obj[QStringLiteral("easySwitchSlots")].toArray()[0].toObject()[QStringLiteral("xPct")].toDouble(), 0.10);
 }
+
+TEST(EditorModel, ReplaceImageCopiesFileAndUpdatesPending) {
+    QTemporaryDir tmp; ASSERT_TRUE(tmp.isValid());
+    const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
+
+    const QString src = tmp.path() + QStringLiteral("/source-image.png");
+    QFile sf(src);
+    ASSERT_TRUE(sf.open(QIODevice::WriteOnly));
+    sf.write("\x89PNG\r\n");
+    sf.close();
+
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+    m.setActiveDevicePath(path);
+
+    m.replaceImage(QStringLiteral("back"), src);
+
+    EXPECT_TRUE(m.hasUnsavedChanges());
+    EXPECT_TRUE(m.canUndo());
+    EXPECT_TRUE(QFile::exists(path + QStringLiteral("/back.png")));
+}

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -72,3 +72,33 @@ TEST(EditorModel, UpdateSlotPositionMutatesPendingAndPushesUndo) {
     EXPECT_GE(dirtySpy.count(), 1);
     EXPECT_GE(undoSpy.count(), 1);
 }
+
+TEST(EditorModel, UpdateHotspotMutatesPendingAndPushesUndo) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    QDir().mkpath(tmp.path() + QStringLiteral("/dev"));
+    QFile f(tmp.path() + QStringLiteral("/dev/descriptor.json"));
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
+    f.write(R"({
+  "name": "Tester", "status": "community-local", "productIds": ["0xffff"],
+  "features": {}, "controls": [],
+  "hotspots": {
+    "buttons": [
+      {"buttonIndex": 0, "xPct": 0.10, "yPct": 0.20, "side": "left", "labelOffsetYPct": 0.0}
+    ],
+    "scroll": []
+  },
+  "images": {}, "easySwitchSlots": []
+})");
+    f.close();
+    const QString path = QFileInfo(tmp.path() + QStringLiteral("/dev")).canonicalFilePath();
+
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+    m.setActiveDevicePath(path);
+
+    m.updateHotspot(0, 0.55, 0.66, QStringLiteral("right"), 0.10);
+
+    EXPECT_TRUE(m.hasUnsavedChanges());
+    EXPECT_TRUE(m.canUndo());
+}

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -102,3 +102,24 @@ TEST(EditorModel, UpdateHotspotMutatesPendingAndPushesUndo) {
     EXPECT_TRUE(m.hasUnsavedChanges());
     EXPECT_TRUE(m.canUndo());
 }
+
+TEST(EditorModel, UndoRestoresSlotPosition) {
+    QTemporaryDir tmp; ASSERT_TRUE(tmp.isValid());
+    const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+    m.setActiveDevicePath(path);
+
+    m.updateSlotPosition(0, 0.99, 0.99);
+    EXPECT_TRUE(m.canUndo());
+    m.undo();
+
+    EXPECT_FALSE(m.canUndo());
+    EXPECT_TRUE(m.canRedo());
+    EXPECT_FALSE(m.hasUnsavedChanges());
+
+    m.redo();
+    EXPECT_TRUE(m.canUndo());
+    EXPECT_FALSE(m.canRedo());
+    EXPECT_TRUE(m.hasUnsavedChanges());
+}

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -123,3 +123,34 @@ TEST(EditorModel, UndoRestoresSlotPosition) {
     EXPECT_FALSE(m.canRedo());
     EXPECT_TRUE(m.hasUnsavedChanges());
 }
+
+TEST(EditorModel, UpdateTextEditsAllThreeKindsAndUndoes) {
+    QTemporaryDir tmp; ASSERT_TRUE(tmp.isValid());
+    QDir().mkpath(tmp.path() + QStringLiteral("/dev"));
+    QFile f(tmp.path() + QStringLiteral("/dev/descriptor.json"));
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
+    f.write(R"({
+  "name": "Original Name", "status": "community-local", "productIds": ["0xffff"],
+  "features": {},
+  "controls": [
+    {"controlId": "0x0050", "buttonIndex": 0, "defaultName": "Left", "defaultActionType": "default", "configurable": false}
+  ],
+  "hotspots": {"buttons": [], "scroll": []}, "images": {},
+  "easySwitchSlots": [{"xPct": 0.1, "yPct": 0.2}]
+})");
+    f.close();
+    const QString path = QFileInfo(tmp.path() + QStringLiteral("/dev")).canonicalFilePath();
+
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+    m.setActiveDevicePath(path);
+
+    m.updateText(QStringLiteral("deviceName"), -1, QStringLiteral("New Name"));
+    m.updateText(QStringLiteral("controlDisplayName"), 0, QStringLiteral("Primary"));
+    m.updateText(QStringLiteral("slotLabel"), 0, QStringLiteral("Mac"));
+
+    EXPECT_TRUE(m.canUndo());
+    m.undo(); m.undo(); m.undo();
+    EXPECT_FALSE(m.hasUnsavedChanges());
+    EXPECT_FALSE(m.canUndo());
+}

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -227,3 +227,26 @@ TEST(EditorModel, SaveFailurePreservesState) {
     QFile::setPermissions(path,
         QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner);
 }
+
+TEST(EditorModel, ResetDiscardsPendingAndClearsStacks) {
+    QTemporaryDir tmp; ASSERT_TRUE(tmp.isValid());
+    const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
+
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+    m.setActiveDevicePath(path);
+
+    m.updateSlotPosition(0, 0.99, 0.99);
+    EXPECT_TRUE(m.hasUnsavedChanges());
+
+    m.reset();
+
+    EXPECT_FALSE(m.hasUnsavedChanges());
+    EXPECT_FALSE(m.canUndo());
+    EXPECT_FALSE(m.canRedo());
+
+    QFile f(path + QStringLiteral("/descriptor.json"));
+    ASSERT_TRUE(f.open(QIODevice::ReadOnly));
+    auto obj = QJsonDocument::fromJson(f.readAll()).object();
+    EXPECT_DOUBLE_EQ(obj[QStringLiteral("easySwitchSlots")].toArray()[0].toObject()[QStringLiteral("xPct")].toDouble(), 0.10);
+}

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -271,3 +271,34 @@ TEST(EditorModel, ReplaceImageCopiesFileAndUpdatesPending) {
     EXPECT_TRUE(m.canUndo());
     EXPECT_TRUE(QFile::exists(path + QStringLiteral("/back.png")));
 }
+
+TEST(EditorModel, ExternalChangeSilentReloadWhenNotDirty) {
+    QTemporaryDir tmp; ASSERT_TRUE(tmp.isValid());
+    const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
+
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+    m.setActiveDevicePath(path);
+
+    QSignalSpy externalSpy(&m, &logitune::EditorModel::externalChangeDetected);
+    m.onExternalFileChanged(path + QStringLiteral("/descriptor.json"));
+
+    EXPECT_EQ(externalSpy.count(), 0);
+}
+
+TEST(EditorModel, ExternalChangeWhileDirtyEmitsConflictSignal) {
+    QTemporaryDir tmp; ASSERT_TRUE(tmp.isValid());
+    const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
+
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+    m.setActiveDevicePath(path);
+    m.updateSlotPosition(0, 0.99, 0.99);
+
+    QSignalSpy externalSpy(&m, &logitune::EditorModel::externalChangeDetected);
+    m.onExternalFileChanged(path + QStringLiteral("/descriptor.json"));
+
+    EXPECT_EQ(externalSpy.count(), 1);
+    EXPECT_EQ(externalSpy.first().first().toString(), path);
+    EXPECT_TRUE(m.hasUnsavedChanges());
+}

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -204,3 +204,26 @@ TEST(EditorModel, SaveWritesPendingAndClearsState) {
     auto obj = QJsonDocument::fromJson(f.readAll()).object();
     EXPECT_DOUBLE_EQ(obj[QStringLiteral("easySwitchSlots")].toArray()[0].toObject()[QStringLiteral("xPct")].toDouble(), 0.55);
 }
+
+TEST(EditorModel, SaveFailurePreservesState) {
+    QTemporaryDir tmp; ASSERT_TRUE(tmp.isValid());
+    const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
+
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+    m.setActiveDevicePath(path);
+    m.updateSlotPosition(0, 0.55, 0.66);
+
+    // Make the device dir read-only so QSaveFile.commit() fails
+    QFile::setPermissions(path, QFileDevice::ReadOwner | QFileDevice::ExeOwner);
+
+    QSignalSpy failSpy(&m, &logitune::EditorModel::saveFailed);
+    m.save();
+
+    EXPECT_EQ(failSpy.count(), 1);
+    EXPECT_TRUE(m.hasUnsavedChanges());
+    EXPECT_TRUE(m.canUndo());
+
+    QFile::setPermissions(path,
+        QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner);
+}

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -105,6 +105,39 @@ TEST(EditorModel, UpdateHotspotMutatesPendingAndPushesUndo) {
     EXPECT_TRUE(m.canUndo());
 }
 
+TEST(EditorModel, UpdateScrollHotspotMutatesScrollArray) {
+    QTemporaryDir tmp; ASSERT_TRUE(tmp.isValid());
+    QDir().mkpath(tmp.path() + QStringLiteral("/dev"));
+    QFile f(tmp.path() + QStringLiteral("/dev/descriptor.json"));
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
+    f.write(R"({
+  "name": "Tester", "status": "community-local", "productIds": ["0xffff"],
+  "features": {}, "controls": [],
+  "hotspots": {
+    "buttons": [],
+    "scroll": [
+      {"buttonIndex": -1, "xPct": 0.10, "yPct": 0.20, "side": "left", "labelOffsetYPct": 0.0, "kind": "scrollwheel"}
+    ]
+  },
+  "images": {}, "easySwitchSlots": []
+})");
+    f.close();
+    const QString path = QFileInfo(tmp.path() + QStringLiteral("/dev")).canonicalFilePath();
+
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+    m.setActiveDevicePath(path);
+
+    m.updateScrollHotspot(0, 0.55, 0.66, QStringLiteral("right"), 0.10);
+
+    EXPECT_TRUE(m.hasUnsavedChanges());
+    EXPECT_TRUE(m.canUndo());
+
+    m.undo();
+    EXPECT_FALSE(m.hasUnsavedChanges());
+    EXPECT_FALSE(m.canUndo());
+}
+
 TEST(EditorModel, UndoRestoresSlotPosition) {
     QTemporaryDir tmp; ASSERT_TRUE(tmp.isValid());
     const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -154,3 +154,28 @@ TEST(EditorModel, UpdateTextEditsAllThreeKindsAndUndoes) {
     EXPECT_FALSE(m.hasUnsavedChanges());
     EXPECT_FALSE(m.canUndo());
 }
+
+TEST(EditorModel, PerDeviceStacksAreIsolated) {
+    QTemporaryDir tmp; ASSERT_TRUE(tmp.isValid());
+    const QString pathA = writeMinimalDescriptor(tmp.path() + QStringLiteral("/devA"));
+    const QString pathB = writeMinimalDescriptor(tmp.path() + QStringLiteral("/devB"));
+
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+
+    m.setActiveDevicePath(pathA);
+    m.updateSlotPosition(0, 0.5, 0.5);
+    EXPECT_TRUE(m.canUndo());
+    EXPECT_TRUE(m.hasUnsavedChanges());
+
+    m.setActiveDevicePath(pathB);
+    EXPECT_FALSE(m.canUndo());
+    EXPECT_FALSE(m.hasUnsavedChanges());
+
+    m.updateSlotPosition(0, 0.7, 0.7);
+    EXPECT_TRUE(m.canUndo());
+
+    m.setActiveDevicePath(pathA);
+    EXPECT_TRUE(m.canUndo());
+    EXPECT_TRUE(m.hasUnsavedChanges());
+}

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -5,6 +5,8 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
 #include "EditorModel.h"
 #include "DeviceRegistry.h"
 
@@ -178,4 +180,27 @@ TEST(EditorModel, PerDeviceStacksAreIsolated) {
     m.setActiveDevicePath(pathA);
     EXPECT_TRUE(m.canUndo());
     EXPECT_TRUE(m.hasUnsavedChanges());
+}
+
+TEST(EditorModel, SaveWritesPendingAndClearsState) {
+    QTemporaryDir tmp; ASSERT_TRUE(tmp.isValid());
+    const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
+
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+    m.setActiveDevicePath(path);
+
+    QSignalSpy savedSpy(&m, &logitune::EditorModel::saved);
+    m.updateSlotPosition(0, 0.55, 0.66);
+    m.save();
+
+    EXPECT_FALSE(m.hasUnsavedChanges());
+    EXPECT_FALSE(m.canUndo());
+    EXPECT_FALSE(m.canRedo());
+    EXPECT_EQ(savedSpy.count(), 1);
+
+    QFile f(path + QStringLiteral("/descriptor.json"));
+    ASSERT_TRUE(f.open(QIODevice::ReadOnly));
+    auto obj = QJsonDocument::fromJson(f.readAll()).object();
+    EXPECT_DOUBLE_EQ(obj[QStringLiteral("easySwitchSlots")].toArray()[0].toObject()[QStringLiteral("xPct")].toDouble(), 0.55);
 }

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+#include <QSignalSpy>
+#include "EditorModel.h"
+#include "DeviceRegistry.h"
+
+TEST(EditorModel, EditingFlagAndInitialState) {
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, /*editing=*/true);
+    EXPECT_TRUE(m.editing());
+    EXPECT_FALSE(m.hasUnsavedChanges());
+    EXPECT_FALSE(m.canUndo());
+    EXPECT_FALSE(m.canRedo());
+    EXPECT_TRUE(m.activeDevicePath().isEmpty());
+}
+
+TEST(EditorModel, ActiveDevicePathSetterEmitsSignals) {
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+    QSignalSpy pathSpy(&m, &logitune::EditorModel::activeDevicePathChanged);
+    QSignalSpy dirtySpy(&m, &logitune::EditorModel::dirtyChanged);
+    m.setActiveDevicePath(QStringLiteral("/tmp/foo"));
+    EXPECT_EQ(pathSpy.count(), 1);
+    EXPECT_EQ(dirtySpy.count(), 1);
+    EXPECT_EQ(m.activeDevicePath(), QStringLiteral("/tmp/foo"));
+}

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -302,3 +302,20 @@ TEST(EditorModel, ExternalChangeWhileDirtyEmitsConflictSignal) {
     EXPECT_EQ(externalSpy.first().first().toString(), path);
     EXPECT_TRUE(m.hasUnsavedChanges());
 }
+
+TEST(EditorModel, SaveSuppressesOwnWatcherFire) {
+    QTemporaryDir tmp; ASSERT_TRUE(tmp.isValid());
+    const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
+
+    logitune::DeviceRegistry reg;
+    logitune::EditorModel m(&reg, true);
+    m.setActiveDevicePath(path);
+    m.updateSlotPosition(0, 0.55, 0.66);
+
+    QSignalSpy externalSpy(&m, &logitune::EditorModel::externalChangeDetected);
+    m.save();
+
+    m.onExternalFileChanged(path + QStringLiteral("/descriptor.json"));
+
+    EXPECT_EQ(externalSpy.count(), 0);
+}

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -35,7 +35,7 @@ QString writeMinimalDescriptor(const QString &dir) {
 
 TEST(EditorModel, EditingFlagAndInitialState) {
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, /*editing=*/true);
+    logitune::EditorModel m(&reg, nullptr, /*editing=*/true);
     EXPECT_TRUE(m.editing());
     EXPECT_FALSE(m.hasUnsavedChanges());
     EXPECT_FALSE(m.canUndo());
@@ -45,7 +45,7 @@ TEST(EditorModel, EditingFlagAndInitialState) {
 
 TEST(EditorModel, ActiveDevicePathSetterEmitsSignals) {
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
     QSignalSpy pathSpy(&m, &logitune::EditorModel::activeDevicePathChanged);
     QSignalSpy dirtySpy(&m, &logitune::EditorModel::dirtyChanged);
     m.setActiveDevicePath(QStringLiteral("/tmp/foo"));
@@ -60,7 +60,7 @@ TEST(EditorModel, UpdateSlotPositionMutatesPendingAndPushesUndo) {
     const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
 
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
     m.setActiveDevicePath(path);
 
     QSignalSpy dirtySpy(&m, &logitune::EditorModel::dirtyChanged);
@@ -96,7 +96,7 @@ TEST(EditorModel, UpdateHotspotMutatesPendingAndPushesUndo) {
     const QString path = QFileInfo(tmp.path() + QStringLiteral("/dev")).canonicalFilePath();
 
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
     m.setActiveDevicePath(path);
 
     m.updateHotspot(0, 0.55, 0.66, QStringLiteral("right"), 0.10);
@@ -125,7 +125,7 @@ TEST(EditorModel, UpdateScrollHotspotMutatesScrollArray) {
     const QString path = QFileInfo(tmp.path() + QStringLiteral("/dev")).canonicalFilePath();
 
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
     m.setActiveDevicePath(path);
 
     m.updateScrollHotspot(0, 0.55, 0.66, QStringLiteral("right"), 0.10);
@@ -142,7 +142,7 @@ TEST(EditorModel, UndoRestoresSlotPosition) {
     QTemporaryDir tmp; ASSERT_TRUE(tmp.isValid());
     const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
     m.setActiveDevicePath(path);
 
     m.updateSlotPosition(0, 0.99, 0.99);
@@ -177,7 +177,7 @@ TEST(EditorModel, UpdateTextEditsAllThreeKindsAndUndoes) {
     const QString path = QFileInfo(tmp.path() + QStringLiteral("/dev")).canonicalFilePath();
 
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
     m.setActiveDevicePath(path);
 
     m.updateText(QStringLiteral("deviceName"), -1, QStringLiteral("New Name"));
@@ -196,7 +196,7 @@ TEST(EditorModel, PerDeviceStacksAreIsolated) {
     const QString pathB = writeMinimalDescriptor(tmp.path() + QStringLiteral("/devB"));
 
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
 
     m.setActiveDevicePath(pathA);
     m.updateSlotPosition(0, 0.5, 0.5);
@@ -220,7 +220,7 @@ TEST(EditorModel, SaveWritesPendingAndClearsState) {
     const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
 
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
     m.setActiveDevicePath(path);
 
     QSignalSpy savedSpy(&m, &logitune::EditorModel::saved);
@@ -243,7 +243,7 @@ TEST(EditorModel, SaveFailurePreservesState) {
     const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
 
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
     m.setActiveDevicePath(path);
     m.updateSlotPosition(0, 0.55, 0.66);
 
@@ -266,7 +266,7 @@ TEST(EditorModel, ResetDiscardsPendingAndClearsStacks) {
     const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
 
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
     m.setActiveDevicePath(path);
 
     m.updateSlotPosition(0, 0.99, 0.99);
@@ -295,7 +295,7 @@ TEST(EditorModel, ReplaceImageCopiesFileAndUpdatesPending) {
     sf.close();
 
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
     m.setActiveDevicePath(path);
 
     m.replaceImage(QStringLiteral("back"), src);
@@ -310,7 +310,7 @@ TEST(EditorModel, ExternalChangeSilentReloadWhenNotDirty) {
     const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
 
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
     m.setActiveDevicePath(path);
 
     QSignalSpy externalSpy(&m, &logitune::EditorModel::externalChangeDetected);
@@ -324,7 +324,7 @@ TEST(EditorModel, ExternalChangeWhileDirtyEmitsConflictSignal) {
     const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
 
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
     m.setActiveDevicePath(path);
     m.updateSlotPosition(0, 0.99, 0.99);
 
@@ -341,7 +341,7 @@ TEST(EditorModel, SaveSuppressesOwnWatcherFire) {
     const QString path = writeMinimalDescriptor(tmp.path() + QStringLiteral("/dev"));
 
     logitune::DeviceRegistry reg;
-    logitune::EditorModel m(&reg, true);
+    logitune::EditorModel m(&reg, nullptr, true);
     m.setActiveDevicePath(path);
     m.updateSlotPosition(0, 0.55, 0.66);
 

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -247,8 +247,9 @@ TEST(EditorModel, SaveFailurePreservesState) {
     m.setActiveDevicePath(path);
     m.updateSlotPosition(0, 0.55, 0.66);
 
-    // Make the device dir read-only so QSaveFile.commit() fails
-    QFile::setPermissions(path, QFileDevice::ReadOwner | QFileDevice::ExeOwner);
+    // Remove the descriptor so QSaveFile can't write (works even as root)
+    QFile::remove(path + QStringLiteral("/descriptor.json"));
+    QDir(path).removeRecursively();
 
     QSignalSpy failSpy(&m, &logitune::EditorModel::saveFailed);
     m.save();
@@ -256,9 +257,6 @@ TEST(EditorModel, SaveFailurePreservesState) {
     EXPECT_EQ(failSpy.count(), 1);
     EXPECT_TRUE(m.hasUnsavedChanges());
     EXPECT_TRUE(m.canUndo());
-
-    QFile::setPermissions(path,
-        QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner);
 }
 
 TEST(EditorModel, ResetDiscardsPendingAndClearsStacks) {

--- a/tests/test_json_device.cpp
+++ b/tests/test_json_device.cpp
@@ -6,6 +6,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QFile>
+#include <QFileInfo>
 
 using namespace logitune;
 
@@ -401,4 +402,31 @@ TEST(JsonDevice, FeatureFlagDefaults)
     EXPECT_FALSE(f.reprogControls);
     EXPECT_FALSE(f.gestureV2);
     EXPECT_FALSE(f.persistentRemappableAction);
+}
+
+TEST(JsonDevice, TracksSourcePathAndLoadMtime) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    QFile f(tmp.path() + QStringLiteral("/descriptor.json"));
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write(R"({
+  "name": "Tester",
+  "status": "community-local",
+  "productIds": ["0xffff"],
+  "features": {},
+  "controls": [],
+  "hotspots": {"buttons": [], "scroll": []},
+  "images": {},
+  "easySwitchSlots": []
+})");
+    f.close();
+
+    auto dev = logitune::JsonDevice::load(tmp.path());
+    ASSERT_NE(dev, nullptr);
+
+    EXPECT_EQ(dev->sourcePath(), QFileInfo(tmp.path()).canonicalFilePath());
+
+    const qint64 expected = QFileInfo(tmp.path() + "/descriptor.json")
+        .lastModified().toSecsSinceEpoch();
+    EXPECT_EQ(dev->loadedMtime(), expected);
 }

--- a/tests/test_json_device.cpp
+++ b/tests/test_json_device.cpp
@@ -500,3 +500,34 @@ TEST(JsonDevice, OptionalEditorFieldsDefaultEmptyWhenAbsent) {
     for (const auto &s : dev->easySwitchSlotPositions())
         EXPECT_TRUE(s.label.isEmpty());
 }
+
+TEST(JsonDevice, RefreshRereadsDescriptorInPlace) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+
+    auto write = [&](const QString &name) {
+        QFile f(tmp.path() + QStringLiteral("/descriptor.json"));
+        ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
+        f.write(QStringLiteral(R"({
+  "name": "%1",
+  "status": "community-local",
+  "productIds": ["0xffff"],
+  "features": {},
+  "controls": [],
+  "hotspots": {"buttons": [], "scroll": []},
+  "images": {},
+  "easySwitchSlots": []
+})").arg(name).toUtf8());
+    };
+
+    write(QStringLiteral("Original Name"));
+    auto dev = logitune::JsonDevice::load(tmp.path());
+    ASSERT_NE(dev, nullptr);
+    const auto *raw = dev.get();
+    EXPECT_EQ(dev->deviceName(), QStringLiteral("Original Name"));
+
+    write(QStringLiteral("Mutated Name"));
+    ASSERT_TRUE(dev->refresh());
+    EXPECT_EQ(dev->deviceName(), QStringLiteral("Mutated Name"));
+    EXPECT_EQ(dev.get(), raw);
+}

--- a/tests/test_json_device.cpp
+++ b/tests/test_json_device.cpp
@@ -430,3 +430,73 @@ TEST(JsonDevice, TracksSourcePathAndLoadMtime) {
         .lastModified().toSecsSinceEpoch();
     EXPECT_EQ(dev->loadedMtime(), expected);
 }
+
+TEST(JsonDevice, ParsesOptionalEditorFields) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    QFile f(tmp.path() + QStringLiteral("/descriptor.json"));
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write(R"({
+  "name": "Tester",
+  "status": "community-local",
+  "productIds": ["0xffff"],
+  "features": {},
+  "controls": [
+    {
+      "controlId": "0x0050",
+      "buttonIndex": 0,
+      "defaultName": "Left click",
+      "defaultActionType": "default",
+      "configurable": false,
+      "displayName": "Primary Button"
+    }
+  ],
+  "hotspots": {"buttons": [], "scroll": []},
+  "images": {},
+  "easySwitchSlots": [
+    {"xPct": 0.42, "yPct": 0.78, "label": "Mac"},
+    {"xPct": 0.50, "yPct": 0.78}
+  ]
+})");
+    f.close();
+
+    auto dev = logitune::JsonDevice::load(tmp.path());
+    ASSERT_NE(dev, nullptr);
+
+    const auto controls = dev->controls();
+    ASSERT_EQ(controls.size(), 1);
+    EXPECT_EQ(controls[0].displayName, QStringLiteral("Primary Button"));
+
+    const auto slotPositions = dev->easySwitchSlotPositions();
+    ASSERT_EQ(slotPositions.size(), 2);
+    EXPECT_EQ(slotPositions[0].label, QStringLiteral("Mac"));
+    EXPECT_TRUE(slotPositions[1].label.isEmpty());
+}
+
+TEST(JsonDevice, OptionalEditorFieldsDefaultEmptyWhenAbsent) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    QFile f(tmp.path() + QStringLiteral("/descriptor.json"));
+    ASSERT_TRUE(f.open(QIODevice::WriteOnly));
+    f.write(R"({
+  "name": "Tester",
+  "status": "community-local",
+  "productIds": ["0xffff"],
+  "features": {},
+  "controls": [
+    {"controlId": "0x0050", "buttonIndex": 0, "defaultName": "Left click",
+     "defaultActionType": "default", "configurable": false}
+  ],
+  "hotspots": {"buttons": [], "scroll": []},
+  "images": {},
+  "easySwitchSlots": [{"xPct": 0.1, "yPct": 0.2}]
+})");
+    f.close();
+
+    auto dev = logitune::JsonDevice::load(tmp.path());
+    ASSERT_NE(dev, nullptr);
+    for (const auto &c : dev->controls())
+        EXPECT_TRUE(c.displayName.isEmpty());
+    for (const auto &s : dev->easySwitchSlotPositions())
+        EXPECT_TRUE(s.label.isEmpty());
+}


### PR DESCRIPTION
Closes #33.

## Summary

- `--simulate-all` debug flag populates the carousel from registry without HID++ probing
- `--edit` flag (orthogonal) enables WYSIWYG descriptor editor: drag markers, cards, and easy-switch slots directly on device pages
- Unified `HotspotControl` component owns marker + connector line + card as siblings
- `EditorModel` ViewModel with per-device undo/redo, manual save via atomic `DescriptorWriter`, file watcher with conflict detection
- `JsonDevice::refreshFromObject()` for live preview without disk round-trip
- Themed icon toolbar (Save/Reset/Undo/Redo), sidebar amber stripe in edit mode
- Double-click in-place text editing for button names, slot labels, device name
- Drag-drop + file picker for image upload (back/side)
- 493 C++ tests + 72 QML tests, all passing

## Test plan

- [x] All tests pass
- [x] Easy-switch slot drag + save + restart persists
- [x] Button marker drag sticks, line follows live
- [x] Button card drag with column-snap on release
- [x] Point & scroll marker + card drag works
- [x] Double-click card label to rename
- [x] Toolbar only visible on device pages
- [x] Production mode (no --edit) unchanged