### PR TITLE
Clarify license as GPL-3.0-only (SPDX)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 cmake_minimum_required(VERSION 3.22)
 project(logitune VERSION 0.2.3 LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -134,4 +134,4 @@ C++20 · Qt 6 Quick · CMake · HID++ 2.0 · GTest
 
 ## 📄 License
 
-GPL-3.0
+[GPL-3.0-only](https://spdx.org/licenses/GPL-3.0-only.html)


### PR DESCRIPTION
Closes #32.

Adds `SPDX-License-Identifier: GPL-3.0-only` to CMakeLists.txt and updates the README license section to link to the SPDX page.