### PR TITLE
Simplify device status to verified/beta

### DIFF
--- a/devices/mx-master-2s/descriptor.json
+++ b/devices/mx-master-2s/descriptor.json
@@ -1,6 +1,6 @@
 {
   "name": "MX Master 2S",
-  "status": "implemented",
+  "status": "verified",
   "productIds": ["0xb019"],
   "features": {
     "battery": true,

--- a/devices/mx-master-3s/descriptor.json
+++ b/devices/mx-master-3s/descriptor.json
@@ -1,6 +1,6 @@
 {
   "name": "MX Master 3S",
-  "status": "implemented",
+  "status": "verified",
   "productIds": ["0xb034"],
   "features": {
     "battery": true,

--- a/devices/mx-master-4/descriptor.json
+++ b/devices/mx-master-4/descriptor.json
@@ -1,6 +1,6 @@
 {
   "name": "MX Master 4",
-  "status": "implemented",
+  "status": "verified",
   "productIds": ["0xb042"],
   "features": {
     "battery": true,

--- a/src/app/models/DeviceModel.cpp
+++ b/src/app/models/DeviceModel.cpp
@@ -58,14 +58,12 @@ QVariant DeviceModel::data(const QModelIndex &index, int role) const
         if (!device->descriptor())
             return QStringLiteral("unknown");
         auto* json = dynamic_cast<const JsonDevice*>(device->descriptor());
-        if (!json) return QStringLiteral("implemented");
+        if (!json) return QStringLiteral("beta");
         switch (json->status()) {
-        case JsonDevice::Status::Implemented:       return QStringLiteral("implemented");
-        case JsonDevice::Status::CommunityVerified: return QStringLiteral("community-verified");
-        case JsonDevice::Status::CommunityLocal:    return QStringLiteral("community-local");
-        case JsonDevice::Status::Placeholder:       return QStringLiteral("placeholder");
+        case JsonDevice::Status::Verified: return QStringLiteral("verified");
+        case JsonDevice::Status::Beta:     return QStringLiteral("beta");
         }
-        return QStringLiteral("unknown");
+        return QStringLiteral("beta");
     }
     case IsSelectedRole:
         return index.row() == m_selectedIndex;
@@ -776,14 +774,12 @@ QString DeviceModel::deviceStatus() const
         return QStringLiteral("unknown");
     auto* json = dynamic_cast<const JsonDevice*>(s->descriptor());
     if (!json)
-        return QStringLiteral("implemented");
+        return QStringLiteral("beta");
     switch (json->status()) {
-    case JsonDevice::Status::Implemented:       return QStringLiteral("implemented");
-    case JsonDevice::Status::CommunityVerified: return QStringLiteral("community-verified");
-    case JsonDevice::Status::CommunityLocal:    return QStringLiteral("community-local");
-    case JsonDevice::Status::Placeholder:       return QStringLiteral("placeholder");
+    case JsonDevice::Status::Verified: return QStringLiteral("verified");
+    case JsonDevice::Status::Beta:     return QStringLiteral("beta");
     }
-    return QStringLiteral("unknown");
+    return QStringLiteral("beta");
 }
 
 } // namespace logitune

--- a/src/app/qml/components/DeviceCard.qml
+++ b/src/app/qml/components/DeviceCard.qml
@@ -27,7 +27,7 @@ Item {
         fillMode: Image.PreserveAspectFit
         smooth: true; mipmap: true
 
-        opacity: root.status === "placeholder" ? 0.4 : 1.0
+        opacity: root.status === "beta" ? 0.8 : 1.0
     }
 
     Rectangle {
@@ -38,23 +38,19 @@ Item {
 
         color: {
             switch (root.status) {
-            case "implemented": return "#22c55e";
-            case "community-verified": return "#3b82f6";
-            case "community-local": return "#f59e0b";
-            default: return "#666";
+            case "verified": return "#22c55e";
+            default:         return "#f59e0b";
             }
         }
 
         Text {
             anchors.centerIn: parent
             font.pixelSize: 12; font.bold: true
-            color: root.status === "community-local" ? "#222" : "#fff"
+            color: "#fff"
             text: {
                 switch (root.status) {
-                case "implemented": return "\u2713";
-                case "community-verified": return "\u2605";
-                case "community-local": return "\u270E";
-                default: return "?";
+                case "verified": return "\u2713";
+                default:         return "\u03B2";
                 }
             }
         }
@@ -64,13 +60,13 @@ Item {
         anchors { top: deviceImg.bottom; topMargin: 8; horizontalCenter: parent.horizontalCenter }
         text: root.deviceName
         font { pixelSize: root.isSelected ? 13 : 11; bold: root.isSelected }
-        color: root.status === "placeholder" ? "#666" : (root.isSelected ? Theme.text : "#888")
+        color: root.isSelected ? Theme.text : "#888"
     }
 
     Row {
         anchors { top: deviceImg.bottom; topMargin: 26; horizontalCenter: parent.horizontalCenter }
         spacing: 6
-        visible: root.isSelected && root.status !== "placeholder"
+        visible: root.isSelected
 
         Text {
             text: root.batteryLevel + "%"
@@ -82,14 +78,6 @@ Item {
             font.pixelSize: 10
             color: Theme.textSecondary
         }
-    }
-
-    Text {
-        anchors { top: deviceImg.bottom; topMargin: 26; horizontalCenter: parent.horizontalCenter }
-        visible: root.status === "placeholder"
-        text: "Setup needed"
-        font.pixelSize: 9
-        color: "#666"
     }
 
     MouseArea {

--- a/src/core/devices/JsonDevice.cpp
+++ b/src/core/devices/JsonDevice.cpp
@@ -21,13 +21,9 @@ bool JsonDevice::matchesPid(uint16_t pid) const
 
 static JsonDevice::Status parseStatus(const QString& s)
 {
-    if (s == QStringLiteral("implemented"))
-        return JsonDevice::Status::Implemented;
-    if (s == QStringLiteral("community-verified"))
-        return JsonDevice::Status::CommunityVerified;
-    if (s == QStringLiteral("community-local"))
-        return JsonDevice::Status::CommunityLocal;
-    return JsonDevice::Status::Placeholder;
+    if (s == QStringLiteral("verified") || s == QStringLiteral("implemented"))
+        return JsonDevice::Status::Verified;
+    return JsonDevice::Status::Beta;
 }
 
 static ButtonAction::Type parseButtonActionType(const QString& s)
@@ -219,8 +215,7 @@ bool JsonDevice::parseFromObject(const QJsonObject& root, const QString& dirPath
     m_defaultGestures = parseDefaultGestures(
         root.value(QStringLiteral("defaultGestures")).toObject());
 
-    const bool strictGate = strict && (m_status == Status::Implemented
-                                       || m_status == Status::CommunityVerified);
+    const bool strictGate = strict && (m_status == Status::Verified);
 
     if (strict && m_name.isEmpty()) {
         qCWarning(lcDevice) << "JsonDevice: missing name in" << filePath;
@@ -234,11 +229,11 @@ bool JsonDevice::parseFromObject(const QJsonObject& root, const QString& dirPath
 
     if (strictGate) {
         if (m_controls.isEmpty()) {
-            qCWarning(lcDevice) << "JsonDevice: implemented device has no controls in" << filePath;
+            qCWarning(lcDevice) << "JsonDevice: verified device has no controls in" << filePath;
             return false;
         }
         if (m_buttonHotspots.isEmpty()) {
-            qCWarning(lcDevice) << "JsonDevice: implemented device has no button hotspots in" << filePath;
+            qCWarning(lcDevice) << "JsonDevice: verified device has no button hotspots in" << filePath;
             return false;
         }
         if (!QFileInfo::exists(m_frontImage)) {
@@ -278,7 +273,7 @@ bool JsonDevice::refresh()
     m_backImage.clear();
     m_features = FeatureSupport{};
     m_name.clear();
-    m_status = Status::Placeholder;
+    m_status = Status::Beta;
     m_minDpi = 200;
     m_maxDpi = 8000;
     m_dpiStep = 50;
@@ -302,7 +297,7 @@ bool JsonDevice::refreshFromObject(const QJsonObject &root)
     m_backImage.clear();
     m_features = FeatureSupport{};
     m_name.clear();
-    m_status = Status::Placeholder;
+    m_status = Status::Beta;
     m_minDpi = 200;
     m_maxDpi = 8000;
     m_dpiStep = 50;

--- a/src/core/devices/JsonDevice.h
+++ b/src/core/devices/JsonDevice.h
@@ -8,7 +8,7 @@ namespace logitune {
 
 class JsonDevice : public IDevice {
 public:
-    enum class Status { Implemented, CommunityVerified, CommunityLocal, Placeholder };
+    enum class Status { Verified, Beta };
 
     static std::unique_ptr<JsonDevice> load(const QString& dirPath);
 
@@ -40,7 +40,7 @@ private:
     bool parseFromDir(const QString& dirPath);
     bool parseFromObject(const QJsonObject& root, const QString& dirPath, bool strict = true);
 
-    Status m_status = Status::Placeholder;
+    Status m_status = Status::Beta;
     QString m_name;
     std::vector<uint16_t> m_pids;
     FeatureSupport m_features;

--- a/tests/test_device_registry.cpp
+++ b/tests/test_device_registry.cpp
@@ -162,7 +162,7 @@ TEST(DeviceRegistry, ReloadByPathRefreshesSingleDevice) {
         QFile f(descPath);
         if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
             return false;
-        f.write(QStringLiteral(R"({"name":"%1","status":"community-local","productIds":["0xffff"],"features":{},"controls":[],"hotspots":{"buttons":[],"scroll":[]},"images":{},"easySwitchSlots":[]})").arg(name).toUtf8());
+        f.write(QStringLiteral(R"({"name":"%1","status":"beta","productIds":["0xffff"],"features":{},"controls":[],"hotspots":{"buttons":[],"scroll":[]},"images":{},"easySwitchSlots":[]})").arg(name).toUtf8());
         f.close();
         return true;
     };

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -17,7 +17,7 @@ QString writeMinimalDescriptor(const QString &dir) {
     f.open(QIODevice::WriteOnly | QIODevice::Truncate);
     f.write(R"({
   "name": "Tester",
-  "status": "community-local",
+  "status": "beta",
   "productIds": ["0xffff"],
   "features": {},
   "controls": [],
@@ -82,7 +82,7 @@ TEST(EditorModel, UpdateHotspotMutatesPendingAndPushesUndo) {
     QFile f(tmp.path() + QStringLiteral("/dev/descriptor.json"));
     ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
     f.write(R"({
-  "name": "Tester", "status": "community-local", "productIds": ["0xffff"],
+  "name": "Tester", "status": "beta", "productIds": ["0xffff"],
   "features": {}, "controls": [],
   "hotspots": {
     "buttons": [
@@ -111,7 +111,7 @@ TEST(EditorModel, UpdateScrollHotspotMutatesScrollArray) {
     QFile f(tmp.path() + QStringLiteral("/dev/descriptor.json"));
     ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
     f.write(R"({
-  "name": "Tester", "status": "community-local", "productIds": ["0xffff"],
+  "name": "Tester", "status": "beta", "productIds": ["0xffff"],
   "features": {}, "controls": [],
   "hotspots": {
     "buttons": [],
@@ -165,7 +165,7 @@ TEST(EditorModel, UpdateTextEditsAllThreeKindsAndUndoes) {
     QFile f(tmp.path() + QStringLiteral("/dev/descriptor.json"));
     ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
     f.write(R"({
-  "name": "Original Name", "status": "community-local", "productIds": ["0xffff"],
+  "name": "Original Name", "status": "beta", "productIds": ["0xffff"],
   "features": {},
   "controls": [
     {"controlId": "0x0050", "buttonIndex": 0, "defaultName": "Left", "defaultActionType": "default", "configurable": false}

--- a/tests/test_json_device.cpp
+++ b/tests/test_json_device.cpp
@@ -38,11 +38,11 @@ static QJsonObject makeHotspot(int idx, double x, double y,
     };
 }
 
-static QJsonObject makeMinimalImplemented()
+static QJsonObject makeMinimalVerified()
 {
     QJsonObject root;
     root[QStringLiteral("name")] = QStringLiteral("Test Device");
-    root[QStringLiteral("status")] = QStringLiteral("implemented");
+    root[QStringLiteral("status")] = QStringLiteral("verified");
     root[QStringLiteral("productIds")] = QJsonArray{QStringLiteral("0xAAAA")};
     root[QStringLiteral("features")] = QJsonObject{
         {QStringLiteral("battery"), true},
@@ -87,11 +87,11 @@ static QJsonObject makeMinimalImplemented()
     return root;
 }
 
-static QJsonObject makeMinimalPlaceholder()
+static QJsonObject makeMinimalBeta()
 {
     QJsonObject root;
-    root[QStringLiteral("name")] = QStringLiteral("Placeholder Mouse");
-    root[QStringLiteral("status")] = QStringLiteral("placeholder");
+    root[QStringLiteral("name")] = QStringLiteral("Beta Mouse");
+    root[QStringLiteral("status")] = QStringLiteral("beta");
     root[QStringLiteral("productIds")] = QJsonArray{QStringLiteral("0xBBBB")};
     root[QStringLiteral("features")] = QJsonObject{};
     root[QStringLiteral("controls")] = QJsonArray{};
@@ -121,20 +121,20 @@ static void writeDummyImage(const QString& dirPath, const QString& name)
 // Tests
 // ---------------------------------------------------------------------------
 
-TEST(JsonDevice, LoadValidImplemented)
+TEST(JsonDevice, LoadValidVerified)
 {
     QTemporaryDir tmp;
     ASSERT_TRUE(tmp.isValid());
     const QString dir = tmp.path();
 
-    writeJson(dir, makeMinimalImplemented());
+    writeJson(dir, makeMinimalVerified());
     writeDummyImage(dir, QStringLiteral("front.png"));
 
     auto dev = JsonDevice::load(dir);
     ASSERT_NE(dev, nullptr);
 
     EXPECT_EQ(dev->deviceName(), QStringLiteral("Test Device"));
-    EXPECT_EQ(dev->status(), JsonDevice::Status::Implemented);
+    EXPECT_EQ(dev->status(), JsonDevice::Status::Verified);
 
     // Product IDs
     auto pids = dev->productIds();
@@ -186,7 +186,7 @@ TEST(JsonDevice, HotspotKindRoundTrip)
     ASSERT_TRUE(tmp.isValid());
     const QString dir = tmp.path();
 
-    QJsonObject root = makeMinimalImplemented();
+    QJsonObject root = makeMinimalVerified();
     QJsonObject hotspots = root.value("hotspots").toObject();
     QJsonArray scroll;
 
@@ -219,18 +219,18 @@ TEST(JsonDevice, HotspotKindRoundTrip)
     EXPECT_EQ(dev->scrollHotspots()[1].kind, QStringLiteral("thumbwheel"));
 }
 
-TEST(JsonDevice, LoadValidPlaceholder)
+TEST(JsonDevice, LoadValidBeta)
 {
     QTemporaryDir tmp;
     ASSERT_TRUE(tmp.isValid());
     const QString dir = tmp.path();
 
-    writeJson(dir, makeMinimalPlaceholder());
+    writeJson(dir, makeMinimalBeta());
 
     auto dev = JsonDevice::load(dir);
     ASSERT_NE(dev, nullptr);
-    EXPECT_EQ(dev->deviceName(), QStringLiteral("Placeholder Mouse"));
-    EXPECT_EQ(dev->status(), JsonDevice::Status::Placeholder);
+    EXPECT_EQ(dev->deviceName(), QStringLiteral("Beta Mouse"));
+    EXPECT_EQ(dev->status(), JsonDevice::Status::Beta);
     EXPECT_TRUE(dev->controls().isEmpty());
     EXPECT_TRUE(dev->buttonHotspots().isEmpty());
 }
@@ -254,13 +254,13 @@ TEST(JsonDevice, InvalidJsonReturnsNull)
     EXPECT_EQ(dev, nullptr);
 }
 
-TEST(JsonDevice, ImplementedMissingControlsReturnsNull)
+TEST(JsonDevice, VerifiedMissingControlsReturnsNull)
 {
     QTemporaryDir tmp;
     ASSERT_TRUE(tmp.isValid());
     const QString dir = tmp.path();
 
-    auto obj = makeMinimalImplemented();
+    auto obj = makeMinimalVerified();
     obj[QStringLiteral("controls")] = QJsonArray{}; // empty controls
     writeJson(dir, obj);
     writeDummyImage(dir, QStringLiteral("front.png"));
@@ -269,14 +269,14 @@ TEST(JsonDevice, ImplementedMissingControlsReturnsNull)
     EXPECT_EQ(dev, nullptr);
 }
 
-TEST(JsonDevice, PlaceholderMissingControlsLoads)
+TEST(JsonDevice, BetaMissingControlsLoads)
 {
     QTemporaryDir tmp;
     ASSERT_TRUE(tmp.isValid());
     const QString dir = tmp.path();
 
-    auto obj = makeMinimalPlaceholder();
-    // controls already empty in placeholder
+    auto obj = makeMinimalBeta();
+    // controls already empty in beta
     writeJson(dir, obj);
 
     auto dev = JsonDevice::load(dir);
@@ -290,7 +290,7 @@ TEST(JsonDevice, CidParsing)
     ASSERT_TRUE(tmp.isValid());
     const QString dir = tmp.path();
 
-    auto obj = makeMinimalImplemented();
+    auto obj = makeMinimalVerified();
     // Replace controls with one that has the CID we want to verify
     obj[QStringLiteral("controls")] = QJsonArray{
         makeControl(QStringLiteral("0x00C3"), 0, QStringLiteral("Gesture"), QStringLiteral("gesture-trigger"), true),
@@ -310,7 +310,7 @@ TEST(JsonDevice, UnknownKeysIgnored)
     ASSERT_TRUE(tmp.isValid());
     const QString dir = tmp.path();
 
-    auto obj = makeMinimalImplemented();
+    auto obj = makeMinimalVerified();
     obj[QStringLiteral("unknownTopLevel")] = QStringLiteral("should be ignored");
     auto feat = obj[QStringLiteral("features")].toObject();
     feat[QStringLiteral("futureFeature")] = true;
@@ -329,7 +329,7 @@ TEST(JsonDevice, ImagePathResolution)
     ASSERT_TRUE(tmp.isValid());
     const QString dir = tmp.path();
 
-    writeJson(dir, makeMinimalImplemented());
+    writeJson(dir, makeMinimalVerified());
     writeDummyImage(dir, QStringLiteral("front.png"));
 
     auto dev = JsonDevice::load(dir);
@@ -350,7 +350,7 @@ TEST(JsonDevice, DefaultGesturesParsing)
     ASSERT_TRUE(tmp.isValid());
     const QString dir = tmp.path();
 
-    auto obj = makeMinimalPlaceholder();
+    auto obj = makeMinimalBeta();
     obj[QStringLiteral("defaultGestures")] = QJsonObject{
         {QStringLiteral("up"), QJsonObject{
             {QStringLiteral("type"), QStringLiteral("Default")},
@@ -385,7 +385,7 @@ TEST(JsonDevice, FeatureFlagDefaults)
     const QString dir = tmp.path();
 
     // Placeholder with empty features object
-    auto obj = makeMinimalPlaceholder();
+    auto obj = makeMinimalBeta();
     obj[QStringLiteral("features")] = QJsonObject{};
     writeJson(dir, obj);
 
@@ -411,7 +411,7 @@ TEST(JsonDevice, TracksSourcePathAndLoadMtime) {
     ASSERT_TRUE(f.open(QIODevice::WriteOnly));
     f.write(R"({
   "name": "Tester",
-  "status": "community-local",
+  "status": "beta",
   "productIds": ["0xffff"],
   "features": {},
   "controls": [],
@@ -438,7 +438,7 @@ TEST(JsonDevice, ParsesOptionalEditorFields) {
     ASSERT_TRUE(f.open(QIODevice::WriteOnly));
     f.write(R"({
   "name": "Tester",
-  "status": "community-local",
+  "status": "beta",
   "productIds": ["0xffff"],
   "features": {},
   "controls": [
@@ -480,7 +480,7 @@ TEST(JsonDevice, OptionalEditorFieldsDefaultEmptyWhenAbsent) {
     ASSERT_TRUE(f.open(QIODevice::WriteOnly));
     f.write(R"({
   "name": "Tester",
-  "status": "community-local",
+  "status": "beta",
   "productIds": ["0xffff"],
   "features": {},
   "controls": [
@@ -510,7 +510,7 @@ TEST(JsonDevice, RefreshRereadsDescriptorInPlace) {
         ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
         f.write(QStringLiteral(R"({
   "name": "%1",
-  "status": "community-local",
+  "status": "beta",
   "productIds": ["0xffff"],
   "features": {},
   "controls": [],
@@ -530,4 +530,16 @@ TEST(JsonDevice, RefreshRereadsDescriptorInPlace) {
     ASSERT_TRUE(dev->refresh());
     EXPECT_EQ(dev->deviceName(), QStringLiteral("Mutated Name"));
     EXPECT_EQ(dev.get(), raw);
+}
+
+TEST(JsonDevice, OldStatusStringsStillParse) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    auto root = makeMinimalVerified();
+    root[QStringLiteral("status")] = QStringLiteral("implemented");
+    writeJson(tmp.path(), root);
+    writeDummyImage(tmp.path(), QStringLiteral("front.png"));
+    auto dev = logitune::JsonDevice::load(tmp.path());
+    ASSERT_NE(dev, nullptr);
+    EXPECT_EQ(dev->status(), logitune::JsonDevice::Status::Verified);
 }


### PR DESCRIPTION
## Summary

Collapses four device status levels into two:

| Old | New | Badge | Validation |
|-----|-----|-------|------------|
| `implemented` | `verified` | ✓ green | Strict (must have controls, hotspots, front image) |
| `community-verified` | `verified` | ✓ green | Strict |
| `community-local` | `beta` | β amber | Relaxed |
| `placeholder` | `beta` | β amber | Relaxed |

**Verified** = tested on real hardware, fully working.
**Beta** = descriptor exists, untested or partially tested.

Old status strings (`"implemented"`, `"community-verified"`, `"community-local"`, `"placeholder"`) are still accepted for backwards compatibility with existing descriptors.

## Changes

- `JsonDevice::Status` enum: `Verified`, `Beta` (was 4 values)
- `parseStatus()` maps old + new strings
- `DeviceModel` emits `"verified"` / `"beta"` to QML
- `DeviceCard.qml` simplified to 2 badges
- Shipped descriptors updated to `"verified"`
- All tests renamed and updated + backwards-compat test added

## Test plan

- [x] 494 C++ tests pass (includes new `OldStatusStringsStillParse` test)
- [x] 72 QML tests pass
- [x] Community-devices repo descriptors should be updated to `"beta"` in a follow-up PR