### PR TITLE
Startup hardening: remove stale crash dialog, block Kvantum override

### DIFF
--- a/src/core/logging/CrashHandler.cpp
+++ b/src/core/logging/CrashHandler.cpp
@@ -48,7 +48,16 @@ void CrashHandler::removeLockFile()
 
 bool CrashHandler::previousSessionCrashed() const
 {
-    return QFile::exists(lockFilePath());
+    if (!QFile::exists(lockFilePath()))
+        return false;
+
+    // Catchable crashes (SIGSEGV, SIGABRT, exceptions) already show
+    // the crash dialog at the moment they happen via the signal handler.
+    // Uncatchable exits (SIGKILL, OOM, power loss, reboot) leave the
+    // lock behind but the user already knows — no value in showing a
+    // dialog on next launch. Silently clean up.
+    QFile::remove(lockFilePath());
+    return false;
 }
 
 CrashInfo CrashHandler::previousSessionCrashInfo() const


### PR DESCRIPTION
Closes #11.

## Two startup fixes

### 1. Remove on-launch crash dialog

Catchable crashes (SIGSEGV, SIGABRT, exceptions) already show the crash dialog at the moment they happen via the signal handler + try/catch. Uncatchable exits (SIGKILL, OOM, reboot, power loss) leave a stale lock file, but the user already knows what happened. The on-launch dialog added no value — now the stale lock is silently cleaned up.

### 2. Block Kvantum/external theme override

Unsets `QT_STYLE_OVERRIDE` at startup so Kvantum and other external Qt theme engines don't override our `Theme.qml` styling. Fixes the broken UI reported on Hyprland and other non-KDE Wayland compositors.

## Test plan

- [x] All 493 tests pass
- [ ] Kill app via `pkill -9`, relaunch — no crash dialog (signal handler showed it at crash time)
- [ ] Clean quit, relaunch — no dialog
- [ ] Reboot, launch — no dialog
- [ ] With `QT_STYLE_OVERRIDE=kvantum` set in env, app still renders with its own theme