### PR TITLE
Startup hardening: remove stale crash dialog, block Kvantum override

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -42,6 +42,9 @@ int main(int argc, char *argv[])
     if (qEnvironmentVariableIsEmpty("GSETTINGS_BACKEND"))
         qputenv("GSETTINGS_BACKEND", "memory");
 
+    // Prevent Kvantum/external Qt theme engines from overriding our Theme.qml.
+    qunsetenv("QT_STYLE_OVERRIDE");
+
     // Qt 6.4 QML JIT hangs on some CPU/kernel combinations during compilation.
     // Force the interpreter — startup is ~100ms either way for our QML set.
 #if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)

--- a/src/core/logging/CrashHandler.cpp
+++ b/src/core/logging/CrashHandler.cpp
@@ -48,7 +48,16 @@ void CrashHandler::removeLockFile()
 
 bool CrashHandler::previousSessionCrashed() const
 {
-    return QFile::exists(lockFilePath());
+    if (!QFile::exists(lockFilePath()))
+        return false;
+
+    // Catchable crashes (SIGSEGV, SIGABRT, exceptions) already show
+    // the crash dialog at the moment they happen via the signal handler.
+    // Uncatchable exits (SIGKILL, OOM, power loss, reboot) leave the
+    // lock behind but the user already knows — no value in showing a
+    // dialog on next launch. Silently clean up.
+    QFile::remove(lockFilePath());
+    return false;
 }
 
 CrashInfo CrashHandler::previousSessionCrashInfo() const


### PR DESCRIPTION
Closes #11.

## Two startup fixes

### 1. Remove on-launch crash dialog

Catchable crashes (SIGSEGV, SIGABRT, exceptions) already show the crash dialog at the moment they happen via the signal handler + try/catch. Uncatchable exits (SIGKILL, OOM, reboot, power loss) leave a stale lock file, but the user already knows what happened. The on-launch dialog added no value — now the stale lock is silently cleaned up.

### 2. Block Kvantum/external theme override

Unsets `QT_STYLE_OVERRIDE` at startup so Kvantum and other external Qt theme engines don't override our `Theme.qml` styling. Fixes the broken UI reported on Hyprland and other non-KDE Wayland compositors.

## Test plan

- [x] All 493 tests pass
- [x] Kill app via `pkill -9`, relaunch — no crash dialog (verified locally)
- [x] Clean quit, relaunch — no dialog
- [x] Reboot, launch — no dialog
- [x] With `QT_STYLE_OVERRIDE=kvantum` set in env, app still renders with its own theme