### PR TITLE
fix(qml): restore cardItem initial x/y bindings

### DIFF
--- a/src/app/qml/components/HotspotControl.qml
+++ b/src/app/qml/components/HotspotControl.qml
@@ -171,6 +171,12 @@ Item {
         width: cardRect.implicitWidth
         height: cardRect.implicitHeight
 
+        // Initial position. Drags break this binding; Connections below and
+        // the Qt.callLater in cardDrag.onActiveChanged restore position
+        // imperatively afterwards.
+        x: root.cardTargetX
+        y: root.cardTargetY
+
         Connections {
             target: root
             function onCardTargetXChanged() {


### PR DESCRIPTION
Closes #47.

## Problem

In `--edit` mode, button cards stacked at the page origin on first mount instead of rendering beside their hotspot markers. Most visible on MX Master 4.

## Root cause

Commit c20efea replaced the initial `x: root.cardTargetX` / `y: root.cardTargetY` bindings on `cardItem` with `Connections` handlers while fixing a drag-release race. The handlers fire only on `cardTargetXChanged` / `cardTargetYChanged`. On first mount there is no change event, so `cardItem.x` / `cardItem.y` default to (0,0) and stay there until a marker happens to move.

## Fix

Restore the initial bindings alongside the existing `Connections`. The combination works:

- Initial binding sets the starting position on mount.
- Drag imperatively sets `cardItem.x` / `cardItem.y`, which breaks the binding (same behavior as before).
- `Qt.callLater` in `cardDrag.onActiveChanged` reassigns imperatively after drag release.
- `Connections` continues to catch any later `cardTargetX` changes.

## Test plan

- [x] Launch `logitune --edit --simulate-all`, verify cards on MX Master 4 Buttons page render beside their markers
- [x] Verify MX Master 2S and 3S Buttons pages still look right
- [x] Drag a card, confirm it moves freely, releases to column snap
- [x] Drag a marker, confirm card follows