### PR TITLE
fix(qml): wheel scroll navigates carousel

### DIFF
--- a/src/app/qml/HomeView.qml
+++ b/src/app/qml/HomeView.qml
@@ -105,6 +105,18 @@ Item {
                         carousel.currentIndex = index
                 }
             }
+
+            WheelHandler {
+                acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+                onWheel: function(event) {
+                    if (DeviceModel.count <= 1)
+                        return
+                    if (event.angleDelta.y > 0 || event.angleDelta.x > 0)
+                        carousel.decrementCurrentIndex()
+                    else if (event.angleDelta.y < 0 || event.angleDelta.x < 0)
+                        carousel.incrementCurrentIndex()
+                }
+            }
         }
 
         // Counter text

--- a/src/app/qml/HomeView.qml
+++ b/src/app/qml/HomeView.qml
@@ -106,15 +106,28 @@ Item {
                 }
             }
 
+            // Debounce wheel events: step once per event, ignore further
+            // events until the card-swap animation settles. Without this a
+            // fast spin dispatches many events in rapid succession and the
+            // carousel jitters or wraps through the list.
+            property double wheelLastTick: 0
+
             WheelHandler {
                 acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
                 onWheel: function(event) {
                     if (DeviceModel.count <= 1)
                         return
-                    if (event.angleDelta.y > 0 || event.angleDelta.x > 0)
+                    var now = Date.now()
+                    if (now - carousel.wheelLastTick < carousel.highlightMoveDuration)
+                        return
+                    var delta = event.angleDelta.y + event.angleDelta.x
+                    if (Math.abs(delta) < 20)
+                        return
+                    if (delta > 0)
                         carousel.decrementCurrentIndex()
-                    else if (event.angleDelta.y < 0 || event.angleDelta.x < 0)
+                    else
                         carousel.incrementCurrentIndex()
+                    carousel.wheelLastTick = now
                 }
             }
         }


### PR DESCRIPTION
Closes #49.

## Problem

On the Home view, scrolling the mouse wheel over the device carousel did nothing. Changing device required clicking the adjacent card.

## Fix

Add a `WheelHandler` as a child of the carousel `PathView`. On wheel event, decrement or increment `currentIndex` based on `angleDelta.y`. Also honor `angleDelta.x` so horizontal tilt or touchpad horizontal scroll navigates. Accepts both mouse and touchpad devices. No-op when there is a single device.

## Test plan

- [x] Scroll wheel up / down over the carousel to navigate between simulated devices
- [x] Confirm click-to-select still works
- [x] Confirm touch flick still works
- [x] Single device case: wheel does nothing (no index change)