### PR TITLE
ci(release): mark pre-release tags as GitHub pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,3 +69,7 @@ jobs:
           files: |
             logitune-*.deb
           generate_release_notes: true
+          # Tags with a pre-release identifier (e.g. v0.2.0-beta.1, v0.2.0-rc.1)
+          # are published as GitHub pre-releases so they do not appear as the
+          # latest stable download.
+          prerelease: ${{ contains(github.ref_name, '-') }}


### PR DESCRIPTION
## Summary

Tags matching a semver pre-release identifier (`v0.2.0-beta.1`,
`v0.2.0-rc.1`, etc.) are now explicitly published with the GitHub
`prerelease` flag set, so they do not surface as the latest stable
release.

Currently `softprops/action-gh-release@v2` auto-detects pre-release
tags from the dash in the tag name, but making it explicit keeps the
behavior stable across future action version bumps.

## Motivation

Coming out of #54 (MX Anywhere family, beta status), I want to be able
to cut beta tags so a hardware tester can install a pre-built .deb
without building from source. Without this flag, a beta tag could get
published as the latest release and be served to every stable user.

## Test plan

No runtime behavior change in the app. Verification is workflow-level:
- Next `v*-*` tag (e.g. `v0.2.0-beta.1`) should produce a release marked
  "Pre-release" in the GitHub Releases UI.
- A stable `v*` tag (no dash) should continue to produce a release marked
  as "Latest".
