### PR TITLE
ci(release): derive version from tag, publish rpm + pacman alongside deb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release
 on:
   push:
     tags: ['v*']
+  # Manual trigger lets us dry-run the packaging jobs without publishing.
+  # The `release` job is skipped unless a tag was pushed, so nothing is
+  # uploaded; artifacts are still attached to the run for inspection.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -16,21 +20,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Route apt's .deb cache into a user-owned directory so actions/cache
-      # can both read it on save and extract into it on restore. Caching
-      # /var/cache/apt/archives on a native runner fails on restore because
-      # the directory is root-owned and tar runs as the runner user.
       - name: Cache apt archives
         uses: actions/cache@v4
         with:
-          path: ~/.cache/apt-archives
-          key: release-deb-apt-v2
+          path: /var/cache/apt/archives
+          key: release-deb-apt-v1
 
       - name: Install dependencies
         run: |
-          mkdir -p ~/.cache/apt-archives/partial
+          echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' | \
+            sudo tee /etc/apt/apt.conf.d/01keep-debs >/dev/null
           sudo apt-get update
-          sudo apt-get -o Dir::Cache::archives="$HOME/.cache/apt-archives" install -y \
+          sudo apt-get install -y \
             build-essential cmake ninja-build pkg-config dpkg-dev \
             qt6-base-dev qt6-declarative-dev qt6-svg-dev \
             qt6-tools-dev qt6-tools-dev-tools \
@@ -40,7 +41,7 @@ jobs:
             qml6-module-qtquick-dialogs qml6-module-qt5compat-graphicaleffects \
             qt6-qpa-plugins libqt6opengl6-dev libqt6svg6-dev \
             libxkbcommon-dev libudev-dev
-          sudo chown -R "$(id -u):$(id -g)" ~/.cache/apt-archives
+          sudo chmod -R a+rX /var/cache/apt/archives
 
       - name: Build .deb
         run: bash scripts/package-deb.sh
@@ -52,11 +53,78 @@ jobs:
           path: logitune-*.deb
 
   # --------------------------------------------------------------------------
+  # Fedora / RHEL package (.rpm)
+  # --------------------------------------------------------------------------
+  package-rpm:
+    runs-on: ubuntu-24.04
+    container:
+      image: fedora:41
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          dnf install -y \
+            gcc gcc-c++ cmake ninja-build pkgconf-pkg-config rpm-build \
+            qt6-qtbase-devel qt6-qtdeclarative-devel qt6-qtsvg-devel \
+            qt6-qttools-devel qt6-qt5compat-devel \
+            libxkbcommon-devel systemd-devel grep
+
+      - name: Build .rpm
+        run: bash scripts/package-rpm.sh
+
+      - name: Collect .rpm
+        run: cp "$HOME"/rpmbuild/RPMS/x86_64/logitune-*.rpm .
+
+      - name: Upload .rpm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpm-package
+          path: logitune-*.rpm
+
+  # --------------------------------------------------------------------------
+  # Arch Linux package (.pkg.tar.zst)
+  # --------------------------------------------------------------------------
+  package-arch:
+    runs-on: ubuntu-24.04
+    container:
+      image: archlinux:latest
+      options: --user root
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm --needed \
+            base-devel cmake ninja \
+            qt6-base qt6-declarative qt6-svg qt6-tools qt6-5compat \
+            libxkbcommon systemd-libs sudo
+
+      - name: Create unprivileged build user (makepkg refuses root)
+        run: |
+          useradd -m builder
+          echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder
+          chown -R builder:builder "$GITHUB_WORKSPACE"
+
+      - name: Build pacman package
+        run: sudo -E -u builder bash scripts/package-arch.sh
+
+      - name: Upload pacman artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pacman-package
+          path: logitune-*.pkg.tar.zst
+
+  # --------------------------------------------------------------------------
   # Create GitHub Release with all packages
   # --------------------------------------------------------------------------
   release:
-    needs: [package-deb]
+    needs: [package-deb, package-rpm, package-arch]
     runs-on: ubuntu-latest
+    # Only publish when triggered by a tag push. workflow_dispatch runs are
+    # for dry-running the package jobs and stop before the release step.
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -68,6 +136,8 @@ jobs:
         with:
           files: |
             logitune-*.deb
+            logitune-*.rpm
+            logitune-*.pkg.tar.zst
           generate_release_notes: true
           # Tags with a pre-release identifier (e.g. v0.2.0-beta.1, v0.2.0-rc.1)
           # are published as GitHub pre-releases so they do not appear as the

--- a/scripts/package-arch.sh
+++ b/scripts/package-arch.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 set -e
 
-VERSION=$(grep -oP 'project\(logitune VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
+# Derive version from the tag when the workflow is triggered by a tag push,
+# otherwise fall back to the version in CMakeLists.txt. pkgver forbids
+# hyphens and tildes, so pre-release identifiers use dots: v0.3.0-beta.1
+# becomes 0.3.0.beta.1.
+if [ -n "$GITHUB_REF_NAME" ] && [[ "$GITHUB_REF_NAME" =~ ^v[0-9] ]]; then
+    TAG="${GITHUB_REF_NAME#v}"
+else
+    TAG=$(grep -oP 'project\(logitune VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
+fi
+VERSION="${TAG//-/.}"
 SRCDIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 echo "Building Arch package v$VERSION"

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 set -e
 
-VERSION=$(grep -oP 'project\(logitune VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
+# Derive version from the tag when the workflow is triggered by a tag push,
+# otherwise fall back to the version in CMakeLists.txt. Pre-release tags
+# like v0.3.0-beta.1 encode as 0.3.0~beta.1 so dpkg sorts them before 0.3.0.
+if [ -n "$GITHUB_REF_NAME" ] && [[ "$GITHUB_REF_NAME" =~ ^v[0-9] ]]; then
+    TAG="${GITHUB_REF_NAME#v}"
+else
+    TAG=$(grep -oP 'project\(logitune VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
+fi
+VERSION="${TAG//-/\~}"
 PKGDIR="/tmp/logitune-deb"
 ARCH=$(dpkg --print-architecture 2>/dev/null || echo "amd64")
 

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 set -e
 
-VERSION=$(grep -oP 'project\(logitune VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
+# Derive version from the tag when the workflow is triggered by a tag push,
+# otherwise fall back to the version in CMakeLists.txt. rpm 4.10+ treats
+# tilde as a pre-release separator that sorts before digits, so 0.3.0~beta.1
+# sorts before 0.3.0.
+if [ -n "$GITHUB_REF_NAME" ] && [[ "$GITHUB_REF_NAME" =~ ^v[0-9] ]]; then
+    TAG="${GITHUB_REF_NAME#v}"
+else
+    TAG=$(grep -oP 'project\(logitune VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
+fi
+VERSION="${TAG//-/\~}"
 
 echo "Building .rpm package v$VERSION"
 


### PR DESCRIPTION
## Summary

Fixes the v0.3.0-beta.1 release having shipped as `logitune-0.2.3_amd64.deb`
and extends the workflow to build RPM (Fedora) and pacman (Arch) packages.

## Why 0.2.3 ended up on a 0.3.0-beta.1 release

`scripts/package-deb.sh` read the version from `CMakeLists.txt`
(`project(logitune VERSION 0.2.3)`), not from the git tag. Tagging
`v0.3.0-beta.1` without bumping `CMakeLists.txt` shipped a .deb whose
metadata says 0.2.3, so `dpkg -l logitune` would under-report on a
tester's machine.

## What changed

**Package scripts (`deb`, `rpm`, `arch`):** all three now prefer
`GITHUB_REF_NAME` when present (stripping the leading `v`) and fall
back to `CMakeLists.txt` for local builds. `CMakeLists.txt` no longer
needs to be bumped for every beta cut.

**Pre-release encoding per packaging convention:**
- deb: tilde, `0.3.0~beta.1` (sorts before 0.3.0)
- rpm: tilde, `0.3.0~beta.1` (rpm 4.10+ supports it)
- pacman: dot, `0.3.0.beta.1` (pkgver forbids `-` and `~`)

**Release workflow:**
- New `package-rpm` job on a `fedora:41` container
- New `package-arch` job on `archlinux:latest` with an unprivileged
  `builder` user (makepkg refuses root)
- Release job now bundles all three artifact types
- Added `workflow_dispatch` trigger to dry-run packaging without
  publishing; release job is gated on `startsWith(github.ref, 'refs/tags/v')`

## Test plan

- [x] Local pacman build with `GITHUB_REF_NAME=v0.3.0-beta.1 bash scripts/package-arch.sh`
      produces `logitune-0.3.0.beta.1-1-x86_64.pkg.tar.zst`
- [x] `logitune-tests`: 518 passing
- [ ] workflow_dispatch dry-run on master after merge to validate
      rpm + pacman container jobs before retagging

## Follow-up

After this lands, I will delete the broken `v0.3.0-beta.1` release +
tag and recreate the tag on the new master HEAD so the tester gets the
correct artifacts. The release URL stays the same.
