### PR TITLE
fix(rpm): list device and extension dirs instead of enumerating files

### DIFF
--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -46,14 +46,11 @@ cp -a /tmp/logitune-rpm/* %{buildroot}/
 /usr/share/applications/logitune.desktop
 /usr/etc/xdg/autostart/logitune.desktop
 /usr/share/icons/hicolor/scalable/apps/com.logitune.Logitune.svg
-%dir /usr/share/gnome-shell
-%dir /usr/share/gnome-shell/extensions
-%dir /usr/share/gnome-shell/extensions/logitune-focus@logitune.com
-/usr/share/gnome-shell/extensions/logitune-focus@logitune.com/metadata.json
-%dir /usr/share/gnome-shell/extensions/logitune-focus@logitune.com/v42
-/usr/share/gnome-shell/extensions/logitune-focus@logitune.com/v42/extension.js
-%dir /usr/share/gnome-shell/extensions/logitune-focus@logitune.com/v45
-/usr/share/gnome-shell/extensions/logitune-focus@logitune.com/v45/extension.js
+# Device descriptors (JSON + images) and the GNOME shell extension live in
+# their own subtrees. List the directory so new devices and any additional
+# extension resources ship without having to touch this spec.
+/usr/share/logitune
+/usr/share/gnome-shell/extensions/logitune-focus@logitune.com
 
 %post
 udevadm control --reload-rules 2>/dev/null || true


### PR DESCRIPTION
## Summary

Dry-run of the Release workflow on master after #56 merged failed on the
RPM job with `Installed (but unpackaged) file(s) found` for every new
MX Anywhere device asset plus `extension.js` at the GNOME extension root.

The rpm spec's `%files` section enumerated each device's four assets
(descriptor, front, side, back) plus each GNOME extension file by hand,
so any new device trips it.

## Fix

Switch the spec to directory-scoped entries:

- `/usr/share/logitune` — picks up all device descriptors and images
- `/usr/share/gnome-shell/extensions/logitune-focus@logitune.com` — picks
  up the metadata plus the root `extension.js` and any version-gated
  resource

## Test plan

- [ ] workflow_dispatch dry-run on master after merge: package-rpm must
      succeed and produce a `.rpm` with `/usr/share/logitune/devices/...`
      present

## Notes

Not touching the `/usr/etc/xdg/autostart/logitune.desktop` path question
in this PR. That is an unrelated install-path quirk and did not trigger
today's failure.