### PR TITLE
fix(deb): depend on qml6-module-qtquick-dialogs

### DIFF
--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -32,7 +32,7 @@ Version: $VERSION
 Section: utils
 Priority: optional
 Architecture: $ARCH
-Depends: libqt6core6 (>= 6.4), libqt6quick6, libqt6svg6, libqt6dbus6, libqt6widgets6, libudev1, qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-window, qml6-module-qtquick-templates, qml6-module-qtquick-layouts, qml6-module-qtqml, qml6-module-qtqml-workerscript, qml6-module-qt5compat-graphicaleffects
+Depends: libqt6core6 (>= 6.4), libqt6quick6, libqt6svg6, libqt6dbus6, libqt6widgets6, libudev1, qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-dialogs, qml6-module-qtquick-window, qml6-module-qtquick-templates, qml6-module-qtquick-layouts, qml6-module-qtqml, qml6-module-qtqml-workerscript, qml6-module-qt5compat-graphicaleffects
 Maintainer: Mina Maher <mina.maher88@hotmail.com>
 Description: Logitech device configurator for Linux
  Configure Logitech HID++ peripherals (MX Master 3S and more).


### PR DESCRIPTION
## Summary

v0.3.0-beta.1 tester on Debian reported app failing to launch with
`module "QtQuick.Dialogs" is not installed` and no root QML object.

## Cause

DeviceRender.qml and EasySwitchPage.qml both `import QtQuick.Dialogs`.
On Debian/Ubuntu the Qt 6 module is packaged separately as
`qml6-module-qtquick-dialogs`; CI installs it at build time but the
runtime `Depends:` line in `scripts/package-deb.sh` did not declare it,
so `apt install -f` would not pull it in.

Fedora and Arch are unaffected; on those distros the module ships with
the umbrella `qt6-qtdeclarative` / `qt6-declarative` package.

## Fix

Add `qml6-module-qtquick-dialogs` to the deb Depends list.

## Test plan

- [ ] workflow_dispatch dry-run after merge: `.deb` control file lists
      the dep (verify via `dpkg-deb -f logitune-*.deb Depends`)
- [ ] Retag v0.3.0-beta.1 so the tester can retry without the manual
      `sudo apt install qml6-module-qtquick-dialogs` workaround