### PR TITLE
ci(wiki-sync): fix YAML parse error causing CI failure emails

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -62,7 +62,7 @@ jobs:
             echo "Wiki already in sync with docs/wiki; nothing to push."
             exit 0
           fi
-          git commit -m "sync: update wiki from ${GITHUB_SHA::7}
-
-Source: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+          git commit \
+            -m "sync: update wiki from ${GITHUB_SHA::7}" \
+            -m "Source: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
           git push


### PR DESCRIPTION
## Why you are seeing failure emails

Every push to master since PR #53 landed triggers a `Sync Wiki` run
that immediately aborts before any job starts:

> This run likely failed because of a workflow file issue.

Duration is `0s`, `latest_check_runs_count` is 0, and no logs are
produced.

## Root cause

The final step uses a single `-m` with an embedded blank line:

````
          git commit -m "sync: update wiki from ${GITHUB_SHA::7}

Source: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
````

GitHub's workflow parser rejects this even though `yaml.safe_load`
accepts it. The fix `a1f33f2` was written on the feature branch
**after** PR #53 had already merged, so it never reached master.

## Fix

Use two separate `-m` flags (title + description), which git
concatenates into the same commit message and which the workflow
parser accepts.

## Test plan

- [ ] After merge, next push to master triggers wiki-sync and the
      workflow actually runs (either produces a sync commit or exits
      with "Wiki already in sync").