### PR TITLE
fix(wiki): use absolute URLs for CI, license, and release badges

### DIFF
--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,8 +1,8 @@
 # Logitune
 
-[![CI](../../.github/workflows/ci.yml/badge.svg)](../../.github/workflows/ci.yml)
-[![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE)
-[![Release](https://img.shields.io/github/v/release/logitune/logitune)](https://github.com/logitune/logitune/releases)
+[![CI](https://github.com/mmaher88/logitune/actions/workflows/ci.yml/badge.svg)](https://github.com/mmaher88/logitune/actions/workflows/ci.yml)
+[![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](https://github.com/mmaher88/logitune/blob/master/LICENSE)
+[![Release](https://img.shields.io/github/v/release/mmaher88/logitune?include_prereleases)](https://github.com/mmaher88/logitune/releases)
 
 **Logitune** is a native Linux configurator for Logitech HID++ peripherals, starting with the MX Master 3S. It communicates directly with the device over hidraw using the HID++ 2.0 protocol — no Solaar, no logiops, no daemon. Just a Qt 6 / QML desktop application with a system tray icon.
 


### PR DESCRIPTION
## Summary

Home page of the wiki rendered with two broken badges (see
https://github.com/mmaher88/logitune/wiki):

- **CI**: `../../.github/workflows/ci.yml/badge.svg`. The wiki is its
  own git repo and cannot resolve relative paths into the main repo,
  so this 404s. The sync workflow only rewrites `../images/...` paths
  (for image assets under `docs/images/`), not workflow paths.
- **Release**: pointed at `logitune/logitune`, which is not the repo
  slug. Returned `no releases or repo not found`.

## Fix

Switch the three badges to absolute URLs targeting `mmaher88/logitune`.
The release badge now uses `?include_prereleases` so the current
`v0.3.0-beta.1` tag actually shows.

README.md is unaffected — those badges already use absolute URLs.