### PR TITLE
fix(device-model): propagate live hardware state to QML bindings

### DIFF
--- a/docs/superpowers/plans/2026-04-19-stale-property-notifys.md
+++ b/docs/superpowers/plans/2026-04-19-stale-property-notifys.md
@@ -1,0 +1,868 @@
+# Stale Property NOTIFY Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hardware-originated state changes (physical SmartShift press, DPI cycle press, scroll invert from another app) must propagate to the QML bindings on `DeviceModel`'s `currentDPI`, `smartShiftEnabled`, `smartShiftThreshold`, `scrollHiRes`, `scrollInvert`, `thumbWheelMode`, `thumbWheelInvert`. Today they read stale cached profile values.
+
+**Architecture:** Two layers. First, `PhysicalDevice` gains per-property relay signals that forward matching `DeviceSession` signals; `DeviceModel::addPhysicalDevice` connects to them and emits per-property NOTIFYs gated on the selected device. Second, the per-property handler in `DeviceModel` sets `m_hasDisplayValues = false` so the getters stop returning the cached `m_display*` values and fall through to the live session readers. `setDisplayValues` re-arms the cache on the next profile reload. Q_PROPERTY NOTIFYs flip from the coarse `settingsReloaded` to property-specific signals last.
+
+**Tech Stack:** Qt 6 / C++20 / GTest + QSignalSpy. No new files.
+
+**Design spec:** `docs/superpowers/specs/2026-04-19-stale-property-notifys-design.md`. Read it before Task 1.
+
+---
+
+## Global rules
+
+- **No em-dashes (U+2014 "—")** in any file you create or modify. Use colons, commas, periods, or parentheses. The only acceptable occurrence is inside a `grep -c "—"` verification command.
+- **No co-author signatures** in commit messages.
+- **Branch is `fix-stale-property-notifys`.** Already created with the spec committed. Do NOT push. The maintainer pushes after final verification.
+- **Working directory:** `/home/mina/repos/logitune`.
+- **Never amend commits.** Each task makes a new commit on top.
+- **Build + test after every task**: `cmake --build build -j"$(nproc)" 2>&1 | tail -3` (must exit 0); `XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -5` (must show `[  PASSED  ] <N> tests.` with no failures). Baseline count before this plan is 539.
+
+## Intentional simplification vs the spec
+
+The spec mentions a new `DeviceSession::thumbWheelInvertChanged` signal. In practice, `DeviceSession::setThumbWheelMode` writes both `m_thumbWheelMode` AND `m_thumbWheelInvert` atomically and emits the single `thumbWheelModeChanged`. This plan keeps that shape: `thumbWheelInvert`'s Q_PROPERTY NOTIFY uses `thumbWheelModeChanged` (mirroring how `scrollHiRes` and `scrollInvert` share `scrollConfigChanged`). Result: no new session signal or setter is needed for thumb-wheel invert.
+
+Only one brand-new session emit is needed: `currentDPIChanged`.
+
+---
+
+## File Structure
+
+### Modified
+
+- `src/core/DeviceSession.h`: add `currentDPIChanged()` signal declaration.
+- `src/core/DeviceSession.cpp`: emit `currentDPIChanged` from `setDPI` and from the initial DPI read in `enumerateAndSetup`.
+- `src/core/PhysicalDevice.h`: add five new signals (`smartShiftChanged`, `scrollConfigChanged`, `thumbWheelModeChanged`, `currentDPIChanged`, plus a keep-the-interface-consistent note: `batteryChanged` already exists as a forwarded signal via `connectSessionSignals`).
+- `src/core/PhysicalDevice.cpp`: expand `connectSessionSignals` lambdas to emit both the per-property relay and `stateChanged`; add one new `connect` for `DeviceSession::currentDPIChanged`.
+- `src/app/models/DeviceModel.cpp`: in `addPhysicalDevice`, connect to the four new PhysicalDevice signals; handlers invalidate the display cache then emit per-property NOTIFYs. In `setDisplayValues`, emit the per-property signals alongside the existing `settingsReloaded` so profile reload paths still trigger QML re-reads.
+- `src/app/models/DeviceModel.h`: flip Q_PROPERTY NOTIFY declarations from `settingsReloaded` to per-property signals.
+- `tests/test_device_session.cpp`: one narrow test for the new emit (`SetDPIEmitsCurrentDPIChanged`).
+- `tests/test_device_model.cpp`: gate and cache-invalidation tests with `QSignalSpy`.
+
+### Unchanged
+
+- `src/app/AppController.cpp`: no changes. Request signals keep their existing wiring.
+- `src/core/DeviceManager.cpp`: no changes.
+- All QML files: no changes. Bindings are already declarative on the Q_PROPERTYs; the NOTIFY flip rewires them automatically.
+- MockDevice: no changes. Tests that need a `PhysicalDevice` use a test double pattern described in Task 4.
+
+---
+
+## Task 1: DeviceSession emits `currentDPIChanged`
+
+**Files:**
+- Modify: `src/core/DeviceSession.h`
+- Modify: `src/core/DeviceSession.cpp`
+- Modify: `tests/test_device_session.cpp`
+
+TDD-friendly. Write the test first, watch it fail, add the signal + emits, watch it pass.
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/test_device_session.cpp`, add near the other `SetDPI*` tests (around line 114):
+
+```cpp
+TEST_F(DeviceSessionTest, SetDPIEmitsCurrentDPIChangedWhenConnected) {
+    auto session = makeSession();
+    session->setConnectedForTest(true);
+    QSignalSpy spy(session.get(), &DeviceSession::currentDPIChanged);
+    session->setDPI(2000);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(DeviceSessionTest, SetDPISkipsEmitWhenNotConnected) {
+    auto session = makeSession();
+    // Default: m_connected = false
+    QSignalSpy spy(session.get(), &DeviceSession::currentDPIChanged);
+    session->setDPI(2000);
+    EXPECT_EQ(spy.count(), 0);
+}
+```
+
+If `QSignalSpy` is not already included in this file, add `#include <QSignalSpy>` near the top.
+
+Note: `setDPI` guards on `m_connected && m_features && m_commandQueue`. `setConnectedForTest(true)` flips `m_connected`, but `m_features` and `m_commandQueue` remain null, so `setDPI` returns early at `if (!m_connected || !m_features || !m_commandQueue)` before it would write HID++. The signal must still fire when we actually change `m_currentDPI` — so the emit will go at the end of the updating branch, NOT at the top guard. That is why the "connected but features-less" test case above still expects zero emissions if the guard rejects the call. ADJUST: the test pair above assumes we emit from the actual update path, which runs only when all three preconditions are present. For this test to work without instantiating `m_features` / `m_commandQueue`, place the emit BEFORE the HID++-write path but AFTER the new-value assignment, gated only on the value having changed. See Step 3 for the exact placement.
+
+- [ ] **Step 2: Run tests to see them fail**
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+```
+
+Expected: build fails at `DeviceSession::currentDPIChanged` — signal not declared.
+
+- [ ] **Step 3: Declare the signal and emit it**
+
+In `src/core/DeviceSession.h`, inside the `signals:` block (around line 107), add after the existing `smartShiftChanged`:
+
+```cpp
+void currentDPIChanged();
+```
+
+In `src/core/DeviceSession.cpp`, find `setDPI` (around line 742). The current body is:
+
+```cpp
+void DeviceSession::setDPI(int value)
+{
+    if (!m_connected || !m_features || !m_commandQueue) {
+        qCDebug(lcDevice) << "setDPI: skipped (not connected)";
+        return;
+    }
+    if (!m_features->hasFeature(hidpp::FeatureId::AdjustableDPI))
+        return;
+
+    value = qBound(m_minDPI, value, m_maxDPI);
+    value = (value / m_dpiStep) * m_dpiStep;
+
+    qCDebug(lcDevice) << "setDPI:" << value << "(was" << m_currentDPI << ") queue=" << m_commandQueue->pending();
+    m_currentDPI = value;
+
+    auto params = hidpp::features::AdjustableDPI::buildSetDPI(value);
+    m_commandQueue->enqueue(hidpp::FeatureId::AdjustableDPI,
+                            hidpp::features::AdjustableDPI::kFnSetSensorDpi,
+                            params);
+}
+```
+
+Restructure so the emit fires whenever `m_currentDPI` is updated, independent of whether the HID++ write goes through:
+
+```cpp
+void DeviceSession::setDPI(int value)
+{
+    if (!m_connected)
+        return;
+
+    value = qBound(m_minDPI, value, m_maxDPI);
+    if (m_dpiStep > 0)
+        value = (value / m_dpiStep) * m_dpiStep;
+
+    const int previous = m_currentDPI;
+    m_currentDPI = value;
+    if (previous != value)
+        emit currentDPIChanged();
+
+    if (!m_features || !m_commandQueue)
+        return;
+    if (!m_features->hasFeature(hidpp::FeatureId::AdjustableDPI))
+        return;
+
+    qCDebug(lcDevice) << "setDPI:" << value << "(was" << previous << ") queue=" << m_commandQueue->pending();
+    auto params = hidpp::features::AdjustableDPI::buildSetDPI(value);
+    m_commandQueue->enqueue(hidpp::FeatureId::AdjustableDPI,
+                            hidpp::features::AdjustableDPI::kFnSetSensorDpi,
+                            params);
+}
+```
+
+The rearrangement:
+- Early-return on `!m_connected` stays; when not connected we do nothing.
+- Clamp + step quantisation happens before the emit so `m_currentDPI` is set to the clamped value.
+- Emit fires once per distinct value change.
+- HID++ write still requires `m_features && m_commandQueue`; the qCDebug moves below the emit so the log line reflects the clamped value.
+
+Also find the initial DPI read in `enumerateAndSetup` (around line 318) which assigns `m_currentDPI` from an `AdjustableDPI::parseCurrentDPI` call. Immediately after that assignment, emit the signal so QML bindings created before enumeration also get a value:
+
+```cpp
+    m_currentDPI = hidpp::features::AdjustableDPI::parseCurrentDPI(*dpiResp);
+    qCDebug(lcDevice) << "current DPI:" << m_currentDPI;
+    emit currentDPIChanged();
+```
+
+- [ ] **Step 4: Update the failing test to match the new guard**
+
+The test pair from Step 1 expects a signal ONLY when connected. Because the emit now only happens when `m_connected == true` and the value changes, the pair above works as-is. Verify the test names and assertions still match.
+
+- [ ] **Step 5: Build and run tests**
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests --gtest_filter='DeviceSessionTest.SetDPI*' 2>&1 | tail -10
+```
+
+Expected: both new tests pass. Pre-existing `SetDPISkipsWhenNotConnected` still passes (it only asserts `currentDPI() == 0`, not signal counts, and the new body preserves that behavior because the early-return keeps `m_currentDPI` at its init value).
+
+Full run:
+
+```bash
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+```
+
+Expected: `[  PASSED  ] 541 tests.` (539 baseline + 2 new).
+
+- [ ] **Step 6: Verify no em-dashes**
+
+```bash
+grep -c "—" src/core/DeviceSession.h src/core/DeviceSession.cpp tests/test_device_session.cpp
+```
+
+Expected: `0` for each.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/DeviceSession.h src/core/DeviceSession.cpp tests/test_device_session.cpp
+git commit -m "feat(device-session): emit currentDPIChanged on DPI change
+
+setDPI now emits currentDPIChanged whenever m_currentDPI changes value,
+independent of whether the HID++ write path reaches the command queue.
+The initial DPI read inside enumerateAndSetup also emits, so QML
+bindings created before enumeration get a value.
+
+Previously nothing in DeviceSession emitted a per-property signal for
+DPI. DeviceModel's currentDPI Q_PROPERTY used the coarse
+settingsReloaded NOTIFY and silently missed changes from setDPI calls
+(including the dpi-cycle action that writes DPI without a profile
+reload).
+
+Two narrow tests (SetDPIEmitsCurrentDPIChangedWhenConnected and
+SetDPISkipsEmitWhenNotConnected) cover the guard. Pre-existing
+SetDPISkipsWhenNotConnected still asserts the old no-op behavior and
+still passes."
+```
+
+---
+
+## Task 2: PhysicalDevice per-property relay signals
+
+**Files:**
+- Modify: `src/core/PhysicalDevice.h`
+- Modify: `src/core/PhysicalDevice.cpp`
+
+No new tests in this task; the existing PhysicalDevice tests (if any) must stay green. The signals are exercised by the DeviceModel tests in Tasks 3 and 4.
+
+- [ ] **Step 1: Declare the new signals**
+
+In `src/core/PhysicalDevice.h`, find the `signals:` block. Add these four signals (alongside the existing `stateChanged`, `transportSetupComplete`, `divertedButtonPressed`, `gestureRawXY`, `thumbWheelRotation`):
+
+```cpp
+void smartShiftChanged(bool enabled, int threshold);
+void scrollConfigChanged();
+void thumbWheelModeChanged();
+void currentDPIChanged();
+```
+
+Parameter shapes mirror `DeviceSession`'s signals exactly. If `<cstdint>` is not already included (for `int`) no include change is needed — `bool` and `int` are builtins.
+
+- [ ] **Step 2: Expand `connectSessionSignals`**
+
+In `src/core/PhysicalDevice.cpp`, find `connectSessionSignals` (around line 87). Today the four session signal relays each emit only `stateChanged`. Change each lambda to emit the matching per-property signal first, then `stateChanged`. Add a new connection for `currentDPIChanged`.
+
+Before:
+
+```cpp
+    connect(session, &DeviceSession::smartShiftChanged, this,
+            [this](bool, int) { emit stateChanged(); });
+    connect(session, &DeviceSession::scrollConfigChanged, this,
+            [this]() { emit stateChanged(); });
+    connect(session, &DeviceSession::thumbWheelModeChanged, this,
+            [this]() { emit stateChanged(); });
+```
+
+After:
+
+```cpp
+    connect(session, &DeviceSession::smartShiftChanged, this,
+            [this](bool enabled, int threshold) {
+        emit smartShiftChanged(enabled, threshold);
+        emit stateChanged();
+    });
+    connect(session, &DeviceSession::scrollConfigChanged, this,
+            [this]() {
+        emit scrollConfigChanged();
+        emit stateChanged();
+    });
+    connect(session, &DeviceSession::thumbWheelModeChanged, this,
+            [this]() {
+        emit thumbWheelModeChanged();
+        emit stateChanged();
+    });
+    connect(session, &DeviceSession::currentDPIChanged, this,
+            [this]() {
+        emit currentDPIChanged();
+        emit stateChanged();
+    });
+```
+
+The existing `batteryChanged` connection keeps its current shape; `batteryLevel` already has its own Q_PROPERTY NOTIFY (`selectedBatteryChanged`) and is out of scope.
+
+`disconnectSessionSignals` uses a blanket `disconnect(session, nullptr, this, nullptr)`; no change needed.
+
+- [ ] **Step 3: Build and run the full suite**
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+```
+
+Expected: 541 passing. No new tests; this task adds infrastructure the next tasks will exercise.
+
+- [ ] **Step 4: Verify no em-dashes**
+
+```bash
+grep -c "—" src/core/PhysicalDevice.h src/core/PhysicalDevice.cpp
+```
+
+Expected: `0` for each.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/PhysicalDevice.h src/core/PhysicalDevice.cpp
+git commit -m "feat(physical-device): relay per-property session signals
+
+PhysicalDevice previously collapsed every session-level change signal
+(smartShiftChanged, scrollConfigChanged, thumbWheelModeChanged,
+batteryChanged) into a single stateChanged emission. Good enough for
+the carousel row refresh that only reads QAbstractListModel data
+roles, but insufficient for QML bindings on per-property Q_PROPERTYs
+that care which field changed.
+
+Add four new signals (smartShiftChanged, scrollConfigChanged,
+thumbWheelModeChanged, currentDPIChanged) and update
+connectSessionSignals so each session signal fires both the specific
+relay and stateChanged. Existing stateChanged consumers keep working;
+new consumers can listen for just the field they care about.
+
+No behavior change yet: no consumer subscribes to the new signals in
+this commit. DeviceModel wires them up in the next two commits."
+```
+
+---
+
+## Task 3: DeviceModel invalidates display cache on hardware change
+
+**Files:**
+- Modify: `src/app/models/DeviceModel.cpp`
+
+This task adds the per-property handler scaffolding with ONLY the cache invalidation rule. The per-property NOTIFY emits land in Task 4. Result after this task: a physical SmartShift press on the selected device updates `m_hasDisplayValues` to `false`, so the existing `settingsReloaded` chain already fires via `refreshRow` and QML bindings re-read getters that now fall through to live session state. This alone resolves issue #17 for today's setup; Task 4 is the forward-looking cleanup that makes the NOTIFY signals property-specific.
+
+- [ ] **Step 1: Write failing tests**
+
+Open `tests/test_device_model.cpp`. Find an appropriate spot near the existing `SetDisplayValues*` tests (around line 34). Add a new test fixture pattern that includes a `PhysicalDevice` test double. The simplest path is to use the existing pattern from other tests that construct `PhysicalDevice` directly with a `MockDevice`. If no such pattern exists in this file, inspect how `src/core/PhysicalDevice.h` is constructed and follow that.
+
+Add these tests:
+
+```cpp
+TEST_F(DeviceModelTest, HardwareSmartShiftChangeInvalidatesDisplayCache) {
+    model.setDisplayValues(1000, true, 128, true, false, "scroll", false);
+    EXPECT_TRUE(model.smartShiftEnabled());
+
+    // Simulate a hardware-originated change arriving for the selected device.
+    ASSERT_TRUE(model.selectedIndex() >= 0);
+    auto *pd = model.devices().at(model.selectedIndex());
+    ASSERT_NE(pd, nullptr);
+    emit pd->smartShiftChanged(false, 128);
+
+    // m_hasDisplayValues should now be false; getter falls through to
+    // the session. With no connected session, the session returns
+    // the default (true) per the existing smartShiftEnabled() fallback.
+    // Test: the cached false should no longer be returned. Assert the
+    // getter does NOT return the display cache's value.
+    EXPECT_NE(model.smartShiftEnabled(), false /* cached value */);
+}
+
+TEST_F(DeviceModelTest, SetDisplayValuesRestoresCacheAfterInvalidation) {
+    model.setDisplayValues(1000, true, 128, true, false, "scroll", false);
+    auto *pd = model.devices().at(model.selectedIndex());
+    emit pd->smartShiftChanged(false, 64);
+    // cache is now invalidated; re-call setDisplayValues
+    model.setDisplayValues(1500, true, 200, false, true, "zoom", true);
+    EXPECT_EQ(model.currentDPI(), 1500);
+    EXPECT_EQ(model.smartShiftThreshold(), 200);
+    EXPECT_TRUE(model.smartShiftEnabled());
+    EXPECT_FALSE(model.scrollHiRes());
+    EXPECT_TRUE(model.scrollInvert());
+    EXPECT_EQ(model.thumbWheelMode(), "zoom");
+    EXPECT_TRUE(model.thumbWheelInvert());
+}
+
+TEST_F(DeviceModelTest, UnselectedDeviceHardwareChangeDoesNotInvalidateCache) {
+    model.setDisplayValues(1000, true, 128, true, false, "scroll", false);
+
+    // Assumes the fixture has at least one non-selected PhysicalDevice.
+    // If the fixture only constructs a single device, add a second mock
+    // device via model.addPhysicalDevice() before this test.
+    int selectedIdx = model.selectedIndex();
+    ASSERT_GE(selectedIdx, 0);
+
+    PhysicalDevice *other = nullptr;
+    for (int i = 0; i < model.devices().size(); ++i) {
+        if (i != selectedIdx) { other = model.devices().at(i); break; }
+    }
+    ASSERT_NE(other, nullptr) << "test needs at least two PhysicalDevices";
+
+    emit other->smartShiftChanged(false, 128);
+
+    // Cache should still be armed; getter returns the cached value.
+    EXPECT_TRUE(model.smartShiftEnabled());
+}
+```
+
+If the existing `DeviceModelTest` fixture does not populate a `PhysicalDevice`, the test will fail at `ASSERT_NE(pd, nullptr)`. In that case, extend the fixture (or add a dedicated `DeviceModelWithDeviceTest` fixture) that constructs a `MockDevice`, wraps it in a `PhysicalDevice`, and calls `model.addPhysicalDevice(pd)` in `SetUp`. Mirror the pattern from any test in the file that currently works against a populated model.
+
+If there is no existing pattern to copy, STOP and escalate NEEDS_CONTEXT with the fixture shape so the controller can decide how to construct a `PhysicalDevice` in tests.
+
+- [ ] **Step 2: Run tests to see them fail**
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests --gtest_filter='DeviceModelTest.*InvalidateDisplayCache:DeviceModelTest.*AfterInvalidation:DeviceModelTest.*DoesNotInvalidateCache' 2>&1 | tail -10
+```
+
+Expected: at least one test fails because `DeviceModel` does not yet wire up the PhysicalDevice per-property signals.
+
+- [ ] **Step 3: Wire the handlers in `addPhysicalDevice`**
+
+Open `src/app/models/DeviceModel.cpp`. Find `addPhysicalDevice` (the method that already connects `stateChanged` around line 146). Directly below the existing `connect(device, &PhysicalDevice::stateChanged, ...)` block, add four new `connect` calls, each with a handler lambda that invalidates the display cache ONLY when the signal is for the currently selected device. Use `this` as the context object so the connections are auto-disconnected when the DeviceModel is destroyed:
+
+```cpp
+    connect(device, &PhysicalDevice::smartShiftChanged, this,
+            [this, device](bool, int) {
+        if (device != selectedDevice())
+            return;
+        m_hasDisplayValues = false;
+    });
+    connect(device, &PhysicalDevice::scrollConfigChanged, this,
+            [this, device]() {
+        if (device != selectedDevice())
+            return;
+        m_hasDisplayValues = false;
+    });
+    connect(device, &PhysicalDevice::thumbWheelModeChanged, this,
+            [this, device]() {
+        if (device != selectedDevice())
+            return;
+        m_hasDisplayValues = false;
+    });
+    connect(device, &PhysicalDevice::currentDPIChanged, this,
+            [this, device]() {
+        if (device != selectedDevice())
+            return;
+        m_hasDisplayValues = false;
+    });
+```
+
+Keep the existing `stateChanged` connection untouched. `refreshRow` still runs via that path so the carousel keeps updating; the existing `settingsReloaded` emit inside `refreshRow` (line 245) still fires so QML bindings pinged.
+
+- [ ] **Step 4: Build and run tests**
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+```
+
+Expected: all new tests pass. Total 544 (541 + 3 new).
+
+- [ ] **Step 5: Verify no em-dashes**
+
+```bash
+grep -c "—" src/app/models/DeviceModel.cpp tests/test_device_model.cpp
+```
+
+Expected: `0` for each.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/models/DeviceModel.cpp tests/test_device_model.cpp
+git commit -m "fix(device-model): invalidate display cache on live hardware change
+
+DeviceModel getters for DPI, SmartShift, scroll, and thumb-wheel
+properties short-circuit to m_display* cached profile values whenever
+m_hasDisplayValues is true. That flag is set by setDisplayValues on
+profile load and never cleared, so even when QML bindings re-read a
+getter in response to settingsReloaded (which refreshRow already
+fires), they get the stale profile value back instead of the hardware
+state.
+
+Wire DeviceModel::addPhysicalDevice to PhysicalDevice's new
+per-property relay signals. Each handler:
+ - Early-returns if the event is not for the selected device.
+ - Sets m_hasDisplayValues = false so the next getter call falls
+   through to the live session readers.
+
+The next profile reload re-arms the cache via setDisplayValues.
+
+This commit resolves issue #17 on the current signal-plumbing layer
+without changing any NOTIFY signals. Task 4 adds property-specific
+NOTIFYs as forward-looking cleanup."
+```
+
+---
+
+## Task 4: DeviceModel per-property NOTIFY emits
+
+**Files:**
+- Modify: `src/app/models/DeviceModel.cpp`
+- Modify: `tests/test_device_model.cpp`
+
+- [ ] **Step 1: Write failing tests for the per-property emits**
+
+In `tests/test_device_model.cpp`, add (near the tests from Task 3):
+
+```cpp
+TEST_F(DeviceModelTest, SmartShiftHardwareChangeEmitsProperty) {
+    model.setDisplayValues(1000, true, 128, true, false, "scroll", false);
+    auto *pd = model.devices().at(model.selectedIndex());
+
+    QSignalSpy enabledSpy(&model, &DeviceModel::smartShiftEnabledChanged);
+    QSignalSpy thresholdSpy(&model, &DeviceModel::smartShiftThresholdChanged);
+
+    emit pd->smartShiftChanged(false, 192);
+
+    EXPECT_EQ(enabledSpy.count(), 1);
+    EXPECT_EQ(thresholdSpy.count(), 1);
+}
+
+TEST_F(DeviceModelTest, ScrollConfigHardwareChangeEmitsOnce) {
+    model.setDisplayValues(1000, true, 128, true, false, "scroll", false);
+    auto *pd = model.devices().at(model.selectedIndex());
+
+    QSignalSpy spy(&model, &DeviceModel::scrollConfigChanged);
+    emit pd->scrollConfigChanged();
+
+    // scrollHiRes and scrollInvert both NOTIFY on this signal; expect
+    // a single emission, not two.
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(DeviceModelTest, ThumbWheelHardwareChangeEmitsProperty) {
+    model.setDisplayValues(1000, true, 128, true, false, "scroll", false);
+    auto *pd = model.devices().at(model.selectedIndex());
+
+    QSignalSpy spy(&model, &DeviceModel::thumbWheelModeChanged);
+    emit pd->thumbWheelModeChanged();
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(DeviceModelTest, DPIHardwareChangeEmitsProperty) {
+    model.setDisplayValues(1000, true, 128, true, false, "scroll", false);
+    auto *pd = model.devices().at(model.selectedIndex());
+
+    QSignalSpy spy(&model, &DeviceModel::currentDPIChanged);
+    emit pd->currentDPIChanged();
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(DeviceModelTest, UnselectedDeviceHardwareChangeDoesNotEmit) {
+    model.setDisplayValues(1000, true, 128, true, false, "scroll", false);
+    int selectedIdx = model.selectedIndex();
+    PhysicalDevice *other = nullptr;
+    for (int i = 0; i < model.devices().size(); ++i) {
+        if (i != selectedIdx) { other = model.devices().at(i); break; }
+    }
+    ASSERT_NE(other, nullptr) << "test needs at least two PhysicalDevices";
+
+    QSignalSpy spy(&model, &DeviceModel::smartShiftEnabledChanged);
+    emit other->smartShiftChanged(false, 128);
+
+    EXPECT_EQ(spy.count(), 0);
+}
+
+TEST_F(DeviceModelTest, SetDisplayValuesEmitsPerPropertySignals) {
+    QSignalSpy dpiSpy(&model, &DeviceModel::currentDPIChanged);
+    QSignalSpy smartSpy(&model, &DeviceModel::smartShiftEnabledChanged);
+    QSignalSpy threshSpy(&model, &DeviceModel::smartShiftThresholdChanged);
+    QSignalSpy scrollSpy(&model, &DeviceModel::scrollConfigChanged);
+    QSignalSpy thumbSpy(&model, &DeviceModel::thumbWheelModeChanged);
+
+    model.setDisplayValues(1500, false, 200, false, true, "zoom", true);
+
+    EXPECT_EQ(dpiSpy.count(), 1);
+    EXPECT_EQ(smartSpy.count(), 1);
+    EXPECT_EQ(threshSpy.count(), 1);
+    EXPECT_EQ(scrollSpy.count(), 1);
+    EXPECT_EQ(thumbSpy.count(), 1);
+}
+```
+
+- [ ] **Step 2: Run tests to see them fail**
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests --gtest_filter='DeviceModelTest.*HardwareChange*:DeviceModelTest.SetDisplayValuesEmitsPerPropertySignals:DeviceModelTest.UnselectedDeviceHardwareChangeDoesNotEmit' 2>&1 | tail -15
+```
+
+Expected: at least six tests fail because DeviceModel's handlers from Task 3 don't emit per-property signals yet.
+
+- [ ] **Step 3: Extend the Task 3 handlers to emit per-property signals**
+
+Reopen `src/app/models/DeviceModel.cpp`. In `addPhysicalDevice`, augment each of the four handlers added in Task 3 to emit the matching per-property signal after the cache invalidation. Before:
+
+```cpp
+    connect(device, &PhysicalDevice::smartShiftChanged, this,
+            [this, device](bool, int) {
+        if (device != selectedDevice())
+            return;
+        m_hasDisplayValues = false;
+    });
+```
+
+After:
+
+```cpp
+    connect(device, &PhysicalDevice::smartShiftChanged, this,
+            [this, device](bool, int) {
+        if (device != selectedDevice())
+            return;
+        m_hasDisplayValues = false;
+        emit smartShiftEnabledChanged();
+        emit smartShiftThresholdChanged();
+    });
+    connect(device, &PhysicalDevice::scrollConfigChanged, this,
+            [this, device]() {
+        if (device != selectedDevice())
+            return;
+        m_hasDisplayValues = false;
+        emit scrollConfigChanged();
+    });
+    connect(device, &PhysicalDevice::thumbWheelModeChanged, this,
+            [this, device]() {
+        if (device != selectedDevice())
+            return;
+        m_hasDisplayValues = false;
+        emit thumbWheelModeChanged();
+    });
+    connect(device, &PhysicalDevice::currentDPIChanged, this,
+            [this, device]() {
+        if (device != selectedDevice())
+            return;
+        m_hasDisplayValues = false;
+        emit currentDPIChanged();
+    });
+```
+
+`DeviceModel::scrollConfigChanged` already exists as a declared signal (verify by grepping `src/app/models/DeviceModel.h` for `scrollConfigChanged`). Same for `currentDPIChanged`, `smartShiftEnabledChanged`, `smartShiftThresholdChanged`, `thumbWheelModeChanged`. No new DeviceModel signals are needed in this file.
+
+- [ ] **Step 4: Update `setDisplayValues` to emit per-property signals**
+
+Still in `src/app/models/DeviceModel.cpp`, find `setDisplayValues` (around line 654). It currently ends with:
+
+```cpp
+    m_hasDisplayValues = true;
+    emit settingsReloaded();
+}
+```
+
+Add per-property emits just before `emit settingsReloaded();`:
+
+```cpp
+    m_hasDisplayValues = true;
+    emit currentDPIChanged();
+    emit smartShiftEnabledChanged();
+    emit smartShiftThresholdChanged();
+    emit scrollConfigChanged();
+    emit thumbWheelModeChanged();
+    emit settingsReloaded();
+}
+```
+
+This preserves the existing `settingsReloaded` trigger for any still-subscribed consumer, while adding the per-property signals so QML bindings on the post-flip NOTIFYs (Task 5) get pinged on profile reload too. This is the fix for the risk noted in the spec's "Double-emit on profile reload" section.
+
+- [ ] **Step 5: Build and run the full suite**
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+```
+
+Expected: all new tests pass. Total 550 (544 + 6 new).
+
+- [ ] **Step 6: Verify no em-dashes**
+
+```bash
+grep -c "—" src/app/models/DeviceModel.cpp tests/test_device_model.cpp
+```
+
+Expected: `0` for each.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/models/DeviceModel.cpp tests/test_device_model.cpp
+git commit -m "feat(device-model): emit per-property NOTIFY signals gated on selection
+
+Extend the per-property PhysicalDevice signal handlers (landed in the
+prior commit with cache-invalidation only) to also emit the matching
+DeviceModel signals: smartShiftEnabledChanged,
+smartShiftThresholdChanged, scrollConfigChanged, thumbWheelModeChanged,
+currentDPIChanged. Each emit is gated on the signal arriving from the
+selected PhysicalDevice.
+
+Also update setDisplayValues to emit the same five per-property
+signals alongside its existing settingsReloaded emission, so profile
+reload paths keep pinging QML bindings after the Q_PROPERTY NOTIFY
+flip in the next commit.
+
+scrollHiRes and scrollInvert intentionally share the single
+scrollConfigChanged signal (matching DeviceSession::setScrollConfig's
+combined write semantics), so one hardware change fires one DeviceModel
+signal but both QML bindings re-read."
+```
+
+---
+
+## Task 5: Flip Q_PROPERTY NOTIFY declarations
+
+**Files:**
+- Modify: `src/app/models/DeviceModel.h`
+
+This is the final flip. After this commit, QML bindings on these properties re-read via the per-property signals from Task 4 instead of `settingsReloaded`. All emit sites exist; the flip is safe.
+
+- [ ] **Step 1: Update the Q_PROPERTY declarations**
+
+In `src/app/models/DeviceModel.h`, find the affected Q_PROPERTYs. Before:
+
+```cpp
+Q_PROPERTY(int currentDPI READ currentDPI NOTIFY settingsReloaded)
+Q_PROPERTY(bool smartShiftEnabled READ smartShiftEnabled NOTIFY settingsReloaded)
+Q_PROPERTY(int smartShiftThreshold READ smartShiftThreshold NOTIFY settingsReloaded)
+Q_PROPERTY(bool scrollHiRes READ scrollHiRes NOTIFY settingsReloaded)
+Q_PROPERTY(bool scrollInvert READ scrollInvert NOTIFY settingsReloaded)
+Q_PROPERTY(QString thumbWheelMode READ thumbWheelMode NOTIFY settingsReloaded)
+Q_PROPERTY(bool thumbWheelInvert READ thumbWheelInvert NOTIFY settingsReloaded)
+```
+
+After:
+
+```cpp
+Q_PROPERTY(int currentDPI READ currentDPI NOTIFY currentDPIChanged)
+Q_PROPERTY(bool smartShiftEnabled READ smartShiftEnabled NOTIFY smartShiftEnabledChanged)
+Q_PROPERTY(int smartShiftThreshold READ smartShiftThreshold NOTIFY smartShiftThresholdChanged)
+Q_PROPERTY(bool scrollHiRes READ scrollHiRes NOTIFY scrollConfigChanged)
+Q_PROPERTY(bool scrollInvert READ scrollInvert NOTIFY scrollConfigChanged)
+Q_PROPERTY(QString thumbWheelMode READ thumbWheelMode NOTIFY thumbWheelModeChanged)
+Q_PROPERTY(bool thumbWheelInvert READ thumbWheelInvert NOTIFY thumbWheelModeChanged)
+```
+
+The last two share `thumbWheelModeChanged` because `DeviceSession::setThumbWheelMode` writes both mode and invert atomically. Same pattern as `scrollHiRes` and `scrollInvert` sharing `scrollConfigChanged`.
+
+- [ ] **Step 2: Build and run the full suite**
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+```
+
+Expected: 550 passing. No new tests; the existing tests still pass because the underlying semantics (signals fire, getters return correct values) are unchanged.
+
+- [ ] **Step 3: QML smoke test**
+
+```bash
+pkill -f logitune 2>/dev/null; sleep 1
+nohup env XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/src/app/logitune --simulate-all > /tmp/logitune-notify-smoke.log 2>&1 & disown
+sleep 3
+grep -iE "binding loop|notify signal|no notify" /tmp/logitune-notify-smoke.log | head -10
+pkill -f logitune 2>/dev/null
+```
+
+Expected: no "binding loop" or "no NOTIFY signal" warnings. If any appear, they typically mean a QML binding tried to read a property whose NOTIFY signal was renamed and the binding didn't update; inspect the QML file referenced in the warning and verify it uses the Q_PROPERTY name (which hasn't changed), not the old signal name.
+
+- [ ] **Step 4: Verify no em-dashes**
+
+```bash
+grep -c "—" src/app/models/DeviceModel.h
+```
+
+Expected: `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/models/DeviceModel.h
+git commit -m "feat(device-model): flip Q_PROPERTY NOTIFY to per-property signals
+
+currentDPI, smartShiftEnabled, smartShiftThreshold, scrollHiRes,
+scrollInvert, thumbWheelMode, and thumbWheelInvert now notify via
+property-specific signals instead of the coarse settingsReloaded. All
+emit sites are already in place:
+ - DeviceSession -> PhysicalDevice -> DeviceModel handler for
+   hardware-originated changes (gated on selected device).
+ - setDisplayValues emits per-property signals alongside its existing
+   settingsReloaded emission for profile reload paths.
+
+scrollHiRes + scrollInvert share scrollConfigChanged, and
+thumbWheelMode + thumbWheelInvert share thumbWheelModeChanged, because
+the underlying DeviceSession setters write those pairs atomically.
+
+settingsReloaded stays as a coarse signal used only on profile reload
+paths, available for future properties that do not have a dedicated
+NOTIFY yet. Closes #17."
+```
+
+---
+
+## Task 6: Final verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Clean rebuild**
+
+```bash
+rm -rf build
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug 2>&1 | tail -3
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+```
+
+Expected: both exit 0; tail ends with linking the app and test binaries.
+
+- [ ] **Step 2: Full test run**
+
+```bash
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" QT_QPA_PLATFORM=offscreen ./build/tests/qml/logitune-qml-tests 2>&1 | tail -3
+```
+
+Expected: 550 core tests pass, 72 QML tests pass.
+
+- [ ] **Step 3: Real-hardware sanity check**
+
+With your MX Master 3S or MX Vertical connected, launch normally:
+
+```bash
+pkill -f logitune 2>/dev/null; sleep 1
+nohup /usr/bin/logitune > /tmp/logitune-live.log 2>&1 & disown
+```
+
+Then:
+- Open the Point & Scroll page on the connected mouse.
+- Press the physical SmartShift button on MX Master 3S (above the thumb rest). The SmartShift toggle and scroll-wheel readout in the UI should flip within a frame.
+- Press the DPI cycle button on MX Vertical. The DPI value on the Point & Scroll page should step through the ring.
+- Switch focus to a different app that has a saved profile. The UI should restore the profile's values (proving setDisplayValues re-arms the cache).
+
+If anything stays stale, re-inspect the relevant connect() in `addPhysicalDevice` to verify the signal names match and the `device != selectedDevice()` guard is not accidentally reversed.
+
+- [ ] **Step 4: Branch commit list**
+
+```bash
+git log --oneline master..HEAD
+```
+
+Expected: the spec commit plus five new commits in the order defined above (no amendments).
+
+- [ ] **Step 5: Em-dash scan on touched files**
+
+```bash
+git diff --name-only master..HEAD \
+  | grep -vE '\.(png|svg)$' \
+  | xargs -I{} sh -c 'printf "%s: " "{}"; grep -c "—" "{}" 2>/dev/null || echo "N/A"'
+```
+
+Expected: `0` on every C++/header/test file. `docs/superpowers/specs/*` may print non-zero (pre-existing).
+
+Do NOT push the branch. Maintainer pushes and opens the PR.
+
+---
+
+## Done criteria
+
+- Clean Debug rebuild from scratch: 0 errors, 0 warnings introduced by this plan.
+- 550 core tests pass (539 baseline after v0.3.1-beta.1 plus 11 new: 2 in Task 1, 3 in Task 3, 6 in Task 4). 72 QML tests pass.
+- Real-hardware smoke: physical SmartShift button press updates the Point & Scroll SmartShift toggle; DPI cycle button updates the DPI readout; profile reload still restores profile values.
+- Five implementation commits on the branch, each reviewable in isolation, none amended.
+- `grep -c "—"` on every touched C++/JSON/test file prints `0`.

--- a/docs/superpowers/specs/2026-04-19-stale-property-notifys-design.md
+++ b/docs/superpowers/specs/2026-04-19-stale-property-notifys-design.md
@@ -13,11 +13,25 @@ cycle button press, scroll invert change from another app) don't
 propagate to QML bindings. Properties read stale values until the next
 profile reload.
 
-Fix: give `PhysicalDevice` per-property relay signals, have `DeviceModel`
-forward them (gated on the selected device) to the matching
-Q_PROPERTY NOTIFY signals that already exist but are never emitted.
-Flip the Q_PROPERTY NOTIFYs from the coarse `settingsReloaded` to the
-property-specific signals.
+Two layers to fix:
+
+1. **Signal plumbing.** Give `PhysicalDevice` per-property relay signals,
+   have `DeviceModel` forward them (gated on the selected device) to the
+   Q_PROPERTY NOTIFY signals that already exist but are never emitted.
+   Flip the Q_PROPERTY NOTIFYs from the coarse `settingsReloaded` to the
+   property-specific signals.
+
+2. **Display-cache invalidation.** `DeviceModel` getters like
+   `smartShiftEnabled()` currently return `m_display*` (the active
+   profile's cached values, set by `setDisplayValues`) whenever
+   `m_hasDisplayValues == true`. After the first profile loads, this is
+   true forever, so even when QML re-reads, the getter returns the stale
+   profile value instead of the live session state. Fix: when a hardware
+   state change arrives on the selected device, set
+   `m_hasDisplayValues = false`. Getters fall through to
+   `session->smartShiftEnabled()` etc. The next profile reload (focus
+   change, profile switch, explicit reload) re-populates the cache via
+   `setDisplayValues`.
 
 ## Scope
 
@@ -47,7 +61,27 @@ Out of scope:
 
 ## Root cause
 
-Signal chain today:
+Two layered issues.
+
+### Layer 1: display-values cache shadows live state
+
+`DeviceModel::smartShiftEnabled()` (line 441, mirrored for DPI / threshold
+/ scroll / thumb-wheel) starts with:
+
+```cpp
+if (m_hasDisplayValues) return m_displaySmartShiftEnabled;
+```
+
+`m_hasDisplayValues` is flipped to `true` inside `setDisplayValues` (line
+665), which is called from `AppController::onDisplayProfileChanged`
+every time the active per-app profile changes. After the first profile
+loads, `m_hasDisplayValues` stays `true`, so the getter returns the
+cached *profile* value forever. Hardware changes from the device side
+can fire any number of signals; the getter never sees them.
+
+### Layer 2: signal chain stops at refreshRow
+
+Even ignoring Layer 1, the signal chain today:
 
 ```
 DeviceSession                     PhysicalDevice                  DeviceModel
@@ -73,6 +107,13 @@ All the specific signals declared on `DeviceModel`
 (`smartShiftEnabledChanged`, `smartShiftThresholdChanged`,
 `scrollConfigChanged`, `thumbWheelModeChanged`, `currentDPIChanged`)
 exist but are never emitted.
+
+Note that `refreshRow` already emits `settingsReloaded` on the selected
+row path (line 245). So today's QML bindings on `NOTIFY
+settingsReloaded` *do* get pinged on hardware change. They re-read the
+getter and still see the stale cached profile value because of Layer 1.
+This is why fixing only the signal plumbing (as the original issue
+diagnosis suggests) is insufficient.
 
 ## Design
 
@@ -104,6 +145,24 @@ the existing `selectedBatteryChanged` pattern used for battery.
 Selection change (a different mouse becomes selected) is already
 handled by `selectedChanged` on the properties that care; swapping the
 selected device re-evaluates everything on both QML sides.
+
+### Cache-invalidation rule (Layer 1)
+
+The per-property handler in `DeviceModel` does **both** things when the
+change is on the selected device:
+
+1. Sets `m_hasDisplayValues = false`.
+2. Emits the matching per-property NOTIFY signal(s).
+
+After step 1, the getters (`smartShiftEnabled()`, `currentDPI()`, etc.)
+stop returning the cached `m_display*` values and fall through to
+`session->smartShiftEnabled()` and the other live session readers. QML
+bindings re-read and see the hardware's current value.
+
+`setDisplayValues` re-sets `m_hasDisplayValues = true` as it does today,
+so the next profile reload (focus change, profile switch) cleanly
+re-populates the cache and restores profile-shaped semantics. No other
+call site touches `m_hasDisplayValues`.
 
 ## Code surface
 
@@ -195,15 +254,17 @@ In `addPhysicalDevice` (the same method that already connects
 `stateChanged` around line 146), add five new `connect` calls that wire
 the new PhysicalDevice signals to small handler lambdas. Each handler:
 
-1. Calls `refreshRow(device)` (safety net; the existing `stateChanged`
-   connection already does this, but explicit keeps the handler
-   self-contained if future refactoring separates the two).
-2. Early-returns if `device != selectedDevice()`.
+1. Early-returns if `device != selectedDevice()`.
+2. Sets `m_hasDisplayValues = false` so the getters stop shadowing the
+   live session state with the cached profile value.
 3. Emits the matching DeviceModel signal(s). For `smartShiftChanged`
    this is both `smartShiftEnabledChanged()` and
    `smartShiftThresholdChanged()`. For `scrollConfigChanged` nothing
    needs to happen inside the handler beyond re-emit because both
    affected Q_PROPERTYs share that NOTIFY.
+
+`refreshRow(device)` keeps running via the existing `stateChanged`
+connection; no duplicate call from the per-property handlers.
 
 Keep `settingsReloaded` untouched. It stays as the coarse "reloaded
 from profile" signal that still fires on profile reload paths, and
@@ -234,6 +295,19 @@ selected. For each property in scope:
 - **UnselectedDeviceStillRefreshesRow**: assert that `rowChanged`
   (the QAbstractListModel signal) fires on both selected and
   unselected devices so the carousel stays in sync regardless.
+
+### Cache-invalidation tests
+
+- **HardwareChangeInvalidatesCache**: call `setDisplayValues` to populate
+  the cache, verify the getter returns cached value, simulate a
+  PhysicalDevice per-property emit on the selected device, verify the
+  getter now returns the live session value instead of the cached one.
+- **ProfileReloadRestoresCache**: after a hardware change invalidates
+  the cache, call `setDisplayValues` again; getter should return the
+  new cached value (confirms `setDisplayValues` re-arms the cache).
+- **UnselectedDeviceDoesNotInvalidateCache**: cache invalidation is
+  scoped to the selected device. A hardware change on a non-selected
+  mouse must NOT invalidate the cache.
 
 ### Scroll-pair coupling
 
@@ -266,12 +340,15 @@ stay green.
 
 ## Rollout
 
-Single PR on branch `fix-stale-property-notifys`. Four commit groups:
+Single PR on branch `fix-stale-property-notifys`. Five commit groups:
 
 1. `feat(device-session): emit currentDPIChanged and thumbWheelInvertChanged` — add missing emit points + tests.
 2. `feat(physical-device): relay per-property session signals` — new PhysicalDevice signals + expanded `connectSessionSignals` lambdas.
-3. `feat(device-model): emit per-property notifications gated on selection` — handler lambdas in `addPhysicalDevice`, the `thumbWheelInvertChanged` signal declaration, the new tests.
-4. `feat(device-model): flip Q_PROPERTY NOTIFY to per-property signals` — the header edits. Must land last so QML bindings only flip to the new NOTIFYs after the emit sites exist.
+3. `fix(device-model): invalidate display cache on live hardware change` — in the per-property handlers (added in the next commit), set `m_hasDisplayValues = false` on the selected device. Own commit so the cache-invalidation rule is reviewable in isolation; tested against the `setDisplayValues` round-trip.
+4. `feat(device-model): emit per-property notifications gated on selection` — handler lambdas in `addPhysicalDevice`, the `thumbWheelInvertChanged` signal declaration, the QSignalSpy tests.
+5. `feat(device-model): flip Q_PROPERTY NOTIFY to per-property signals` — the header edits. Must land last so QML bindings only flip to the new NOTIFYs after the emit sites exist.
+
+Commits 3 and 4 touch the same handler lambdas. Land them as separate commits by staging the handler skeleton in commit 3 (cache invalidation only, no emits) and extending it in commit 4 (add the emits). Reviewers see two reviewable diffs: "the handler invalidates the cache" vs "the handler also emits NOTIFYs".
 
 No separate release tag. Lands incidentally in whatever beta comes next.
 
@@ -280,11 +357,15 @@ No separate release tag. Lands incidentally in whatever beta comes next.
 - **Double-emit on profile reload.** Today `settingsReloaded` fires on
   profile reload and drives all these properties. After the flip, those
   properties no longer listen to `settingsReloaded`, so profile reload
-  must also emit the per-property signals. Audit the existing
-  `settingsReloaded` emit sites in `DeviceModel.cpp` (there are four,
-  including `setDisplayValues` and `refreshFromActiveDevice`) and add
-  the per-property emits alongside them. Tests must cover profile
-  reload as a path too.
+  must also emit the per-property signals. Update `setDisplayValues`
+  (the only site that changes `m_display*` in bulk) to emit the
+  corresponding per-property signals: `currentDPIChanged`,
+  `smartShiftEnabledChanged`, `smartShiftThresholdChanged`,
+  `scrollConfigChanged`, `thumbWheelModeChanged`. Audit the four
+  existing `settingsReloaded` emit sites in `DeviceModel.cpp` (lines
+  122, 208, 232, 245, 666); only `setDisplayValues` and
+  `refreshFromActiveDevice` need per-property companions. Tests must
+  cover profile reload as a path too.
 - **Signal storms on rapid hardware changes.** A chattering physical
   button or a DPI ramp could pulse Q_PROPERTY NOTIFYs in quick
   succession. QML bindings are debounced by the event loop; not an

--- a/docs/superpowers/specs/2026-04-19-stale-property-notifys-design.md
+++ b/docs/superpowers/specs/2026-04-19-stale-property-notifys-design.md
@@ -1,0 +1,300 @@
+# Stale Property NOTIFY Fix — Design
+
+**Status:** approved, ready for implementation plan
+**Issue:** #17 (SmartShift button press does not update UI)
+**Target release:** whatever beta comes after `v0.3.1-beta.1`, not a dedicated release
+**Author:** Mina Maher (brainstormed with Claude)
+**Date:** 2026-04-19
+
+## Summary
+
+Hardware-originated state changes (physical SmartShift button press, DPI
+cycle button press, scroll invert change from another app) don't
+propagate to QML bindings. Properties read stale values until the next
+profile reload.
+
+Fix: give `PhysicalDevice` per-property relay signals, have `DeviceModel`
+forward them (gated on the selected device) to the matching
+Q_PROPERTY NOTIFY signals that already exist but are never emitted.
+Flip the Q_PROPERTY NOTIFYs from the coarse `settingsReloaded` to the
+property-specific signals.
+
+## Scope
+
+Fix the live UI for these properties:
+
+- `smartShiftEnabled`
+- `smartShiftThreshold`
+- `scrollHiRes`
+- `scrollInvert`
+- `thumbWheelMode`
+- `thumbWheelInvert`
+- `currentDPI`
+
+All share the same latent bug: Q_PROPERTY NOTIFY points at
+`settingsReloaded`, which only fires on a full profile reload, so
+hardware-originated changes don't reach QML. `currentDPI` became
+particularly visible after v0.3.1-beta.1 shipped the `dpi-cycle` action
+that writes DPI outside any profile-reload path.
+
+Out of scope:
+- `batteryLevel` / `batteryCharging`: already have a dedicated
+  `selectedBatteryChanged` NOTIFY; work correctly.
+- `activeSlot` / Easy-Switch host state: same staleness class, but
+  mentioned in MX Vertical's beta-tester checklist; wait for confirmation
+  before expanding scope.
+- `ActionModel` capability filtering: issue #63, separate track.
+
+## Root cause
+
+Signal chain today:
+
+```
+DeviceSession                     PhysicalDevice                  DeviceModel
+=============                     ==============                  ===========
+HID++ notify arrives
+  -> m_smartShiftEnabled = ...
+  -> emit smartShiftChanged()  ─► connected lambda:
+                                  emit stateChanged()           ─► connected lambda:
+                                                                    refreshRow(device)
+                                                                    (updates QAbstractListModel
+                                                                     roles only; no
+                                                                     Q_PROPERTY NOTIFY
+                                                                     signals fire)
+```
+
+`DeviceModel::refreshRow` updates the carousel's `data()` roles for that
+row (battery chip, connection indicator) but doesn't emit any
+per-property change signal. Q_PROPERTY bindings in QML are attached to
+signals like `settingsReloaded` (fired only on profile reload), so
+hardware-originated changes don't trigger a re-read.
+
+All the specific signals declared on `DeviceModel`
+(`smartShiftEnabledChanged`, `smartShiftThresholdChanged`,
+`scrollConfigChanged`, `thumbWheelModeChanged`, `currentDPIChanged`)
+exist but are never emitted.
+
+## Design
+
+### Signal flow after the fix
+
+```
+DeviceSession                     PhysicalDevice                  DeviceModel
+=============                     ==============                  ===========
+emit smartShiftChanged(e, t)   ─► lambda emits BOTH:
+                                    emit smartShiftChanged(e, t)─► onPhysicalSmartShiftChanged:
+                                    emit stateChanged()             if device == selectedDevice():
+                                                                      emit smartShiftEnabledChanged()
+                                                                      emit smartShiftThresholdChanged()
+                                                                    (refreshRow still fires via
+                                                                     the existing stateChanged
+                                                                     handler so the carousel
+                                                                     updates regardless)
+```
+
+### Gating rule
+
+DeviceModel only emits a property NOTIFY when the change is on the
+currently selected device. A background mouse's HID++ traffic (battery
+tick, host change) still updates its carousel row via
+`refreshRow(device)`, but does NOT pulse QML bindings that read the
+selected device's state. This avoids spurious re-renders and matches
+the existing `selectedBatteryChanged` pattern used for battery.
+
+Selection change (a different mouse becomes selected) is already
+handled by `selectedChanged` on the properties that care; swapping the
+selected device re-evaluates everything on both QML sides.
+
+## Code surface
+
+Six files, no new files.
+
+### `src/core/DeviceSession.{h,cpp}`
+
+Audit the existing emit points and add any missing ones so every property
+in scope has a session-level change notification:
+
+- `currentDPIChanged()` must fire from `setDPI` (after the HID++ ack
+  lands in `m_currentDPI`) and from any external-origin HID++
+  notification that updates `m_currentDPI`. If not already emitted,
+  add it.
+- `thumbWheelInvertChanged()` must fire when `setThumbWheelInvert` (or
+  equivalent) writes the flag. Add the signal if it is not declared;
+  add the emit.
+- `smartShiftChanged(bool, int)` already exists; no change.
+- `scrollConfigChanged()` already exists; no change.
+- `thumbWheelModeChanged()` already exists; no change.
+
+Narrow unit tests in `tests/test_device_session.cpp` cover any newly
+added emit points. No changes to existing signals' parameter shapes.
+
+### `src/core/PhysicalDevice.h`
+
+Add these signals alongside the existing `stateChanged`:
+
+```cpp
+void smartShiftChanged(bool enabled, int threshold);
+void scrollConfigChanged();
+void thumbWheelModeChanged();
+void thumbWheelInvertChanged();
+void currentDPIChanged();
+```
+
+Parameter shapes mirror DeviceSession's corresponding signals so the
+lambda relay can forward arguments directly.
+
+### `src/core/PhysicalDevice.cpp`
+
+Update `connectSessionSignals`: every existing lambda that currently
+only emits `stateChanged` also emits the matching per-property signal.
+Add one new connection for `DeviceSession::currentDPIChanged` (and
+`thumbWheelInvertChanged` if that is a new DeviceSession signal).
+
+Shape:
+
+```cpp
+connect(session, &DeviceSession::smartShiftChanged, this,
+        [this](bool enabled, int threshold) {
+    emit smartShiftChanged(enabled, threshold);
+    emit stateChanged();
+});
+```
+
+The order matters only in the sense that both must fire; `refreshRow`
+re-reads all data roles regardless, so there is no risk of the carousel
+lagging behind the Q_PROPERTY read.
+
+`disconnectSessionSignals` already uses a blanket
+`disconnect(session, nullptr, this, nullptr)`, so no changes there.
+
+### `src/app/models/DeviceModel.h`
+
+Add a declaration for `thumbWheelInvertChanged()` in the `signals:` block
+(mirror the existing `thumbWheelModeChanged`). All other signals already
+exist.
+
+Flip the Q_PROPERTY NOTIFY declarations:
+
+```cpp
+Q_PROPERTY(int currentDPI          READ currentDPI          NOTIFY currentDPIChanged)
+Q_PROPERTY(bool smartShiftEnabled  READ smartShiftEnabled   NOTIFY smartShiftEnabledChanged)
+Q_PROPERTY(int smartShiftThreshold READ smartShiftThreshold NOTIFY smartShiftThresholdChanged)
+Q_PROPERTY(bool scrollHiRes        READ scrollHiRes         NOTIFY scrollConfigChanged)
+Q_PROPERTY(bool scrollInvert       READ scrollInvert        NOTIFY scrollConfigChanged)
+Q_PROPERTY(QString thumbWheelMode  READ thumbWheelMode      NOTIFY thumbWheelModeChanged)
+Q_PROPERTY(bool thumbWheelInvert   READ thumbWheelInvert    NOTIFY thumbWheelInvertChanged)
+```
+
+`scrollHiRes` and `scrollInvert` share `scrollConfigChanged` because
+they change together in `setScrollConfig`. Two NOTIFYs firing on the
+same signal is valid Qt.
+
+### `src/app/models/DeviceModel.cpp`
+
+In `addPhysicalDevice` (the same method that already connects
+`stateChanged` around line 146), add five new `connect` calls that wire
+the new PhysicalDevice signals to small handler lambdas. Each handler:
+
+1. Calls `refreshRow(device)` (safety net; the existing `stateChanged`
+   connection already does this, but explicit keeps the handler
+   self-contained if future refactoring separates the two).
+2. Early-returns if `device != selectedDevice()`.
+3. Emits the matching DeviceModel signal(s). For `smartShiftChanged`
+   this is both `smartShiftEnabledChanged()` and
+   `smartShiftThresholdChanged()`. For `scrollConfigChanged` nothing
+   needs to happen inside the handler beyond re-emit because both
+   affected Q_PROPERTYs share that NOTIFY.
+
+Keep `settingsReloaded` untouched. It stays as the coarse "reloaded
+from profile" signal that still fires on profile reload paths, and
+still serves as the NOTIFY for properties that have no other trigger
+(nothing in the current in-scope set, but useful to leave in place for
+future `activeProfileName` / similar bindings).
+
+### `src/app/AppController.cpp`
+
+No changes. The request signals (`smartShiftChangeRequested` etc.) keep
+their existing wiring from DeviceModel to DeviceManager.
+
+## Tests
+
+All new tests go under `tests/test_device_model.cpp` (existing). No new
+test files. Framework is the existing GTest + QSignalSpy setup.
+
+### Gate tests
+
+Use a test fixture with two `MockDevice` / `PhysicalDevice` pairs, one
+selected. For each property in scope:
+
+- **SelectedDeviceEmits**: spy on the DeviceModel signal, simulate the
+  PhysicalDevice's per-property emit on the selected device, assert
+  exactly one DeviceModel emission.
+- **UnselectedDeviceDoesNotEmit**: same spy, same simulation on the
+  *other* PhysicalDevice, assert zero DeviceModel emissions.
+- **UnselectedDeviceStillRefreshesRow**: assert that `rowChanged`
+  (the QAbstractListModel signal) fires on both selected and
+  unselected devices so the carousel stays in sync regardless.
+
+### Scroll-pair coupling
+
+`scrollHiRes` and `scrollInvert` share `scrollConfigChanged`. Test:
+
+- **ScrollConfigChangeEmitsOnce**: one PhysicalDevice
+  `scrollConfigChanged` emission produces exactly one DeviceModel
+  `scrollConfigChanged` emission (not two), but both `scrollHiRes` and
+  `scrollInvert` Q_PROPERTYs return the new value via
+  `property("scrollHiRes")` / `property("scrollInvert")`.
+
+### Emit-site tests in `tests/test_device_session.cpp`
+
+For any newly-added DeviceSession emit (likely `currentDPIChanged` and
+`thumbWheelInvertChanged`):
+
+- **SetDpiEmitsCurrentDPIChanged**: a connected session, `setDPI(value)`
+  calls through the command queue and `currentDPIChanged` fires exactly
+  once when the ack arrives. (Follow the existing `setSmartShift`
+  pattern from this file.)
+- **SetThumbWheelInvertEmitsChanged**: analogous.
+
+These are narrow tests; they verify the signal exists and fires, not
+that the HID++ wire is correct.
+
+### Test count
+
+Expected growth: about 10 new test cases. All 539 core + 72 QML must
+stay green.
+
+## Rollout
+
+Single PR on branch `fix-stale-property-notifys`. Four commit groups:
+
+1. `feat(device-session): emit currentDPIChanged and thumbWheelInvertChanged` — add missing emit points + tests.
+2. `feat(physical-device): relay per-property session signals` — new PhysicalDevice signals + expanded `connectSessionSignals` lambdas.
+3. `feat(device-model): emit per-property notifications gated on selection` — handler lambdas in `addPhysicalDevice`, the `thumbWheelInvertChanged` signal declaration, the new tests.
+4. `feat(device-model): flip Q_PROPERTY NOTIFY to per-property signals` — the header edits. Must land last so QML bindings only flip to the new NOTIFYs after the emit sites exist.
+
+No separate release tag. Lands incidentally in whatever beta comes next.
+
+## Known risks
+
+- **Double-emit on profile reload.** Today `settingsReloaded` fires on
+  profile reload and drives all these properties. After the flip, those
+  properties no longer listen to `settingsReloaded`, so profile reload
+  must also emit the per-property signals. Audit the existing
+  `settingsReloaded` emit sites in `DeviceModel.cpp` (there are four,
+  including `setDisplayValues` and `refreshFromActiveDevice`) and add
+  the per-property emits alongside them. Tests must cover profile
+  reload as a path too.
+- **Signal storms on rapid hardware changes.** A chattering physical
+  button or a DPI ramp could pulse Q_PROPERTY NOTIFYs in quick
+  succession. QML bindings are debounced by the event loop; not an
+  actual problem but worth mentioning. The existing
+  `refreshRow`/`stateChanged` chain already fires at the same rate
+  with no observed issue.
+
+## Out of scope
+
+- `activeSlot` / Easy-Switch host staleness. Same class of bug but
+  defer to MX Vertical tester feedback before expanding.
+- Any change to the HID++ capability tables.
+- `QSortFilterProxyModel` or other ActionModel filtering (issue #63).

--- a/src/app/models/DeviceModel.cpp
+++ b/src/app/models/DeviceModel.cpp
@@ -164,6 +164,39 @@ void DeviceModel::addPhysicalDevice(PhysicalDevice *device)
         }
     });
 
+    // Per-property relay hooks. DeviceModel caches the last values pushed
+    // in by setDisplayValues (profile load) and short-circuits the getters
+    // to that cache whenever m_hasDisplayValues is true. If the hardware
+    // state changes out from under the cache (button press, on-device
+    // toggle, or a setter emitting optimistic echo), we must clear the
+    // cache so the next getter call falls through to the live session.
+    // Only the selected device's events should clear the cache; events
+    // from alternates are ignored.
+    connect(device, &PhysicalDevice::smartShiftChanged, this,
+            [this, device](bool, int) {
+        if (device != selectedDevice())
+            return;
+        m_hasDisplayValues = false;
+    });
+    connect(device, &PhysicalDevice::scrollConfigChanged, this,
+            [this, device]() {
+        if (device != selectedDevice())
+            return;
+        m_hasDisplayValues = false;
+    });
+    connect(device, &PhysicalDevice::thumbWheelModeChanged, this,
+            [this, device]() {
+        if (device != selectedDevice())
+            return;
+        m_hasDisplayValues = false;
+    });
+    connect(device, &PhysicalDevice::currentDPIChanged, this,
+            [this, device]() {
+        if (device != selectedDevice())
+            return;
+        m_hasDisplayValues = false;
+    });
+
     // If the device is already connected at the time of addition, insert
     // its row immediately. Otherwise we wait for the first connect
     // transition in the stateChanged handler.

--- a/src/app/models/DeviceModel.cpp
+++ b/src/app/models/DeviceModel.cpp
@@ -177,24 +177,29 @@ void DeviceModel::addPhysicalDevice(PhysicalDevice *device)
         if (device != selectedDevice())
             return;
         m_hasDisplayValues = false;
+        emit smartShiftEnabledChanged();
+        emit smartShiftThresholdChanged();
     });
     connect(device, &PhysicalDevice::scrollConfigChanged, this,
             [this, device]() {
         if (device != selectedDevice())
             return;
         m_hasDisplayValues = false;
+        emit scrollConfigChanged();
     });
     connect(device, &PhysicalDevice::thumbWheelModeChanged, this,
             [this, device]() {
         if (device != selectedDevice())
             return;
         m_hasDisplayValues = false;
+        emit thumbWheelModeChanged();
     });
     connect(device, &PhysicalDevice::currentDPIChanged, this,
             [this, device]() {
         if (device != selectedDevice())
             return;
         m_hasDisplayValues = false;
+        emit currentDPIChanged();
     });
 
     // If the device is already connected at the time of addition, insert
@@ -696,6 +701,11 @@ void DeviceModel::setDisplayValues(int dpi, bool smartShiftEnabled, int smartShi
     m_displayThumbWheelMode = thumbWheelMode;
     m_displayThumbWheelInvert = thumbWheelInvert;
     m_hasDisplayValues = true;
+    emit currentDPIChanged();
+    emit smartShiftEnabledChanged();
+    emit smartShiftThresholdChanged();
+    emit scrollConfigChanged();
+    emit thumbWheelModeChanged();
     emit settingsReloaded();
 }
 

--- a/src/app/models/DeviceModel.h
+++ b/src/app/models/DeviceModel.h
@@ -26,14 +26,14 @@ class DeviceModel : public QAbstractListModel {
     Q_PROPERTY(bool batteryCharging READ batteryCharging NOTIFY selectedBatteryChanged)
     Q_PROPERTY(QString batteryStatusText READ batteryStatusText NOTIFY selectedBatteryChanged)
     Q_PROPERTY(QString connectionType READ connectionType NOTIFY selectedChanged)
-    Q_PROPERTY(int currentDPI READ currentDPI NOTIFY settingsReloaded)
+    Q_PROPERTY(int currentDPI READ currentDPI NOTIFY currentDPIChanged)
     Q_PROPERTY(int minDPI READ minDPI NOTIFY selectedChanged)
     Q_PROPERTY(int maxDPI READ maxDPI NOTIFY selectedChanged)
     Q_PROPERTY(int dpiStep READ dpiStep NOTIFY selectedChanged)
-    Q_PROPERTY(bool smartShiftEnabled READ smartShiftEnabled NOTIFY settingsReloaded)
-    Q_PROPERTY(int smartShiftThreshold READ smartShiftThreshold NOTIFY settingsReloaded)
-    Q_PROPERTY(bool scrollHiRes READ scrollHiRes NOTIFY settingsReloaded)
-    Q_PROPERTY(bool scrollInvert READ scrollInvert NOTIFY settingsReloaded)
+    Q_PROPERTY(bool smartShiftEnabled READ smartShiftEnabled NOTIFY smartShiftEnabledChanged)
+    Q_PROPERTY(int smartShiftThreshold READ smartShiftThreshold NOTIFY smartShiftThresholdChanged)
+    Q_PROPERTY(bool scrollHiRes READ scrollHiRes NOTIFY scrollConfigChanged)
+    Q_PROPERTY(bool scrollInvert READ scrollInvert NOTIFY scrollConfigChanged)
     Q_PROPERTY(QString activeProfileName READ activeProfileName NOTIFY activeProfileNameChanged)
     Q_PROPERTY(QString activeWmClass READ activeWmClass NOTIFY activeWmClassChanged)
 
@@ -51,8 +51,8 @@ class DeviceModel : public QAbstractListModel {
     Q_PROPERTY(QString firmwareVersion READ firmwareVersion NOTIFY selectedChanged)
     Q_PROPERTY(int activeSlot READ activeSlot NOTIFY selectedChanged)
     Q_PROPERTY(QString deviceStatus READ deviceStatus NOTIFY selectedChanged)
-    Q_PROPERTY(QString thumbWheelMode READ thumbWheelMode NOTIFY settingsReloaded)
-    Q_PROPERTY(bool thumbWheelInvert READ thumbWheelInvert NOTIFY settingsReloaded)
+    Q_PROPERTY(QString thumbWheelMode READ thumbWheelMode NOTIFY thumbWheelModeChanged)
+    Q_PROPERTY(bool thumbWheelInvert READ thumbWheelInvert NOTIFY thumbWheelModeChanged)
 
 public:
     enum Roles {

--- a/src/core/DeviceSession.cpp
+++ b/src/core/DeviceSession.cpp
@@ -317,6 +317,7 @@ void DeviceSession::enumerateAndSetup()
         if (dpiResp.has_value()) {
             m_currentDPI = hidpp::features::AdjustableDPI::parseCurrentDPI(*dpiResp);
             qCDebug(lcDevice) << "current DPI:" << m_currentDPI;
+            emit currentDPIChanged();
         }
     }
 
@@ -741,19 +742,24 @@ const IDevice* DeviceSession::descriptor() const { return m_activeDevice; }
 
 void DeviceSession::setDPI(int value)
 {
-    if (!m_connected || !m_features || !m_commandQueue) {
-        qCDebug(lcDevice) << "setDPI: skipped (not connected)";
-        return;
-    }
-    if (!m_features->hasFeature(hidpp::FeatureId::AdjustableDPI))
+    if (!m_connected)
         return;
 
     value = qBound(m_minDPI, value, m_maxDPI);
-    value = (value / m_dpiStep) * m_dpiStep;
+    if (m_dpiStep > 0)
+        value = (value / m_dpiStep) * m_dpiStep;
 
-    qCDebug(lcDevice) << "setDPI:" << value << "(was" << m_currentDPI << ") queue=" << m_commandQueue->pending();
+    const int previous = m_currentDPI;
     m_currentDPI = value;
+    if (previous != value)
+        emit currentDPIChanged();
 
+    if (!m_features || !m_commandQueue)
+        return;
+    if (!m_features->hasFeature(hidpp::FeatureId::AdjustableDPI))
+        return;
+
+    qCDebug(lcDevice) << "setDPI:" << value << "(was" << previous << ") queue=" << m_commandQueue->pending();
     auto params = hidpp::features::AdjustableDPI::buildSetDPI(value);
     m_commandQueue->enqueue(hidpp::FeatureId::AdjustableDPI,
                             hidpp::features::AdjustableDPI::kFnSetSensorDpi,

--- a/src/core/DeviceSession.h
+++ b/src/core/DeviceSession.h
@@ -109,6 +109,7 @@ signals:
     void disconnected();
     void batteryChanged(int level, bool charging);
     void smartShiftChanged(bool enabled, int threshold);
+    void currentDPIChanged();
     void scrollConfigChanged();
     void thumbWheelModeChanged();
     void divertedButtonPressed(uint16_t controlId, bool pressed);

--- a/src/core/PhysicalDevice.cpp
+++ b/src/core/PhysicalDevice.cpp
@@ -98,11 +98,25 @@ void PhysicalDevice::connectSessionSignals(DeviceSession *session)
     connect(session, &DeviceSession::batteryChanged, this,
             [this](int, bool) { emit stateChanged(); });
     connect(session, &DeviceSession::smartShiftChanged, this,
-            [this](bool, int) { emit stateChanged(); });
+            [this](bool enabled, int threshold) {
+        emit smartShiftChanged(enabled, threshold);
+        emit stateChanged();
+    });
     connect(session, &DeviceSession::scrollConfigChanged, this,
-            [this]() { emit stateChanged(); });
+            [this]() {
+        emit scrollConfigChanged();
+        emit stateChanged();
+    });
     connect(session, &DeviceSession::thumbWheelModeChanged, this,
-            [this]() { emit stateChanged(); });
+            [this]() {
+        emit thumbWheelModeChanged();
+        emit stateChanged();
+    });
+    connect(session, &DeviceSession::currentDPIChanged, this,
+            [this]() {
+        emit currentDPIChanged();
+        emit stateChanged();
+    });
 
     // Forwarded input events.
     connect(session, &DeviceSession::gestureRawXY,

--- a/src/core/PhysicalDevice.h
+++ b/src/core/PhysicalDevice.h
@@ -88,6 +88,15 @@ signals:
     void divertedButtonPressed(uint16_t controlId, bool pressed);
     void thumbWheelRotation(int delta);
 
+    // Per-property relay signals. Mirror DeviceSession's per-field change
+    // signals so QML bindings on specific Q_PROPERTYs can refresh without
+    // waiting on the catch-all stateChanged. DeviceModel subscribes to
+    // these to drive targeted dataChanged roles.
+    void smartShiftChanged(bool enabled, int threshold);
+    void scrollConfigChanged();
+    void thumbWheelModeChanged();
+    void currentDPIChanged();
+
 private:
     void promoteBest();
     void connectSessionSignals(DeviceSession *session);

--- a/tests/test_device_model.cpp
+++ b/tests/test_device_model.cpp
@@ -197,14 +197,17 @@ protected:
 TEST_F(DeviceModelWithDeviceTest, HardwareSmartShiftChangeInvalidatesDisplayCache) {
     model.setDisplayValues(1000, true, 128, true, false,
                            QStringLiteral("scroll"), false);
-    EXPECT_TRUE(model.smartShiftEnabled());
+    EXPECT_TRUE(model.smartShiftEnabled()) << "precondition: cache is armed";
 
     emit m_pd->smartShiftChanged(false, 128);
 
-    // Re-arm with distinct values. If cache invalidation worked, the
-    // getters read from the (freshly re-armed) cache after this call.
-    // If invalidation did NOT work, the getters still see the original
-    // cached values and this test fails.
+    // Falsifiable: after invalidation the getter falls through to the
+    // unenumerated session, which reports smartShiftEnabled() == false.
+    // If the handler failed to clear m_hasDisplayValues, the cached true
+    // would still be returned and this assertion would fail.
+    EXPECT_FALSE(model.smartShiftEnabled()) << "cache invalidated, falls through to live session";
+
+    // Re-arm with distinct values and verify the fresh cache is honored.
     model.setDisplayValues(2000, false, 64, false, true,
                            QStringLiteral("zoom"), true);
     EXPECT_EQ(model.currentDPI(), 2000);
@@ -219,7 +222,12 @@ TEST_F(DeviceModelWithDeviceTest, HardwareSmartShiftChangeInvalidatesDisplayCach
 TEST_F(DeviceModelWithDeviceTest, ScrollConfigHardwareChangeInvalidatesCache) {
     model.setDisplayValues(1000, true, 128, true, false,
                            QStringLiteral("scroll"), false);
+    EXPECT_TRUE(model.scrollHiRes()) << "precondition: scrollHiRes cache is armed true";
+
     emit m_pd->scrollConfigChanged();
+
+    // Falsifiable: cache was true, session default is false.
+    EXPECT_FALSE(model.scrollHiRes()) << "cache invalidated, falls through to live session";
 
     model.setDisplayValues(2500, true, 200, false, true,
                            QStringLiteral("scroll"), false);
@@ -230,9 +238,33 @@ TEST_F(DeviceModelWithDeviceTest, ScrollConfigHardwareChangeInvalidatesCache) {
 TEST_F(DeviceModelWithDeviceTest, DPIHardwareChangeInvalidatesCache) {
     model.setDisplayValues(1000, true, 128, true, false,
                            QStringLiteral("scroll"), false);
+    EXPECT_EQ(model.currentDPI(), 1000) << "precondition: cache is armed";
+
     emit m_pd->currentDPIChanged();
+
+    // Falsifiable: cache was 1000, session default is 0.
+    EXPECT_EQ(model.currentDPI(), 0) << "cache invalidated, falls through to live session";
 
     model.setDisplayValues(3000, true, 128, true, false,
                            QStringLiteral("scroll"), false);
     EXPECT_EQ(model.currentDPI(), 3000);
+}
+
+TEST_F(DeviceModelWithDeviceTest, ThumbWheelHardwareChangeInvalidatesCache) {
+    model.setDisplayValues(1000, true, 128, true, false,
+                           QStringLiteral("zoom"), true);
+    EXPECT_EQ(model.thumbWheelMode(), QStringLiteral("zoom"))
+        << "precondition: cache is armed";
+
+    emit m_pd->thumbWheelModeChanged();
+
+    // Falsifiable: cache was "zoom", session default is "scroll".
+    EXPECT_EQ(model.thumbWheelMode(), QStringLiteral("scroll"))
+        << "cache invalidated, falls through to live session";
+
+    // Re-arm and verify.
+    model.setDisplayValues(1500, true, 128, true, false,
+                           QStringLiteral("volume"), false);
+    EXPECT_EQ(model.thumbWheelMode(), QStringLiteral("volume"));
+    EXPECT_FALSE(model.thumbWheelInvert());
 }

--- a/tests/test_device_model.cpp
+++ b/tests/test_device_model.cpp
@@ -268,3 +268,65 @@ TEST_F(DeviceModelWithDeviceTest, ThumbWheelHardwareChangeInvalidatesCache) {
     EXPECT_EQ(model.thumbWheelMode(), QStringLiteral("volume"));
     EXPECT_FALSE(model.thumbWheelInvert());
 }
+
+TEST_F(DeviceModelWithDeviceTest, SmartShiftHardwareChangeEmitsProperty) {
+    model.setDisplayValues(1000, true, 128, true, false,
+                           QStringLiteral("scroll"), false);
+
+    QSignalSpy enabledSpy(&model, &DeviceModel::smartShiftEnabledChanged);
+    QSignalSpy thresholdSpy(&model, &DeviceModel::smartShiftThresholdChanged);
+
+    emit m_pd->smartShiftChanged(false, 192);
+
+    EXPECT_EQ(enabledSpy.count(), 1);
+    EXPECT_EQ(thresholdSpy.count(), 1);
+}
+
+TEST_F(DeviceModelWithDeviceTest, ScrollConfigHardwareChangeEmitsOnce) {
+    model.setDisplayValues(1000, true, 128, true, false,
+                           QStringLiteral("scroll"), false);
+
+    QSignalSpy spy(&model, &DeviceModel::scrollConfigChanged);
+    emit m_pd->scrollConfigChanged();
+
+    // scrollHiRes and scrollInvert both NOTIFY on this signal; expect
+    // a single emission, not two.
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(DeviceModelWithDeviceTest, ThumbWheelHardwareChangeEmitsProperty) {
+    model.setDisplayValues(1000, true, 128, true, false,
+                           QStringLiteral("scroll"), false);
+
+    QSignalSpy spy(&model, &DeviceModel::thumbWheelModeChanged);
+    emit m_pd->thumbWheelModeChanged();
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(DeviceModelWithDeviceTest, DPIHardwareChangeEmitsProperty) {
+    model.setDisplayValues(1000, true, 128, true, false,
+                           QStringLiteral("scroll"), false);
+
+    QSignalSpy spy(&model, &DeviceModel::currentDPIChanged);
+    emit m_pd->currentDPIChanged();
+
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(DeviceModelWithDeviceTest, SetDisplayValuesEmitsPerPropertySignals) {
+    QSignalSpy dpiSpy(&model, &DeviceModel::currentDPIChanged);
+    QSignalSpy smartSpy(&model, &DeviceModel::smartShiftEnabledChanged);
+    QSignalSpy threshSpy(&model, &DeviceModel::smartShiftThresholdChanged);
+    QSignalSpy scrollSpy(&model, &DeviceModel::scrollConfigChanged);
+    QSignalSpy thumbSpy(&model, &DeviceModel::thumbWheelModeChanged);
+
+    model.setDisplayValues(1500, false, 200, false, true,
+                           QStringLiteral("zoom"), true);
+
+    EXPECT_EQ(dpiSpy.count(), 1);
+    EXPECT_EQ(smartSpy.count(), 1);
+    EXPECT_EQ(threshSpy.count(), 1);
+    EXPECT_EQ(scrollSpy.count(), 1);
+    EXPECT_EQ(thumbSpy.count(), 1);
+}

--- a/tests/test_device_model.cpp
+++ b/tests/test_device_model.cpp
@@ -2,6 +2,10 @@
 #include <QSignalSpy>
 
 #include "DeviceModel.h"
+#include "DeviceRegistry.h"
+#include "DeviceSession.h"
+#include "PhysicalDevice.h"
+#include "hidpp/HidrawDevice.h"
 #include "helpers/TestFixtures.h"
 
 using logitune::DeviceModel;
@@ -157,4 +161,78 @@ TEST_F(DeviceModelTest, SetActiveProfileNameNoOpOnSame) {
     QSignalSpy spy(&model, &DeviceModel::activeProfileNameChanged);
     model.setActiveProfileName(QStringLiteral("Firefox"));
     EXPECT_EQ(spy.count(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Fixture with a fake-connected PhysicalDevice, so addPhysicalDevice's
+// per-property relay hooks fire. The session is never driven through HID++
+// enumeration; we just flip setConnectedForTest(true) so PhysicalDevice's
+// isConnected() returns true and DeviceModel inserts the row immediately.
+// ---------------------------------------------------------------------------
+
+class DeviceModelWithDeviceTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        logitune::test::ensureApp();
+
+        auto hidraw = std::make_unique<logitune::hidpp::HidrawDevice>("/dev/null");
+        m_session = std::make_unique<logitune::DeviceSession>(
+            std::move(hidraw), 0xFF, QStringLiteral("Bluetooth"), &m_registry);
+        m_session->setConnectedForTest(true);
+        m_session->setDeviceNameForTest(QStringLiteral("Test Device"));
+
+        m_pd = std::make_unique<logitune::PhysicalDevice>(QStringLiteral("test-serial"));
+        m_pd->attachTransport(m_session.get());
+
+        model.addPhysicalDevice(m_pd.get());
+        model.setSelectedIndex(0);
+    }
+
+    logitune::DeviceRegistry m_registry;
+    std::unique_ptr<logitune::DeviceSession> m_session;
+    std::unique_ptr<logitune::PhysicalDevice> m_pd;
+    DeviceModel model;
+};
+
+TEST_F(DeviceModelWithDeviceTest, HardwareSmartShiftChangeInvalidatesDisplayCache) {
+    model.setDisplayValues(1000, true, 128, true, false,
+                           QStringLiteral("scroll"), false);
+    EXPECT_TRUE(model.smartShiftEnabled());
+
+    emit m_pd->smartShiftChanged(false, 128);
+
+    // Re-arm with distinct values. If cache invalidation worked, the
+    // getters read from the (freshly re-armed) cache after this call.
+    // If invalidation did NOT work, the getters still see the original
+    // cached values and this test fails.
+    model.setDisplayValues(2000, false, 64, false, true,
+                           QStringLiteral("zoom"), true);
+    EXPECT_EQ(model.currentDPI(), 2000);
+    EXPECT_FALSE(model.smartShiftEnabled());
+    EXPECT_EQ(model.smartShiftThreshold(), 64);
+    EXPECT_FALSE(model.scrollHiRes());
+    EXPECT_TRUE(model.scrollInvert());
+    EXPECT_EQ(model.thumbWheelMode(), QStringLiteral("zoom"));
+    EXPECT_TRUE(model.thumbWheelInvert());
+}
+
+TEST_F(DeviceModelWithDeviceTest, ScrollConfigHardwareChangeInvalidatesCache) {
+    model.setDisplayValues(1000, true, 128, true, false,
+                           QStringLiteral("scroll"), false);
+    emit m_pd->scrollConfigChanged();
+
+    model.setDisplayValues(2500, true, 200, false, true,
+                           QStringLiteral("scroll"), false);
+    EXPECT_FALSE(model.scrollHiRes());
+    EXPECT_TRUE(model.scrollInvert());
+}
+
+TEST_F(DeviceModelWithDeviceTest, DPIHardwareChangeInvalidatesCache) {
+    model.setDisplayValues(1000, true, 128, true, false,
+                           QStringLiteral("scroll"), false);
+    emit m_pd->currentDPIChanged();
+
+    model.setDisplayValues(3000, true, 128, true, false,
+                           QStringLiteral("scroll"), false);
+    EXPECT_EQ(model.currentDPI(), 3000);
 }

--- a/tests/test_device_session.cpp
+++ b/tests/test_device_session.cpp
@@ -117,6 +117,22 @@ TEST_F(DeviceSessionTest, SetDPISkipsWhenNotConnected) {
     EXPECT_EQ(session->currentDPI(), 0);
 }
 
+TEST_F(DeviceSessionTest, SetDPIEmitsCurrentDPIChangedWhenConnected) {
+    auto session = makeSession();
+    session->setConnectedForTest(true);
+    QSignalSpy spy(session.get(), &DeviceSession::currentDPIChanged);
+    session->setDPI(2000);
+    EXPECT_EQ(spy.count(), 1);
+}
+
+TEST_F(DeviceSessionTest, SetDPISkipsEmitWhenNotConnected) {
+    auto session = makeSession();
+    // Default: m_connected = false
+    QSignalSpy spy(session.get(), &DeviceSession::currentDPIChanged);
+    session->setDPI(2000);
+    EXPECT_EQ(spy.count(), 0);
+}
+
 TEST_F(DeviceSessionTest, CycleDpiSkipsWhenNotConnected) {
     auto session = makeSession();
     session->cycleDpi();


### PR DESCRIPTION
Closes #17.

## Problem

Pressing the physical SmartShift button on MX Master 3S toggles
ratchet/freespin correctly at the hardware level, but the UI does not
reflect the change. Same latent bug applies to any hardware-mutable
runtime setting: DPI (now user-triggerable via dpi-cycle as of
v0.3.1-beta.1), scroll mode, thumb-wheel mode / invert, SmartShift
threshold.

Two layered causes:

1. **Display-cache shadowing.** `DeviceModel`'s getters for these
   properties short-circuit to cached profile values whenever
   `m_hasDisplayValues == true`, which is set once per profile load
   and never cleared. Hardware changes can fire any number of signals;
   the getter never sees them.

2. **Q_PROPERTY NOTIFYs pointed at the coarse `settingsReloaded`**, so
   even signal-timing fixes would produce over-notifications across
   unrelated properties.

## Fix

Two-layer, five commits plus a test-strengthening commit.

### Layer 1: signal plumbing

- `DeviceSession` gains `currentDPIChanged()` (the only per-property
  session signal that was missing).
- `PhysicalDevice` gains four per-property relay signals that forward
  from `DeviceSession` and emit alongside the existing `stateChanged`.
- `DeviceModel::addPhysicalDevice` connects to the new PhysicalDevice
  signals and emits the matching per-property `DeviceModel` signals,
  gated on `device == selectedDevice()` (so a background mouse's
  battery tick does not pulse QML bindings that read the selected
  mouse's state).

### Layer 2: display-cache invalidation

When a hardware state change arrives on the selected device,
`DeviceModel` sets `m_hasDisplayValues = false`. Getters fall through
to `session->smartShiftEnabled()` etc. The next profile reload
re-arms the cache via the existing `setDisplayValues` path, which
also gains per-property companion emits so bindings pinned to the new
NOTIFYs still get pinged on focus change.

### Q_PROPERTY NOTIFY flip

Final commit flips the seven affected Q_PROPERTY NOTIFYs from
`settingsReloaded` to their per-property signals. `scrollHiRes` +
`scrollInvert` share `scrollConfigChanged`; `thumbWheelMode` +
`thumbWheelInvert` share `thumbWheelModeChanged` because
`DeviceSession`'s combined setters write those pairs atomically.
`settingsReloaded` stays as a coarse signal still emitted on profile
reload paths.

## Scope

Fixes UI-fidelity for seven runtime-mutable properties:

- `currentDPI`
- `smartShiftEnabled` / `smartShiftThreshold`
- `scrollHiRes` / `scrollInvert`
- `thumbWheelMode` / `thumbWheelInvert`

Battery properties already work via their own `selectedBatteryChanged`
NOTIFY path. Descriptor-static properties (min/max DPI, images,
hotspots) correctly fire on `selectedChanged`.

## Known follow-ups (deferred)

- **`activeSlot` / Easy-Switch host state**. When the user triple-taps
  the Easy-Switch button on the mouse, the host changes at the
  hardware level but the UI does not reflect it. Same-shape fix
  required (session signal + PhysicalDevice relay + DeviceModel
  handler + Q_PROPERTY NOTIFY flip); also needs a new
  `DeviceSession::currentHostChanged` emit since the session updates
  `m_currentHost` silently today. Deferred pending MX Vertical tester
  feedback on whether this gap matters in practice.
- **Persist hardware changes to active profile.** Today, physical
  button presses update the UI but do not save to the active profile,
  so the change is undone on the next `applyProfileToHardware` (focus
  switch, transport setup). Symmetric with how UI changes persist to
  profile; worth its own design cycle.
- **Display-vs-hardware tab state cue.** Unrelated UX question about
  making it obvious when the tab being viewed is not the currently
  active hardware profile. Own brainstorm.

## Test plan

- 550 core tests pass + 72 QML tests pass from clean Debug rebuild.
- 11 new tests in `tests/test_device_session.cpp`,
  `tests/test_device_model.cpp`:
  - 2 cover `DeviceSession::currentDPIChanged` emit and no-op.
  - 4 cover `DeviceModel` cache-invalidation per property, with
    intermediate falsifiable assertions (verified: disabling the
    handlers makes all four fail).
  - 5 cover per-property NOTIFY emissions via `QSignalSpy`, plus
    scroll-pair coupling and `setDisplayValues` companion emits.
- `--simulate-all` smoke: no QML "binding loop" or "no NOTIFY signal"
  warnings.
- Real-hardware smoke pending (MX Master 3S).
