### PR TITLE
feat(app): autostart minimized to tray on login

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ endif()
 
 install(FILES data/71-logitune.rules DESTINATION lib/udev/rules.d)
 install(FILES data/logitune.desktop DESTINATION share/applications)
-install(FILES data/logitune.desktop DESTINATION etc/xdg/autostart)
+install(FILES data/logitune-autostart.desktop
+        DESTINATION /etc/xdg/autostart
+        RENAME logitune.desktop)
 install(FILES data/com.logitune.Logitune.svg DESTINATION share/icons/hicolor/scalable/apps)
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/devices/

--- a/data/logitune-autostart.desktop
+++ b/data/logitune-autostart.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Logitune
+Comment=Configure your Logitech devices
+Exec=logitune --minimized
+Icon=com.logitune.Logitune
+Categories=Settings;HardwareSettings;
+Keywords=logitech;mouse;keyboard;
+X-GNOME-Autostart-enabled=true

--- a/docs/superpowers/plans/2026-04-19-autostart-minimized.md
+++ b/docs/superpowers/plans/2026-04-19-autostart-minimized.md
@@ -1,0 +1,552 @@
+# Autostart Minimized Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Logitune so every user autostarts it minimized to the tray on login via `/etc/xdg/autostart/logitune.desktop` with `Exec=logitune --minimized`. The app recognises the flag and hides the main window when a system tray is available.
+
+**Architecture:** Two .desktop files under `data/` (launcher + autostart) so the app launcher does not inherit the minimized flag. CMake install line uses an absolute `/etc/xdg/autostart` destination to fix a pre-existing relative-path bug that landed the file at `/usr/etc/xdg/autostart/`. `main.cpp` adds a `--minimized` `QCommandLineOption` and hides each root `QQuickWindow` if `QSystemTrayIcon::isSystemTrayAvailable()` returns true.
+
+**Tech Stack:** C++20 / Qt 6 / CMake / GTest. No new third-party dependencies.
+
+**Design spec:** `docs/superpowers/specs/2026-04-19-autostart-minimized-design.md`. Read it before Task 1.
+
+---
+
+## Global rules
+
+- **No em-dashes (U+2014 "—")** in any file you create or modify. The only acceptable occurrence is inside a `grep -c "—"` verification command.
+- **No co-author signatures** in commit messages.
+- **Branch is `feat-autostart-minimized`.** Already created with the spec committed. Do NOT push. Maintainer pushes after final verification.
+- **Working directory:** `/home/mina/repos/logitune`.
+- **Never amend commits.** Each task makes a new commit on top.
+- **Build + test verification** after every task that touches C++:
+  - `cmake --build build -j"$(nproc)" 2>&1 | tail -3` (must exit 0)
+  - `XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -5` (must show `[  PASSED  ] <N> tests.`). Baseline count before this plan is 550.
+
+---
+
+## File Structure
+
+### Created
+
+```
+data/logitune-autostart.desktop                  (new, copy of logitune.desktop with --minimized)
+tests/test_autostart_desktop.cpp                 (new, sanity tests for the autostart desktop entry)
+```
+
+### Modified
+
+- `CMakeLists.txt`: update the autostart install destination from the relative `etc/xdg/autostart` to absolute `/etc/xdg/autostart`, switch source file to `data/logitune-autostart.desktop`, add `RENAME logitune.desktop` so the installed filename remains `logitune.desktop`.
+- `src/app/main.cpp`: add the `--minimized` `QCommandLineOption`, parse it, and after QML load iterate root objects and hide each `QQuickWindow` when the flag is set and a system tray is available.
+- `tests/CMakeLists.txt`: add `test_autostart_desktop.cpp` to the `logitune-tests` source list.
+
+### Unchanged
+
+- `data/logitune.desktop` (no `--minimized`, still installed to `share/applications` for the launcher entry).
+- `src/app/qml/Main.qml` (no QML changes; window is hidden at the C++ layer).
+- `src/app/TrayManager.{cpp,h}` (existing show-window-from-tray flow already works).
+- All packaging scripts (`scripts/package-deb.sh`, `scripts/package-rpm.sh`, `scripts/package-arch.sh`). They invoke `cmake --install`, which respects the new destinations.
+
+---
+
+## Task 1: Create the autostart desktop entry and fix its install path
+
+**Files:**
+- Create: `data/logitune-autostart.desktop`
+- Modify: `CMakeLists.txt`
+
+### Step 1: Create the new autostart entry
+
+Create `data/logitune-autostart.desktop` with exactly this content:
+
+```
+[Desktop Entry]
+Type=Application
+Name=Logitune
+Comment=Configure your Logitech devices
+Exec=logitune --minimized
+Icon=com.logitune.Logitune
+Categories=Settings;HardwareSettings;
+Keywords=logitech;mouse;keyboard;
+X-GNOME-Autostart-enabled=true
+```
+
+Note the only difference from `data/logitune.desktop` is `Exec=logitune --minimized`. Everything else is identical byte-for-byte.
+
+### Step 2: Update the CMake install line
+
+Open `CMakeLists.txt`. Find lines 27-28:
+
+```cmake
+install(FILES data/logitune.desktop DESTINATION share/applications)
+install(FILES data/logitune.desktop DESTINATION etc/xdg/autostart)
+```
+
+Replace the second line:
+
+```cmake
+install(FILES data/logitune.desktop DESTINATION share/applications)
+install(FILES data/logitune-autostart.desktop
+        DESTINATION /etc/xdg/autostart
+        RENAME logitune.desktop)
+```
+
+Two edits on that second line:
+- The source file changes from `data/logitune.desktop` to `data/logitune-autostart.desktop`.
+- The destination becomes the absolute path `/etc/xdg/autostart` (previously `etc/xdg/autostart`, which combined with `CMAKE_INSTALL_PREFIX=/usr` produced `/usr/etc/xdg/autostart/`, the broken path no DE reads).
+- `RENAME logitune.desktop` keeps the installed filename as `logitune.desktop` per XDG autostart convention.
+
+### Step 3: Verify install staging produces the right layout
+
+```bash
+rm -rf /tmp/logitune-stage
+cmake -B build-stage -DCMAKE_INSTALL_PREFIX=/tmp/logitune-stage-prefix -DBUILD_TESTING=OFF -Wno-dev 2>&1 | tail -3
+DESTDIR=/tmp/logitune-stage cmake --install build-stage 2>&1 | tail -10
+find /tmp/logitune-stage -name "logitune.desktop" 2>/dev/null
+```
+
+Expected output: two filenames, both named `logitune.desktop`:
+- `/tmp/logitune-stage/tmp/logitune-stage-prefix/share/applications/logitune.desktop` (launcher, no minimized flag)
+- `/tmp/logitune-stage/etc/xdg/autostart/logitune.desktop` (autostart, with minimized flag)
+
+Inspect the autostart copy to confirm it has `Exec=logitune --minimized`:
+
+```bash
+grep "^Exec=" /tmp/logitune-stage/etc/xdg/autostart/logitune.desktop
+```
+
+Expected: `Exec=logitune --minimized`.
+
+Inspect the launcher copy to confirm it does NOT:
+
+```bash
+grep "^Exec=" /tmp/logitune-stage/tmp/logitune-stage-prefix/share/applications/logitune.desktop
+```
+
+Expected: `Exec=logitune`.
+
+Clean up:
+
+```bash
+rm -rf /tmp/logitune-stage /tmp/logitune-stage-prefix build-stage
+```
+
+### Step 4: Verify the main build is still clean
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+```
+
+Expected: build exits 0. Tests still pass at the baseline count (550). The CMake edit has no runtime effect until the package is installed.
+
+### Step 5: Verify no em-dashes
+
+```bash
+grep -c "—" data/logitune-autostart.desktop CMakeLists.txt
+```
+
+Expected: `0` for each.
+
+### Step 6: Commit
+
+```bash
+git add data/logitune-autostart.desktop CMakeLists.txt
+git commit -m "build: install autostart desktop entry to /etc/xdg/autostart
+
+Previously the package installed data/logitune.desktop twice: once to
+share/applications and once to 'etc/xdg/autostart' (relative). With
+CMAKE_INSTALL_PREFIX=/usr that second install landed at
+/usr/etc/xdg/autostart/, which no XDG-compliant desktop environment
+reads, so the in-tree X-GNOME-Autostart-enabled=true flag never
+actually triggered autostart for anyone.
+
+Switch the autostart install to an absolute /etc/xdg/autostart
+destination and source it from a new data/logitune-autostart.desktop
+variant whose Exec line is 'logitune --minimized'. The launcher
+install at share/applications keeps the unflagged file, so clicking
+the app launcher still shows the window normally.
+
+No runtime change yet: main.cpp learns about --minimized in a later
+commit. Ships together with the CLI flag as a single behavioral
+change."
+```
+
+---
+
+## Task 2: Add the autostart desktop entry test
+
+**Files:**
+- Create: `tests/test_autostart_desktop.cpp`
+- Modify: `tests/CMakeLists.txt`
+
+### Step 1: Inspect the existing test registration pattern
+
+```bash
+grep -n "test_" tests/CMakeLists.txt | head -20
+```
+
+You should see a list of `tests/test_*.cpp` source files being appended to the `logitune-tests` target. If the file uses an explicit list (which is what this project does), note the pattern; you will append to it in Step 3.
+
+### Step 2: Write the test
+
+Create `tests/test_autostart_desktop.cpp`:
+
+```cpp
+#include <gtest/gtest.h>
+#include <QFile>
+#include <QString>
+#include <QTextStream>
+
+namespace {
+
+QString readDesktopEntry(const QString &path) {
+    QFile file(path);
+    EXPECT_TRUE(file.open(QIODevice::ReadOnly | QIODevice::Text))
+        << "Failed to open " << path.toStdString();
+    return QString::fromUtf8(file.readAll());
+}
+
+} // namespace
+
+TEST(AutostartDesktopEntry, ExecHasMinimizedFlag) {
+    const QString content = readDesktopEntry(
+        QStringLiteral(SOURCE_ROOT "/data/logitune-autostart.desktop"));
+    EXPECT_TRUE(content.contains(QStringLiteral("Exec=logitune --minimized\n")))
+        << "Autostart entry must invoke logitune with --minimized so the app "
+           "starts hidden to the tray on login";
+}
+
+TEST(AutostartDesktopEntry, HasGnomeAutostartEnabled) {
+    const QString content = readDesktopEntry(
+        QStringLiteral(SOURCE_ROOT "/data/logitune-autostart.desktop"));
+    EXPECT_TRUE(content.contains(QStringLiteral("X-GNOME-Autostart-enabled=true")))
+        << "GNOME autostart requires the explicit opt-in key";
+}
+
+TEST(AutostartDesktopEntry, LauncherEntryDoesNotMinimize) {
+    const QString content = readDesktopEntry(
+        QStringLiteral(SOURCE_ROOT "/data/logitune.desktop"));
+    EXPECT_TRUE(content.contains(QStringLiteral("Exec=logitune\n")))
+        << "Manual app-launcher entry must not inherit --minimized; the user "
+           "clicking the app launcher expects the window to appear";
+    EXPECT_FALSE(content.contains(QStringLiteral("--minimized")))
+        << "Launcher .desktop leaked the autostart flag; split files failed";
+}
+```
+
+The `SOURCE_ROOT` macro is defined in `tests/CMakeLists.txt` (verify in Step 3). If the project uses a different macro name (for example `PROJECT_SOURCE_DIR`), use whichever one is already in scope for existing tests that read repo-relative files. Grep `tests/CMakeLists.txt` for `target_compile_definitions` to find the pattern.
+
+### Step 3: Register the test with CMake
+
+Open `tests/CMakeLists.txt`. Find the list of test sources that populates `logitune-tests`. Append `test_autostart_desktop.cpp` (preserve the existing style — alphabetical, grouped, or chronological as the file does).
+
+If `SOURCE_ROOT` (or the equivalent macro) is not already defined for the tests target, it is. The existing tests (e.g. `test_device_registry.cpp`) reference repo paths through a compile-time macro. Mirror whatever that macro is called when writing the test in Step 2.
+
+### Step 4: Build and run
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests --gtest_filter='AutostartDesktopEntry.*' 2>&1 | tail -10
+```
+
+Expected: all three tests pass.
+
+Full run:
+
+```bash
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+```
+
+Expected: `[  PASSED  ] 553 tests.` (550 baseline + 3 new).
+
+### Step 5: Verify no em-dashes
+
+```bash
+grep -c "—" tests/test_autostart_desktop.cpp tests/CMakeLists.txt
+```
+
+Expected: `0` for each.
+
+### Step 6: Commit
+
+```bash
+git add tests/test_autostart_desktop.cpp tests/CMakeLists.txt
+git commit -m "test(autostart): cover desktop entry invariants
+
+Three narrow regression tests covering the two desktop entries this
+project ships:
+ - data/logitune-autostart.desktop contains Exec=logitune --minimized
+ - data/logitune-autostart.desktop enables X-GNOME-Autostart-enabled
+ - data/logitune.desktop (launcher) does NOT inherit --minimized
+
+Protects against the class of bug that kept autostart broken for
+months: the Exec line silently regressing to something the autostart
+session ignores (missing flag) or something the launcher invokes in
+the wrong mode (flag leaked into launcher)."
+```
+
+---
+
+## Task 3: Parse the --minimized flag and hide the window
+
+**Files:**
+- Modify: `src/app/main.cpp`
+
+### Step 1: Read the existing command-line option setup
+
+Open `src/app/main.cpp`. Find the block around line 63 that starts with `QCommandLineParser parser;` and ends with `parser.process(app);`. Note the pattern for adding an option:
+
+```cpp
+QCommandLineOption simulateAllOption(
+    QStringLiteral("simulate-all"),
+    QStringLiteral("..."));
+parser.addOption(simulateAllOption);
+```
+
+and reading it:
+
+```cpp
+const bool simulateAll = parser.isSet(simulateAllOption);
+```
+
+### Step 2: Add the --minimized option
+
+Immediately after the `editOption` definition and `parser.addOption(editOption)` call (around line 85), add:
+
+```cpp
+QCommandLineOption minimizedOption(
+    QStringLiteral("minimized"),
+    QStringLiteral("Start hidden to the system tray. Intended for autostart "
+                   "launchers; ignored if no system tray is available."));
+parser.addOption(minimizedOption);
+```
+
+After `parser.process(app);` and the existing `const bool simulateAll = ...`, `const bool editMode = ...` lines, add:
+
+```cpp
+const bool startMinimized = parser.isSet(minimizedOption);
+```
+
+### Step 3: Include QSystemTrayIcon
+
+If `QSystemTrayIcon` is not already included in `src/app/main.cpp` (grep for `#include <QSystemTrayIcon>`), add near the other Qt includes:
+
+```cpp
+#include <QSystemTrayIcon>
+```
+
+Note: `TrayManager` internally uses `QSystemTrayIcon`, so the header is already pulled in transitively through `TrayManager.h`, but including it directly makes the availability check self-documenting.
+
+### Step 4: Hide the window after QML load when requested
+
+Find the theme-application block around line 229:
+
+```cpp
+if (!engine.rootObjects().isEmpty()) {
+    QObject *root = engine.rootObjects().first();
+    QQmlExpression expr(QQmlEngine::contextForObject(root), root,
+        isDark ? QStringLiteral("Theme.dark = true")
+               : QStringLiteral("Theme.dark = false"));
+    QVariant result = expr.evaluate();
+    if (expr.hasError())
+        qCWarning(lcApp) << "Theme expression error:" << expr.error().toString();
+    else
+        qCInfo(lcApp) << "Theme.dark applied:" << isDark;
+}
+```
+
+Immediately after that closing brace, add:
+
+```cpp
+const bool trayAvailable = QSystemTrayIcon::isSystemTrayAvailable();
+if (startMinimized && trayAvailable) {
+    for (QObject *obj : engine.rootObjects()) {
+        if (auto *window = qobject_cast<QQuickWindow*>(obj))
+            window->hide();
+    }
+    qCInfo(lcApp) << "Startup: minimized to tray";
+} else if (startMinimized && !trayAvailable) {
+    qCInfo(lcApp) << "Startup: --minimized requested but no system tray "
+                     "available, showing window";
+} else {
+    qCDebug(lcApp) << "Startup: showing window";
+}
+```
+
+### Step 5: Build
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+```
+
+Expected: exit 0. No new warnings.
+
+### Step 6: Run the suite
+
+```bash
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+```
+
+Expected: `[  PASSED  ] 553 tests.` (no new tests in this task; regressions would surface here).
+
+### Step 7: Verify no em-dashes
+
+```bash
+grep -c "—" src/app/main.cpp
+```
+
+Expected: matches whatever the file had before this commit (pre-existing em-dashes are fine, new ones are not). Compare:
+
+```bash
+before=$(git show HEAD:src/app/main.cpp | grep -c "—")
+after=$(grep -c "—" src/app/main.cpp)
+echo "before=$before after=$after"
+[ "$before" = "$after" ] && echo OK || echo FAIL
+```
+
+Expected: `OK`.
+
+### Step 8: Manual verification (run two invocations)
+
+Without `--minimized` (window should appear):
+
+```bash
+pkill -f logitune 2>/dev/null; sleep 1
+nohup env XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/src/app/logitune > /tmp/logitune-no-flag.log 2>&1 & disown
+sleep 3
+grep -E "Startup:" /tmp/logitune-no-flag.log
+pkill -f logitune 2>/dev/null
+```
+
+Expected: log line `Startup: showing window`. Window visible on the desktop.
+
+With `--minimized` (window should be hidden, tray icon visible):
+
+```bash
+pkill -f logitune 2>/dev/null; sleep 1
+nohup env XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/src/app/logitune --minimized > /tmp/logitune-minimized.log 2>&1 & disown
+sleep 3
+grep -E "Startup:" /tmp/logitune-minimized.log
+pkill -f logitune 2>/dev/null
+```
+
+Expected: log line `Startup: minimized to tray` (assuming your desktop has a system tray). No window appears; tray icon does.
+
+### Step 9: Commit
+
+```bash
+git add src/app/main.cpp
+git commit -m "feat(app): --minimized CLI flag hides window to tray
+
+New QCommandLineOption on main.cpp: when --minimized is set and a
+system tray is available, iterate engine.rootObjects() after QML load
+and hide each QQuickWindow. Tray icon still appears via the existing
+TrayManager.show() path.
+
+Fallback when QSystemTrayIcon::isSystemTrayAvailable() returns false:
+skip the hide so the window is visible. Prevents the app from running
+invisibly with no way for the user to restore it on sessions that
+lack a system tray (some Wayland compositors, stripped-down shells).
+
+One info-level log line per case ('Startup: minimized to tray',
+'Startup: --minimized requested but no system tray available,
+showing window', 'Startup: showing window') for debugging.
+
+Paired with the /etc/xdg/autostart/logitune.desktop install at
+Exec=logitune --minimized (prior commit) to deliver issue #10:
+the app autostarts minimized when the user logs in.
+
+Closes #10."
+```
+
+---
+
+## Task 4: Final verification
+
+**Files:** none modified.
+
+### Step 1: Clean rebuild
+
+```bash
+rm -rf build
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug 2>&1 | tail -3
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+```
+
+Expected: both exit 0.
+
+### Step 2: Full test run
+
+```bash
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" QT_QPA_PLATFORM=offscreen ./build/tests/qml/logitune-qml-tests 2>&1 | tail -3
+```
+
+Expected: 553 core tests pass, 72 QML tests pass.
+
+### Step 3: Install to a staging directory and verify layout
+
+```bash
+rm -rf /tmp/logitune-stage
+DESTDIR=/tmp/logitune-stage cmake --install build 2>&1 | grep -iE "desktop|install" | tail -10
+```
+
+Expected among the output: install lines referencing the launcher at `share/applications/logitune.desktop` and the autostart entry at `/etc/xdg/autostart/logitune.desktop`.
+
+Verify both files exist and have the expected Exec lines:
+
+```bash
+find /tmp/logitune-stage -name "logitune.desktop" -exec sh -c 'echo "=== {} ==="; grep "^Exec=" "{}"' \;
+```
+
+Expected (two entries):
+- `.../share/applications/logitune.desktop` with `Exec=logitune`
+- `.../etc/xdg/autostart/logitune.desktop` with `Exec=logitune --minimized`
+
+Clean up staging:
+
+```bash
+rm -rf /tmp/logitune-stage
+```
+
+### Step 4: Branch commit list
+
+```bash
+git log --oneline master..HEAD
+```
+
+Expected: the spec commit plus three implementation commits (Task 1, Task 2, Task 3). No amendments.
+
+### Step 5: Em-dash scan on touched files
+
+```bash
+git diff --name-only master..HEAD \
+  | grep -vE '\.(png|svg)$' \
+  | xargs -I{} sh -c 'printf "%s: " "{}"; grep -c "—" "{}" 2>/dev/null || echo "N/A"'
+```
+
+Expected: C++ / CMake / desktop / test files print `0`. `docs/superpowers/specs/*` may print non-zero (pre-existing).
+
+### Step 6: Hand-off
+
+Do NOT push the branch. Maintainer pushes and opens the PR.
+
+Summarize for the PR body (the maintainer will edit):
+
+- Fixed the broken autostart install path (`/usr/etc/xdg/autostart/` -> `/etc/xdg/autostart/`).
+- Autostart file now invokes `logitune --minimized`.
+- New `--minimized` CLI flag hides the main window to tray at startup when a tray is available; falls through to a visible window when no tray is present.
+- Three tests on the desktop entries, manual verification of the CLI flag.
+- Closes #10.
+
+---
+
+## Done criteria
+
+- Clean Debug rebuild from scratch: 0 errors, 0 warnings introduced by this plan.
+- 553 core tests pass (550 baseline + 3 new `AutostartDesktopEntry.*`), 72 QML tests pass.
+- `cmake --install` staging shows the autostart file at `/etc/xdg/autostart/logitune.desktop` with `Exec=logitune --minimized`, and the launcher file at `share/applications/logitune.desktop` with `Exec=logitune`.
+- Manual run of `./build/src/app/logitune` shows the window; `./build/src/app/logitune --minimized` hides it (tray icon visible).
+- Three implementation commits on the branch, each reviewable in isolation, none amended.
+- `grep -c "—"` on every touched C++/CMake/desktop/test file prints `0`.

--- a/docs/superpowers/specs/2026-04-19-autostart-minimized-design.md
+++ b/docs/superpowers/specs/2026-04-19-autostart-minimized-design.md
@@ -1,0 +1,244 @@
+# Autostart Minimized Design
+
+**Status:** approved, ready for implementation plan
+**Issue:** #10 (Feature request: Option to automatically start the app)
+**Target release:** next beta after `v0.3.1-beta.1`
+**Author:** Mina Maher (brainstormed with Claude)
+**Date:** 2026-04-19
+
+## Summary
+
+Ship Logitune so every user's session autostarts it minimized to the
+system tray on login. No in-app UI toggle in this pass. Users who want
+to opt out use the XDG-standard user-level override.
+
+## Motivation
+
+Issue #10 asks for an autostart option. Today the package installs a
+`.desktop` file with `X-GNOME-Autostart-enabled=true`, but to the wrong
+path (`/usr/etc/xdg/autostart/`), so no desktop environment picks it up.
+Users have to configure autostart manually via their DE, which is the
+friction the issue is asking us to remove.
+
+"Plain and simple" per the maintainer: the app should autostart
+minimized when the user logs in. No first-run prompts, no Settings-page
+toggle in this PR.
+
+## Behavior
+
+- Login to any XDG-compliant desktop environment (GNOME, KDE Plasma,
+  XFCE, LXDE, Mate, Cinnamon).
+- `/etc/xdg/autostart/logitune.desktop` is read by the session
+  autostart mechanism.
+- `Exec=logitune --minimized` launches the app.
+- Tray icon appears. Main window does NOT appear.
+- User clicks tray icon, main window shows (existing
+  `TrayManager::showWindowRequested` flow).
+- User closes main window, it hides to tray (existing
+  `setQuitOnLastWindowClosed(false)` behavior).
+- User selects Quit from tray menu, app exits. Next login the session
+  autostarts Logitune again.
+
+**Manual launch unchanged.** Running `logitune` from a terminal or app
+launcher (no `--minimized` flag) shows the main window as today.
+
+**No-tray fallback.** If `QSystemTrayIcon::isSystemTrayAvailable()`
+returns false, `--minimized` degrades to a no-op and the window is
+shown. Prevents the app from running invisibly with no recovery path
+on sessions that lack a system tray.
+
+**Opt-out.** Users who do not want autostart drop a user-level
+override at `~/.config/autostart/logitune.desktop` with `Hidden=true`
+or `X-GNOME-Autostart-enabled=false`. Standard XDG autostart semantics.
+Documented in release notes; not implemented as an in-app toggle in
+this PR.
+
+## Approach
+
+Three alternatives considered:
+
+1. **XDG autostart `.desktop` + `--minimized` CLI flag** (chosen).
+   Universal across every XDG-compliant DE. One file, one flag. No
+   per-DE special-casing.
+2. **systemd user unit.** Desktop-environment-agnostic but requires
+   `systemctl --user enable`, per-distro packaging, and loses
+   support on distros without user-mode systemd.
+3. **Per-DE native autostart APIs.** GNOME has its own, KDE has its
+   own. Fragments the implementation surface across DEs for zero
+   practical benefit over XDG.
+
+XDG autostart is the standard mechanism every supported DE reads.
+Going with it.
+
+## Code surface
+
+### `src/app/main.cpp`
+
+Add a `QCommandLineOption` next to the existing `--simulate-all` and
+`--edit` options:
+
+```cpp
+QCommandLineOption minimizedOption(
+    QStringLiteral("minimized"),
+    QStringLiteral("Start hidden to the system tray. Intended for autostart "
+                   "launchers; ignored if no system tray is available."));
+parser.addOption(minimizedOption);
+```
+
+After `parser.process(app)`:
+
+```cpp
+const bool startMinimized = parser.isSet(minimizedOption);
+```
+
+After QML load (near the existing theme-application block around
+line 229), if `startMinimized && QSystemTrayIcon::isSystemTrayAvailable()`
+is true, iterate `engine.rootObjects()` and call `hide()` on each
+`QQuickWindow`. Otherwise leave the window visible.
+
+Log one line for observability: "Startup: minimized to tray" or
+"Startup: showing window".
+
+### `src/app/qml/Main.qml`
+
+No change. The root window keeps `visible: true`; the C++ layer hides
+it after load when `--minimized` is set. Rationale: a QML-level
+`visible: false` would introduce a context-property dependency purely
+for startup and make the default manual launch marginally slower
+(briefly invisible, then shown). Hiding at the C++ layer is one line
+and keeps Main.qml declarative defaults.
+
+### `src/app/TrayManager.{cpp,h}`
+
+No change. Existing `showWindowRequested` -> `window->show()` chain
+already restores the window from the tray icon click.
+
+### `data/logitune.desktop`
+
+Change one line:
+
+```
+- Exec=logitune
++ Exec=logitune --minimized
+```
+
+Keep `X-GNOME-Autostart-enabled=true` and the other entries as-is. The
+file is installed twice (launcher + autostart); the launcher install
+also gets the `--minimized` flag, which is wrong for manual app-launcher
+invocations since those should show the window. Handle this either:
+
+Option A: **Two separate files**, `data/logitune.desktop` (no flag,
+for `share/applications`) and `data/logitune-autostart.desktop`
+(with `--minimized`, for `/etc/xdg/autostart`). Cleanest.
+
+Option B: **Single file with `--minimized`**, accept that the app
+launcher also runs the app minimized. Not ideal: clicking "Logitune"
+from the DE's launcher would do nothing visible except the tray icon
+on first invocation (and nothing at all on subsequent invocations
+because the single-instance lock prevents a second run).
+
+Going with **Option A**. One extra file in `data/`, one extra
+`install(FILES ...)` line in CMakeLists.txt, no runtime branching on
+how the app was invoked.
+
+### `CMakeLists.txt`
+
+Current (around lines 27-28):
+
+```cmake
+install(FILES data/logitune.desktop DESTINATION share/applications)
+install(FILES data/logitune.desktop DESTINATION etc/xdg/autostart)
+```
+
+After:
+
+```cmake
+install(FILES data/logitune.desktop DESTINATION share/applications)
+install(FILES data/logitune-autostart.desktop
+        DESTINATION /etc/xdg/autostart
+        RENAME logitune.desktop)
+```
+
+Two edits:
+
+1. The autostart line uses a distinct source file
+   (`logitune-autostart.desktop`) so the `--minimized` flag does not
+   leak into the launcher entry.
+2. The destination becomes an absolute path `/etc/xdg/autostart`. The
+   previous relative path combined with `CMAKE_INSTALL_PREFIX=/usr`
+   produced `/usr/etc/xdg/autostart/`, which no XDG-compliant desktop
+   environment reads. `RENAME` keeps the filename `logitune.desktop`
+   as XDG expects.
+
+## Packaging scripts
+
+- `scripts/package-deb.sh`, `scripts/package-rpm.sh`,
+  `scripts/package-arch.sh`: no source edits. Each script runs
+  `cmake --install`, which respects the new destinations. The
+  resulting packages will ship `/etc/xdg/autostart/logitune.desktop`
+  (corrected path) with the minimized Exec.
+
+## Tests
+
+GTest coverage is minimal here because the feature is mostly config +
+a single CLI flag wired to one window call.
+
+- `tests/test_autostart_desktop.cpp` (new, small): read
+  `data/logitune-autostart.desktop`, assert:
+  - Contains `Exec=logitune --minimized`.
+  - Contains `X-GNOME-Autostart-enabled=true`.
+  - Name and Icon match the launcher entry.
+- No test for the C++ hide-window path. Manual verification in the
+  rollout step. Adding a GTest that instantiates QApplication + QML
+  engine + system tray is heavy for one branch.
+
+## Rollout
+
+Branch `feat-autostart-minimized`. Three commits:
+
+1. `build: fix autostart desktop entry install path` — CMakeLists edit
+   + new `data/logitune-autostart.desktop`. No runtime change; just
+   ships the file to the right place.
+2. `feat(desktop): autostart invocation adds --minimized flag` —
+   update `data/logitune-autostart.desktop` Exec line. Still a no-op
+   until main.cpp supports the flag.
+3. `feat(app): --minimized CLI flag hides window to tray` — add the
+   option, wire hide-on-startup with tray-available fallback, log
+   line. New test.
+
+Lands in the next beta release. Release notes include:
+
+- One-line feature callout: "Logitune now autostarts minimized to the
+  system tray on login. Opt out by placing
+  `~/.config/autostart/logitune.desktop` with
+  `Hidden=true`."
+
+## Known risks
+
+- **Session without a system tray.** Some Wayland compositors or
+  stripped-down sessions do not expose
+  `QSystemTrayIcon::isSystemTrayAvailable() == true`. In that case
+  `--minimized` becomes a no-op and the window appears. User sees a
+  window on login they did not ask for. Mitigation: log it, and
+  accept the degraded behavior as preferable to "invisible with no
+  recovery path".
+- **Opt-out discoverability.** Users who dislike the autostart have
+  to know about the `~/.config/autostart/logitune.desktop` override.
+  The release note covers it; a future PR can add a UI toggle in
+  Settings if feedback warrants.
+- **Manual launch race with single-instance lock.** If autostart
+  already launched Logitune and the user manually clicks the app
+  launcher, the second invocation quits immediately due to the
+  existing lock file. Same behavior as today for simulate-all /
+  normal launches; nothing changes here.
+
+## Out of scope
+
+- In-app "Launch at login" toggle (opt-out stays at the XDG file
+  level).
+- "Start minimized" user preference (distinct from the autostart flag
+  — today's manual launch always shows the window; no toggle to
+  change that).
+- systemd user unit packaging.
+- Per-DE native autostart mechanisms.
+- Changes to tray-close-vs-quit semantics.

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -32,7 +32,7 @@ Version: $VERSION
 Section: utils
 Priority: optional
 Architecture: $ARCH
-Depends: libqt6core6 (>= 6.4), libqt6quick6, libqt6svg6, libqt6dbus6, libqt6widgets6, libudev1, qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-dialogs, qml6-module-qtquick-window, qml6-module-qtquick-templates, qml6-module-qtquick-layouts, qml6-module-qtqml, qml6-module-qtqml-workerscript, qml6-module-qt5compat-graphicaleffects
+Depends: libqt6core6 (>= 6.4), libqt6qml6, libqt6quick6, libqt6svg6, libqt6dbus6, libqt6widgets6, libudev1, qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-dialogs, qml6-module-qtquick-window, qml6-module-qtquick-templates, qml6-module-qtquick-layouts, qml6-module-qtqml-workerscript, qml6-module-qt5compat-graphicaleffects
 Maintainer: Mina Maher <mina.maher88@hotmail.com>
 Description: Logitech device configurator for Linux
  Configure Logitech HID++ peripherals (MX Master 3S and more).

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -44,7 +44,7 @@ cp -a /tmp/logitune-rpm/* %{buildroot}/
 /usr/bin/logitune
 /usr/lib/udev/rules.d/71-logitune.rules
 /usr/share/applications/logitune.desktop
-/usr/etc/xdg/autostart/logitune.desktop
+/etc/xdg/autostart/logitune.desktop
 /usr/share/icons/hicolor/scalable/apps/com.logitune.Logitune.svg
 # Device descriptors (JSON + images) and the GNOME shell extension live in
 # their own subtrees. List the directory so new devices and any additional

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -14,6 +14,7 @@
 #include <QTimer>
 #include <QLockFile>
 #include <QStandardPaths>
+#include <QSystemTrayIcon>
 #include <QDBusConnection>
 #include <QDBusMessage>
 #include <QDBusVariant>
@@ -79,9 +80,15 @@ int main(int argc, char *argv[])
                        "device pages to edit slot positions, hotspots, and images. "
                        "Save writes back to the source descriptor JSON."));
     parser.addOption(editOption);
+    QCommandLineOption minimizedOption(
+        QStringLiteral("minimized"),
+        QStringLiteral("Start hidden to the system tray. Intended for autostart "
+                       "launchers; ignored if no system tray is available."));
+    parser.addOption(minimizedOption);
     parser.process(app);
     const bool simulateAll = parser.isSet(simulateAllOption);
     const bool editMode = parser.isSet(editOption);
+    const bool startMinimized = parser.isSet(minimizedOption);
 
     // Single-instance guard — prevent two instances fighting over the device
     QLockFile lockFile(QStandardPaths::writableLocation(QStandardPaths::TempLocation)
@@ -236,6 +243,20 @@ int main(int argc, char *argv[])
             qCWarning(lcApp) << "Theme expression error:" << expr.error().toString();
         else
             qCInfo(lcApp) << "Theme.dark applied:" << isDark;
+    }
+
+    const bool trayAvailable = QSystemTrayIcon::isSystemTrayAvailable();
+    if (startMinimized && trayAvailable) {
+        for (QObject *obj : engine.rootObjects()) {
+            if (auto *window = qobject_cast<QQuickWindow*>(obj))
+                window->hide();
+        }
+        qCInfo(lcApp) << "Startup: minimized to tray";
+    } else if (startMinimized && !trayAvailable) {
+        qCInfo(lcApp) << "Startup: --minimized requested but no system tray "
+                         "available, showing window";
+    } else {
+        qCDebug(lcApp) << "Startup: showing window";
     }
 
     // System tray

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -245,20 +245,6 @@ int main(int argc, char *argv[])
             qCInfo(lcApp) << "Theme.dark applied:" << isDark;
     }
 
-    const bool trayAvailable = QSystemTrayIcon::isSystemTrayAvailable();
-    if (startMinimized && trayAvailable) {
-        for (QObject *obj : engine.rootObjects()) {
-            if (auto *window = qobject_cast<QQuickWindow*>(obj))
-                window->hide();
-        }
-        qCInfo(lcApp) << "Startup: minimized to tray";
-    } else if (startMinimized && !trayAvailable) {
-        qCInfo(lcApp) << "Startup: --minimized requested but no system tray "
-                         "available, showing window";
-    } else {
-        qCDebug(lcApp) << "Startup: showing window";
-    }
-
     // System tray
     logitune::TrayManager tray(controller.deviceModel());
     QObject::connect(&tray, &logitune::TrayManager::showWindowRequested, [&engine]() {
@@ -272,6 +258,20 @@ int main(int argc, char *argv[])
     });
     QObject::connect(tray.quitAction(), &QAction::triggered, &app, &QApplication::quit);
     tray.show();
+
+    const bool trayVisible = tray.trayIcon()->isVisible();
+    if (startMinimized && trayVisible) {
+        for (QObject *obj : engine.rootObjects()) {
+            if (auto *window = qobject_cast<QQuickWindow*>(obj))
+                window->hide();
+        }
+        qCInfo(lcApp) << "Startup: minimized to tray";
+    } else if (startMinimized && !trayVisible) {
+        qCInfo(lcApp) << "Startup: --minimized requested but tray is not "
+                         "visible, showing window";
+    } else {
+        qCDebug(lcApp) << "Startup: showing window";
+    }
 
     qCInfo(lcApp) << "Startup complete";
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,8 +43,10 @@ add_executable(logitune-tests
     test_json_device.cpp
     test_device_fetcher.cpp
     test_dpi_cycle_ring.cpp
+    test_autostart_desktop.cpp
 )
 target_include_directories(logitune-tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(logitune-tests PRIVATE SOURCE_ROOT="${CMAKE_SOURCE_DIR}")
 target_link_libraries(logitune-tests PRIVATE logitune-core logitune-app-lib Qt6::Test Qt6::Widgets GTest::gtest)
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/logitune)
 file(CREATE_LINK ${CMAKE_SOURCE_DIR}/devices ${CMAKE_BINARY_DIR}/logitune/devices SYMBOLIC)

--- a/tests/test_autostart_desktop.cpp
+++ b/tests/test_autostart_desktop.cpp
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+#include <QFile>
+#include <QString>
+
+namespace {
+
+QString readDesktopEntry(const QString &path) {
+    QFile file(path);
+    EXPECT_TRUE(file.open(QIODevice::ReadOnly | QIODevice::Text))
+        << "Failed to open " << path.toStdString();
+    return QString::fromUtf8(file.readAll());
+}
+
+} // namespace
+
+TEST(AutostartDesktopEntry, ExecHasMinimizedFlag) {
+    const QString content = readDesktopEntry(
+        QStringLiteral(SOURCE_ROOT "/data/logitune-autostart.desktop"));
+    EXPECT_TRUE(content.contains(QStringLiteral("Exec=logitune --minimized\n")))
+        << "Autostart entry must invoke logitune with --minimized so the app "
+           "starts hidden to the tray on login";
+}
+
+TEST(AutostartDesktopEntry, HasGnomeAutostartEnabled) {
+    const QString content = readDesktopEntry(
+        QStringLiteral(SOURCE_ROOT "/data/logitune-autostart.desktop"));
+    EXPECT_TRUE(content.contains(QStringLiteral("X-GNOME-Autostart-enabled=true")))
+        << "GNOME autostart requires the explicit opt-in key";
+}
+
+TEST(AutostartDesktopEntry, LauncherEntryDoesNotMinimize) {
+    const QString content = readDesktopEntry(
+        QStringLiteral(SOURCE_ROOT "/data/logitune.desktop"));
+    EXPECT_TRUE(content.contains(QStringLiteral("Exec=logitune\n")))
+        << "Manual app-launcher entry must not inherit --minimized; the user "
+           "clicking the app launcher expects the window to appear";
+    EXPECT_FALSE(content.contains(QStringLiteral("--minimized")))
+        << "Launcher .desktop leaked the autostart flag; split files failed";
+}

--- a/tests/test_autostart_desktop.cpp
+++ b/tests/test_autostart_desktop.cpp
@@ -2,35 +2,33 @@
 #include <QFile>
 #include <QString>
 
-namespace {
-
-QString readDesktopEntry(const QString &path) {
-    QFile file(path);
-    EXPECT_TRUE(file.open(QIODevice::ReadOnly | QIODevice::Text))
-        << "Failed to open " << path.toStdString();
-    return QString::fromUtf8(file.readAll());
-}
-
-} // namespace
-
 TEST(AutostartDesktopEntry, ExecHasMinimizedFlag) {
-    const QString content = readDesktopEntry(
-        QStringLiteral(SOURCE_ROOT "/data/logitune-autostart.desktop"));
+    QFile file(QStringLiteral(SOURCE_ROOT "/data/logitune-autostart.desktop"));
+    ASSERT_TRUE(file.open(QIODevice::ReadOnly | QIODevice::Text))
+        << "Failed to open " << file.fileName().toStdString();
+    const QString content = QString::fromUtf8(file.readAll());
+
     EXPECT_TRUE(content.contains(QStringLiteral("Exec=logitune --minimized\n")))
         << "Autostart entry must invoke logitune with --minimized so the app "
            "starts hidden to the tray on login";
 }
 
 TEST(AutostartDesktopEntry, HasGnomeAutostartEnabled) {
-    const QString content = readDesktopEntry(
-        QStringLiteral(SOURCE_ROOT "/data/logitune-autostart.desktop"));
+    QFile file(QStringLiteral(SOURCE_ROOT "/data/logitune-autostart.desktop"));
+    ASSERT_TRUE(file.open(QIODevice::ReadOnly | QIODevice::Text))
+        << "Failed to open " << file.fileName().toStdString();
+    const QString content = QString::fromUtf8(file.readAll());
+
     EXPECT_TRUE(content.contains(QStringLiteral("X-GNOME-Autostart-enabled=true")))
         << "GNOME autostart requires the explicit opt-in key";
 }
 
 TEST(AutostartDesktopEntry, LauncherEntryDoesNotMinimize) {
-    const QString content = readDesktopEntry(
-        QStringLiteral(SOURCE_ROOT "/data/logitune.desktop"));
+    QFile file(QStringLiteral(SOURCE_ROOT "/data/logitune.desktop"));
+    ASSERT_TRUE(file.open(QIODevice::ReadOnly | QIODevice::Text))
+        << "Failed to open " << file.fileName().toStdString();
+    const QString content = QString::fromUtf8(file.readAll());
+
     EXPECT_TRUE(content.contains(QStringLiteral("Exec=logitune\n")))
         << "Manual app-launcher entry must not inherit --minimized; the user "
            "clicking the app launcher expects the window to appear";


### PR DESCRIPTION
Closes #10.

## Summary

Logitune now autostarts minimized to the system tray on login for every
user. Clicking the tray icon opens the main window. Users who want to
opt out drop a user-level override at
`~/.config/autostart/logitune.desktop` with `Hidden=true` (standard XDG
autostart override).

## What changed

**Packaging (fixes a long-latent bug):**
- The in-tree `data/logitune.desktop` already had
  `X-GNOME-Autostart-enabled=true`. The CMake install line was shipping
  it to `/usr/etc/xdg/autostart/logitune.desktop` (relative path
  combined with `CMAKE_INSTALL_PREFIX=/usr`), which no XDG-compliant DE
  reads. Fixed to absolute `/etc/xdg/autostart`.
- Split into two `.desktop` files: `data/logitune.desktop` (launcher,
  no flag) and `data/logitune-autostart.desktop` (autostart, with
  `--minimized`). Clicking the app launcher still shows the window.
- Aligned `scripts/package-rpm.sh` `%files` to match the new path.

**Runtime:**
- New `--minimized` CLI flag. When set, `main.cpp` constructs and
  shows the tray first, then (if `tray.trayIcon()->isVisible()` reports
  the tray actually came up) hides all root `QQuickWindow`s. If the
  tray fails to show for any reason, the window stays visible so the
  user never ends up with an invisible app.
- Three info/debug log lines for observability.

**Debian deps (adjacent fix, discovered during install testing):**
- `scripts/package-deb.sh` Depends line listed `qml6-module-qtqml`,
  which is not a real package on Ubuntu 24.04. The base QtQml module
  is linked into `libqt6qml6`; only submodules exist as standalone
  packages. Replaced with `libqt6qml6`. Silently broken since the
  deb script was first written; v0.3.1-beta.1 shipped with this bug
  masked by another dep issue that got fixed first.

## Tests

- 553 core tests pass (550 baseline + 3 new `AutostartDesktopEntry.*`
  tests covering both `.desktop` files' Exec-line invariants).
- Manual smoke on Arch (pacman) + Ubuntu 24.04 (deb in a VM):
  - `pacman -U` / `dpkg -i` both succeed.
  - `/etc/xdg/autostart/logitune.desktop` lands at the correct path
    with `Exec=logitune --minimized`.
  - `/usr/share/applications/logitune.desktop` lands with
    `Exec=logitune`.
  - Autostart fires on login. On Ubuntu default GNOME (no
    AppIndicator extension), the tray fallback correctly shows the
    window instead of leaving the app invisible.

## Known follow-ups

- On Ubuntu default GNOME, the AppIndicator extension is not
  installed, so the tray fallback fires on every login and the
  window appears anyway. A separate follow-up issue will add
  `Recommends: gnome-shell-extension-appindicator` to the deb so
  `apt install` pulls it in, and will fix the in-app banner that
  currently reports "extension is installed but not enabled" when
  the extension is actually not installed at all.

## Known risks

- Some Wayland sessions may register a tray host but the icon fails
  to appear asynchronously. The `tray.trayIcon()->isVisible()` check
  after `tray.show()` catches this at the commit site; the window
  stays visible in that case.
- Users who prefer no autostart need to discover the XDG override
  path. Release notes will call it out. An in-app "Launch at login"
  toggle is explicitly out of scope for this PR.
