### PR TITLE
Fix AppIndicator detection + deb Recommends + distro-aware banner

### DIFF
--- a/docs/superpowers/plans/2026-04-20-appindicator-detection.md
+++ b/docs/superpowers/plans/2026-04-20-appindicator-detection.md
@@ -1,0 +1,777 @@
+# AppIndicator Detection Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop reporting "AppIndicator extension is installed but not enabled" on systems where it is not installed at all; render the banner's install command per detected distro family; pull the extension automatically on Ubuntu/Debian via deb `Recommends`.
+
+**Architecture:** Four surgical changes. A new `logitune::DistroDetector` parses `/etc/os-release` once and classifies the OS as `Arch`, `Debian`, `Fedora`, or `Unknown`. `DeviceModel::appIndicatorInstallCommand()` returns the correct install command for the QML banner. `GnomeDesktop::appIndicatorStatus` detection guards for the empty-dict success-reply case. `scripts/package-deb.sh` gains a `Recommends:` line.
+
+**Tech Stack:** C++20 / Qt 6 / GTest. No new third-party dependencies.
+
+**Design spec:** `docs/superpowers/specs/2026-04-20-appindicator-detection-design.md`. Read it before Task 1.
+
+---
+
+## Global rules
+
+- **No em-dashes (U+2014 "—")** in any file you create or modify. Pre-existing em-dashes in files you otherwise touch are fine; just do not add new ones.
+- **No co-author signatures** in commit messages.
+- **Branch is `fix-appindicator-detection`.** Already created with the spec committed. Do NOT push. Maintainer pushes after final verification.
+- **Working directory:** `/home/mina/repos/logitune`.
+- **Never amend commits.** Each task makes a new commit on top.
+- **Build + test** after every task: `cmake --build build -j"$(nproc)"` must exit 0; `XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests` must show `[  PASSED  ] <N> tests.` Baseline count before this plan is 553.
+
+---
+
+## File Structure
+
+### Created
+
+```
+src/core/DistroDetector.h                          (new, declares DistroFamily + detectDistroFamily())
+src/core/DistroDetector.cpp                        (new, parses /etc/os-release, cached)
+tests/test_distro_detector.cpp                     (new, parameterized unit tests)
+```
+
+### Modified
+
+- `src/core/CMakeLists.txt`: add `DistroDetector.cpp` to the `logitune-core` source list.
+- `tests/CMakeLists.txt`: add `test_distro_detector.cpp` to the `logitune-tests` source list.
+- `src/app/models/DeviceModel.h`: declare `Q_INVOKABLE QString appIndicatorInstallCommand() const;`.
+- `src/app/models/DeviceModel.cpp`: implement the getter using `DistroDetector`.
+- `src/app/qml/HomeView.qml`: banner "not installed" path reads `DeviceModel.appIndicatorInstallCommand()` instead of the hard-coded pacman line.
+- `src/core/desktop/GnomeDesktop.cpp`: fix the empty-dict-is-installed bug (guard the detection branch).
+- `scripts/package-deb.sh`: add `Recommends: gnome-shell-extension-appindicator` to the control-file template.
+
+### Unchanged
+
+- `src/core/desktop/GnomeDesktop.h`: `AppIndicatorState` enum already has the four states needed.
+- `scripts/package-rpm.sh`, `scripts/package-arch.sh`: out of scope per spec.
+
+---
+
+## Task 1: DistroDetector utility
+
+**Files:**
+- Create: `src/core/DistroDetector.h`
+- Create: `src/core/DistroDetector.cpp`
+- Create: `tests/test_distro_detector.cpp`
+- Modify: `src/core/CMakeLists.txt`
+- Modify: `tests/CMakeLists.txt`
+
+Follow TDD: write the parser spec as a test first, watch it fail, then implement.
+
+### Step 1: Write the failing test
+
+Create `tests/test_distro_detector.cpp`:
+
+```cpp
+#include <gtest/gtest.h>
+#include <QTemporaryFile>
+#include <QTextStream>
+#include "DistroDetector.h"
+
+using logitune::util::DistroFamily;
+
+namespace {
+
+// Writes the given body to a temp file and returns its path. The temp
+// file stays alive for the duration of the test via the caller's
+// std::unique_ptr so QTemporaryFile's destructor does not delete it
+// before the detector reads it.
+std::unique_ptr<QTemporaryFile> writeOsRelease(const QString &body) {
+    auto f = std::make_unique<QTemporaryFile>();
+    f->setAutoRemove(true);
+    EXPECT_TRUE(f->open());
+    QTextStream ts(f.get());
+    ts << body;
+    ts.flush();
+    f->close();
+    return f;
+}
+
+} // namespace
+
+TEST(DistroDetector, ArchLinux) {
+    auto f = writeOsRelease(R"(NAME="Arch Linux"
+ID=arch
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Arch);
+}
+
+TEST(DistroDetector, CachyOSViaIdLike) {
+    auto f = writeOsRelease(R"(NAME="CachyOS Linux"
+ID=cachyos
+ID_LIKE=arch
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Arch);
+}
+
+TEST(DistroDetector, Ubuntu) {
+    auto f = writeOsRelease(R"(NAME="Ubuntu"
+ID=ubuntu
+ID_LIKE=debian
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Debian);
+}
+
+TEST(DistroDetector, PopOsViaIdLike) {
+    auto f = writeOsRelease(R"(NAME="Pop!_OS"
+ID=pop
+ID_LIKE="ubuntu debian"
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Debian);
+}
+
+TEST(DistroDetector, PlainDebian) {
+    auto f = writeOsRelease(R"(NAME="Debian GNU/Linux"
+ID=debian
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Debian);
+}
+
+TEST(DistroDetector, Fedora) {
+    auto f = writeOsRelease(R"(NAME="Fedora Linux"
+ID=fedora
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Fedora);
+}
+
+TEST(DistroDetector, RockyLinuxViaIdLike) {
+    auto f = writeOsRelease(R"(NAME="Rocky Linux"
+ID=rocky
+ID_LIKE="centos rhel fedora"
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Fedora);
+}
+
+TEST(DistroDetector, UnknownDistro) {
+    auto f = writeOsRelease(R"(NAME="Frankendistro"
+ID=frankendistro
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Unknown);
+}
+
+TEST(DistroDetector, MissingFileIsUnknown) {
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(
+                  QStringLiteral("/nonexistent/path/to/os-release")),
+              DistroFamily::Unknown);
+}
+```
+
+Note: the tests exercise the explicit-path overload `detectDistroFamilyFromFile(const QString&)` so they can feed synthetic content. Production code uses the zero-arg `detectDistroFamily()` which reads `/etc/os-release`.
+
+### Step 2: Create the header
+
+Create `src/core/DistroDetector.h`:
+
+```cpp
+#pragma once
+
+#include <QString>
+
+namespace logitune::util {
+
+enum class DistroFamily {
+    Unknown,
+    Arch,
+    Debian,
+    Fedora,
+};
+
+// Parse /etc/os-release once per process and classify the distro.
+// Result is cached in a function-local static for subsequent calls.
+DistroFamily detectDistroFamily();
+
+// Test hook: classify from a specific file path. Does NOT cache.
+// Intended for unit tests that feed synthetic content.
+DistroFamily detectDistroFamilyFromFile(const QString &path);
+
+} // namespace logitune::util
+```
+
+### Step 3: Create the implementation
+
+Create `src/core/DistroDetector.cpp`:
+
+```cpp
+#include "DistroDetector.h"
+
+#include <QFile>
+#include <QSet>
+#include <QTextStream>
+
+namespace logitune::util {
+
+namespace {
+
+// Parses a single line of /etc/os-release into (key, value) where the
+// value has surrounding double quotes stripped.
+bool parseLine(const QString &line, QString &key, QString &value) {
+    const int eq = line.indexOf(QLatin1Char('='));
+    if (eq <= 0) return false;
+    key = line.left(eq).trimmed();
+    QString raw = line.mid(eq + 1).trimmed();
+    if (raw.size() >= 2 && raw.startsWith(QLatin1Char('"')) && raw.endsWith(QLatin1Char('"')))
+        raw = raw.mid(1, raw.size() - 2);
+    value = raw;
+    return true;
+}
+
+DistroFamily classify(const QString &id, const QStringList &idLike) {
+    // Exact-ID matches first.
+    if (id == QLatin1String("arch"))
+        return DistroFamily::Arch;
+    if (id == QLatin1String("debian") || id == QLatin1String("ubuntu"))
+        return DistroFamily::Debian;
+    if (id == QLatin1String("fedora") || id == QLatin1String("rhel")
+        || id == QLatin1String("rocky") || id == QLatin1String("almalinux")
+        || id == QLatin1String("centos"))
+        return DistroFamily::Fedora;
+
+    // Fall back to ID_LIKE (space-separated tokens).
+    for (const QString &like : idLike) {
+        if (like == QLatin1String("arch"))
+            return DistroFamily::Arch;
+        if (like == QLatin1String("debian") || like == QLatin1String("ubuntu"))
+            return DistroFamily::Debian;
+        if (like == QLatin1String("fedora") || like == QLatin1String("rhel"))
+            return DistroFamily::Fedora;
+    }
+    return DistroFamily::Unknown;
+}
+
+DistroFamily parseOsRelease(const QString &path) {
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
+        return DistroFamily::Unknown;
+
+    QString id;
+    QStringList idLike;
+    QTextStream ts(&f);
+    while (!ts.atEnd()) {
+        QString key, value;
+        if (!parseLine(ts.readLine(), key, value)) continue;
+        if (key == QLatin1String("ID")) {
+            id = value;
+        } else if (key == QLatin1String("ID_LIKE")) {
+            idLike = value.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        }
+    }
+    return classify(id, idLike);
+}
+
+} // namespace
+
+DistroFamily detectDistroFamily() {
+    static const DistroFamily cached = parseOsRelease(QStringLiteral("/etc/os-release"));
+    return cached;
+}
+
+DistroFamily detectDistroFamilyFromFile(const QString &path) {
+    return parseOsRelease(path);
+}
+
+} // namespace logitune::util
+```
+
+### Step 4: Register with CMake
+
+Open `src/core/CMakeLists.txt`. Find the `target_sources(logitune-core PRIVATE ...)` block and append `DistroDetector.cpp` to the list (preserve existing ordering):
+
+```cmake
+target_sources(logitune-core PRIVATE
+    DeviceManager.cpp
+    DeviceSession.cpp
+    PhysicalDevice.cpp
+    ...
+    DeviceFetcher.cpp
+    DistroDetector.cpp
+)
+```
+
+Open `tests/CMakeLists.txt`. Find the source list for `logitune-tests` (similar `target_sources` or `add_executable` pattern) and append `test_distro_detector.cpp` alphabetically or in the existing ordering convention.
+
+### Step 5: Build and run the new tests
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests --gtest_filter='DistroDetector.*' 2>&1 | tail -15
+```
+
+Expected: 9 tests pass.
+
+### Step 6: Full suite
+
+```bash
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+```
+
+Expected: `[  PASSED  ] 562 tests.` (553 baseline + 9 new).
+
+### Step 7: Verify no em-dashes on added lines
+
+```bash
+git diff HEAD -- src/core/DistroDetector.h src/core/DistroDetector.cpp tests/test_distro_detector.cpp src/core/CMakeLists.txt tests/CMakeLists.txt | grep "^+" | grep -c "—"
+```
+
+Expected: `0`.
+
+### Step 8: Commit
+
+```bash
+git add src/core/DistroDetector.h src/core/DistroDetector.cpp \
+        tests/test_distro_detector.cpp \
+        src/core/CMakeLists.txt tests/CMakeLists.txt
+git commit -m "feat(core): DistroDetector for /etc/os-release family mapping
+
+Small utility that parses /etc/os-release once per process and
+returns a DistroFamily enum (Arch, Debian, Fedora, Unknown). Uses
+ID first, falls back to ID_LIKE space-separated tokens. The public
+API has a zero-arg variant that caches the result and a path-arg
+variant for tests.
+
+Nine parameterized tests cover Arch, CachyOS (ID_LIKE=arch),
+Ubuntu, Pop!_OS (ID_LIKE includes ubuntu+debian), plain Debian,
+Fedora, Rocky Linux, an unknown distro, and a missing file.
+
+No consumer yet: DeviceModel wires the mapping to the
+AppIndicator banner in the next commit."
+```
+
+---
+
+## Task 2: DeviceModel::appIndicatorInstallCommand
+
+**Files:**
+- Modify: `src/app/models/DeviceModel.h`
+- Modify: `src/app/models/DeviceModel.cpp`
+- Modify: `src/app/qml/HomeView.qml`
+
+No new tests specifically for this getter; the DistroDetector tests already cover the mapping logic. A single smoke test in `test_device_model.cpp` confirms the getter returns the canonical package name.
+
+### Step 1: Declare the getter
+
+Open `src/app/models/DeviceModel.h`. Find the existing `Q_INVOKABLE QString gnomeTrayStatus() const;` declaration (around line 143). Add immediately after:
+
+```cpp
+Q_INVOKABLE QString appIndicatorInstallCommand() const;
+```
+
+### Step 2: Implement the getter
+
+Open `src/app/models/DeviceModel.cpp`. Add `#include "DistroDetector.h"` near the other `#include` lines at the top of the file (alphabetical with neighbours).
+
+After the existing `QString DeviceModel::gnomeTrayStatus() const { ... }` block (ends around line 821), add:
+
+```cpp
+QString DeviceModel::appIndicatorInstallCommand() const
+{
+    switch (logitune::util::detectDistroFamily()) {
+    case logitune::util::DistroFamily::Arch:
+        return QStringLiteral("sudo pacman -S gnome-shell-extension-appindicator");
+    case logitune::util::DistroFamily::Debian:
+        return QStringLiteral("sudo apt install gnome-shell-extension-appindicator");
+    case logitune::util::DistroFamily::Fedora:
+        return QStringLiteral("sudo dnf install gnome-shell-extension-appindicator");
+    case logitune::util::DistroFamily::Unknown:
+    default:
+        return QStringLiteral("Install gnome-shell-extension-appindicator via your package manager.");
+    }
+}
+```
+
+### Step 3: Add a narrow test
+
+Open `tests/test_device_model.cpp`. Add a single test at a place that matches the file's existing style (other `DeviceModelTest` cases around line 26-160):
+
+```cpp
+TEST_F(DeviceModelTest, AppIndicatorInstallCommandNonEmpty) {
+    const QString cmd = model.appIndicatorInstallCommand();
+    EXPECT_FALSE(cmd.isEmpty());
+    EXPECT_TRUE(cmd.contains(QStringLiteral("gnome-shell-extension-appindicator")))
+        << "command: " << cmd.toStdString();
+}
+```
+
+This does not pin the exact command (depends on where the test runs), but asserts non-empty + canonical package name is present in the output.
+
+### Step 4: Update QML banner
+
+Open `src/app/qml/HomeView.qml`. Find the banner's "not-installed" remediation text around line 236. Current:
+
+```qml
+if (status === "not-installed")
+    return "Run: sudo pacman -S gnome-shell-extension-appindicator\nThen log out and back in."
+```
+
+Replace with:
+
+```qml
+if (status === "not-installed")
+    return "Run: " + DeviceModel.appIndicatorInstallCommand() + "\nThen log out and back in."
+```
+
+The "disabled" path stays unchanged; `gnome-extensions enable` is distro-agnostic.
+
+### Step 5: Build and run tests
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+```
+
+Expected: `[  PASSED  ] 563 tests.` (562 after Task 1 + 1 new).
+
+### Step 6: Smoke-render the banner
+
+Launch the app with simulate mode and eyeball the banner:
+
+```bash
+pkill -x logitune 2>/dev/null; sleep 1
+nohup env XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/src/app/logitune --simulate-all > /tmp/logitune-banner.log 2>&1 & disown
+sleep 3
+```
+
+The banner will only render if `DeviceModel.gnomeTrayStatus()` returns `"not-installed"` or `"disabled"` on the host running the test. On CachyOS with the extension enabled, the banner will be hidden (status `""`). That is expected; this smoke only confirms the app still starts cleanly.
+
+```bash
+grep -iE "error|QML.*error" /tmp/logitune-banner.log | head -5
+pkill -x logitune 2>/dev/null
+```
+
+Expected: no QML errors. The banner content itself is verified on the Ubuntu VM in Task 5.
+
+### Step 7: Verify no em-dashes on added lines
+
+```bash
+git diff HEAD -- src/app/models/DeviceModel.h src/app/models/DeviceModel.cpp src/app/qml/HomeView.qml tests/test_device_model.cpp | grep "^+" | grep -c "—"
+```
+
+Expected: `0`.
+
+### Step 8: Commit
+
+```bash
+git add src/app/models/DeviceModel.h src/app/models/DeviceModel.cpp \
+        src/app/qml/HomeView.qml tests/test_device_model.cpp
+git commit -m "feat(device-model): appIndicatorInstallCommand per distro family
+
+New Q_INVOKABLE that maps the detected DistroFamily to the correct
+package-manager invocation:
+ - Arch family -> sudo pacman -S gnome-shell-extension-appindicator
+ - Debian/Ubuntu -> sudo apt install gnome-shell-extension-appindicator
+ - Fedora/RHEL -> sudo dnf install gnome-shell-extension-appindicator
+ - Unknown -> generic hint with the package name
+
+HomeView.qml's not-installed banner reads the getter instead of
+hard-coding the pacman command, so Ubuntu users see apt, Fedora
+users see dnf, etc. The enable-extension remediation (gnome-extensions
+enable ...) is already distro-agnostic and stays unchanged.
+
+One smoke test pins the canonical package name in the returned
+string; exact command depends on the host running the test."
+```
+
+---
+
+## Task 3: Fix GnomeDesktop AppIndicator detection
+
+**Files:**
+- Modify: `src/core/desktop/GnomeDesktop.cpp`
+
+No test. DBus mocking for this one probe is heavier than the win. Manual verification on two VMs (Task 5).
+
+### Step 1: Patch the detection block
+
+Open `src/core/desktop/GnomeDesktop.cpp`. Find the block around lines 63-97 that calls `GetExtensionInfo` and maps the result to an `AppIndicatorState`. Current:
+
+```cpp
+if (infoReply.type() != QDBusMessage::ReplyMessage) {
+    m_appIndicatorStatus = AppIndicatorNotInstalled;
+    qCWarning(lcFocus) << "AppIndicator extension not installed -- tray icon will not be visible."
+                       << "Install: gnome-shell-extension-appindicator";
+} else {
+    // Extension exists -- check if enabled (state 1 = ENABLED/ACTIVE)
+    QVariantMap info = qdbus_cast<QVariantMap>(infoReply.arguments().first());
+    double state = info.value(QStringLiteral("state")).toDouble();
+    // GNOME Shell extension states: 1=ENABLED, 2=DISABLED, 3=ERROR, 4=OUT_OF_DATE, 5=DOWNLOADING, 6=INITIALIZED
+    if (state == 1.0) {
+        m_appIndicatorStatus = AppIndicatorActive;
+        qCInfo(lcFocus) << "AppIndicator extension active";
+    } else {
+        m_appIndicatorStatus = AppIndicatorDisabled;
+        qCWarning(lcFocus) << "AppIndicator extension installed but not enabled (state:" << state << ")"
+                           << "-- run: gnome-extensions enable" << kAppIndicatorUuid;
+    }
+}
+```
+
+Replace with:
+
+```cpp
+bool installed = false;
+QVariantMap info;
+if (infoReply.type() == QDBusMessage::ReplyMessage && !infoReply.arguments().isEmpty()) {
+    info = qdbus_cast<QVariantMap>(infoReply.arguments().first());
+    installed = !info.isEmpty();
+}
+
+if (!installed) {
+    m_appIndicatorStatus = AppIndicatorNotInstalled;
+    qCWarning(lcFocus) << "AppIndicator extension not installed -- tray icon will not be visible."
+                       << "Install: gnome-shell-extension-appindicator";
+} else {
+    // GNOME Shell extension states: 1=ENABLED, 2=DISABLED, 3=ERROR,
+    //                               4=OUT_OF_DATE, 5=DOWNLOADING, 6=INITIALIZED.
+    double state = info.value(QStringLiteral("state")).toDouble();
+    if (state == 1.0) {
+        m_appIndicatorStatus = AppIndicatorActive;
+        qCInfo(lcFocus) << "AppIndicator extension active";
+    } else {
+        m_appIndicatorStatus = AppIndicatorDisabled;
+        qCWarning(lcFocus) << "AppIndicator extension installed but not enabled (state:" << state << ")"
+                           << "-- run: gnome-extensions enable" << kAppIndicatorUuid;
+    }
+}
+```
+
+Key changes:
+- Read `info` only when the reply is a `ReplyMessage` AND has at least one argument. Prevents UB on `arguments().first()` for error replies.
+- `installed` is true only when `info` has entries. An empty dict means GNOME Shell returned success but the uuid does not exist, so the extension is not installed.
+- Log messages unchanged.
+
+### Step 2: Build
+
+```bash
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+```
+
+Expected: exit 0, no new warnings.
+
+### Step 3: Full suite
+
+```bash
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+```
+
+Expected: `[  PASSED  ] 563 tests.` (unchanged from Task 2).
+
+### Step 4: Verify no em-dashes on added lines
+
+```bash
+git diff HEAD -- src/core/desktop/GnomeDesktop.cpp | grep "^+" | grep -c "—"
+```
+
+Expected: `0`.
+
+### Step 5: Commit
+
+```bash
+git add src/core/desktop/GnomeDesktop.cpp
+git commit -m "fix(gnome): treat empty GetExtensionInfo as not-installed
+
+GNOME Shell's org.gnome.Shell.Extensions.GetExtensionInfo returns
+an empty a{sv} dict (still a successful ReplyMessage) for uuids that
+are not installed. The previous detection only guarded against
+ErrorMessage, so the empty dict fell into the else branch where
+info.value('state').toDouble() returned 0.0 and we mapped that to
+AppIndicatorDisabled. Every user without the extension saw the UI
+banner 'installed but not enabled' with a remediation command that
+then failed with 'Extension does not exist'.
+
+Guard now requires ReplyMessage AND a non-empty dict before parsing
+state. ErrorMessage replies also fall through to AppIndicatorNotInstalled
+via the same branch, and arguments().first() is only called when the
+reply has arguments, preventing UB on error replies with no body.
+
+No unit test: DBus mocking is out of proportion for this single
+probe. Manual verification on Ubuntu 24.04 (no extension installed:
+reports not-installed) and CachyOS (extension enabled: reports
+active)."
+```
+
+---
+
+## Task 4: Deb `Recommends`
+
+**Files:**
+- Modify: `scripts/package-deb.sh`
+
+### Step 1: Add the Recommends line
+
+Open `scripts/package-deb.sh`. Find the `control` heredoc that emits the deb control file. Look for the `Depends:` line (around line 33-35). Immediately after the `Depends:` line, add:
+
+```
+Recommends: gnome-shell-extension-appindicator
+```
+
+Resulting context:
+
+```
+Package: logitune
+Version: $VERSION
+Section: utils
+Priority: optional
+Architecture: $ARCH
+Depends: libqt6core6 (>= 6.4), libqt6qml6, libqt6quick6, ...
+Recommends: gnome-shell-extension-appindicator
+Maintainer: ...
+```
+
+### Step 2: Build a fresh .deb from this branch to verify the control file
+
+```bash
+GITHUB_REF_NAME=v0.3.3-dev bash scripts/package-deb.sh 2>&1 | tail -3
+```
+
+Expected: ends with `logitune-0.3.3~dev_amd64.deb`.
+
+### Step 3: Inspect the control file inside the new deb
+
+```bash
+dpkg-deb -f logitune-0.3.3~dev_amd64.deb Recommends 2>&1
+```
+
+Expected: `Recommends: gnome-shell-extension-appindicator`.
+
+Clean up the local deb so it does not pollute the repo root:
+
+```bash
+rm -f logitune-0.3.3~dev_amd64.deb
+```
+
+### Step 4: Verify no em-dashes on added lines
+
+```bash
+git diff HEAD -- scripts/package-deb.sh | grep "^+" | grep -c "—"
+```
+
+Expected: `0`.
+
+### Step 5: Commit
+
+```bash
+git add scripts/package-deb.sh
+git commit -m "build(deb): Recommends gnome-shell-extension-appindicator
+
+Ubuntu and Debian install Recommends by default, so 'apt install
+logitune' on a fresh system pulls the AppIndicator extension
+automatically and the tray icon works out of the box. Users who
+want to opt out still can with 'apt install --no-install-recommends
+logitune'.
+
+No change to the RPM spec or pacman PKGBUILD: those ecosystems do
+not have an equivalent install-by-default recommendation mechanism
+we want to lean on here."
+```
+
+---
+
+## Task 5: Final verification
+
+**Files:** none modified.
+
+### Step 1: Clean rebuild
+
+```bash
+rm -rf build
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug 2>&1 | tail -3
+cmake --build build -j"$(nproc)" 2>&1 | tail -3
+```
+
+Expected: both exit 0.
+
+### Step 2: Full test run
+
+```bash
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" ./build/tests/logitune-tests 2>&1 | tail -3
+XDG_DATA_DIRS="$(pwd)/build:/usr/local/share:/usr/share" QT_QPA_PLATFORM=offscreen ./build/tests/qml/logitune-qml-tests 2>&1 | tail -3
+```
+
+Expected: 563 core + 72 QML.
+
+### Step 3: Build and test install on Ubuntu VM (if available)
+
+If the maintainer has an Ubuntu 24.04 VM or container accessible (e.g.
+at `172.16.218.131` on their local network, as seen in the prior
+autostart cycle), build a deb and test install:
+
+```bash
+GITHUB_REF_NAME=v0.3.3-dev bash scripts/package-deb.sh 2>&1 | tail -3
+scp logitune-0.3.3~dev_amd64.deb 172.16.218.131:/tmp/logitune.deb 2>&1 | tail -2
+ssh 172.16.218.131 'sudo dpkg -i /tmp/logitune.deb; sudo apt-get install -f -y 2>&1 | tail -5'
+ssh 172.16.218.131 'dpkg-query -W -f="${Status}\n" gnome-shell-extension-appindicator 2>&1'
+```
+
+Expected:
+- Clean `ii` install of logitune.
+- `gnome-shell-extension-appindicator` shows `install ok installed` (pulled via Recommends).
+
+Clean up:
+
+```bash
+rm -f logitune-0.3.3~dev_amd64.deb
+```
+
+### Step 4: Manual smoke on the Ubuntu VM desktop
+
+Log in on the VM (or ask the maintainer to). After login, the
+autostart should fire with `--minimized`. With the extension now
+installed, the tray icon should appear and the main window should
+stay hidden.
+
+In a terminal on the VM:
+
+```bash
+journalctl --user -u graphical-session.target -b --since "5 minutes ago" 2>&1 | grep -i logitune
+```
+
+Look for `Startup: minimized to tray` (from the autostart PR's log
+line). If the line says `Startup: --minimized requested but tray is
+not visible, showing window`, either the extension is not enabled or
+the tray host is still initialising; user can open the banner via
+the app and confirm status.
+
+### Step 5: Branch commit list
+
+```bash
+git log --oneline master..HEAD
+```
+
+Expected: the spec commit plus four implementation commits (Tasks
+1-4). No amendments.
+
+### Step 6: Em-dash scan on touched files
+
+```bash
+git diff --name-only master..HEAD \
+  | grep -vE '\.(png|svg)$' \
+  | xargs -I{} sh -c 'printf "%s: " "{}"; grep -c "—" "{}" 2>/dev/null || echo "N/A"'
+```
+
+Expected: C++ / CMake / QML / shell / test files print `0`. Docs may
+print non-zero (pre-existing).
+
+### Step 7: Hand-off
+
+Do NOT push the branch. Maintainer pushes and opens the PR.
+
+---
+
+## Done criteria
+
+- Clean Debug rebuild from scratch: 0 errors, 0 warnings introduced.
+- 563 core tests pass (553 baseline + 9 DistroDetector + 1 DeviceModel). 72 QML tests pass.
+- Ubuntu 24.04 `apt install logitune` pulls `gnome-shell-extension-appindicator` via Recommends.
+- In-app banner on a system without the extension reports "not installed" (not "installed but not enabled") with the correct install command for the detected distro.
+- Four implementation commits on the branch, each reviewable in isolation, none amended.
+- `grep -c "—"` on every touched C++/CMake/QML/shell/test file prints `0`.

--- a/docs/superpowers/specs/2026-04-20-appindicator-detection-design.md
+++ b/docs/superpowers/specs/2026-04-20-appindicator-detection-design.md
@@ -1,0 +1,217 @@
+# AppIndicator Extension Detection Fix — Design
+
+**Status:** approved, ready for implementation plan
+**Issue:** #70 (Ubuntu default GNOME: recommend AppIndicator + fix detection banner)
+**Target release:** next beta
+**Author:** Mina Maher (brainstormed with Claude)
+**Date:** 2026-04-20
+
+## Summary
+
+Three small fixes for the AppIndicator GNOME extension story:
+
+1. `GnomeDesktop::appIndicatorStatus` wrongly reports
+   `AppIndicatorDisabled` when the extension is not installed at all.
+   Root cause: empty DBus reply dict parses as `state=0`, which falls
+   into the disabled branch.
+2. The banner's "not installed" remediation hard-codes
+   `sudo pacman -S ...` regardless of distro. Broken on Ubuntu,
+   Fedora, etc.
+3. The deb does not pull the extension package automatically on
+   Ubuntu, so users who `apt install logitune` hit the banner on
+   every login.
+
+## Root cause (bug 1)
+
+`src/core/desktop/GnomeDesktop.cpp` lines 78-95 call
+`org.gnome.Shell.Extensions.GetExtensionInfo(uuid)` with a 2-second
+timeout. The code checks only whether the reply type is a successful
+`ReplyMessage`.
+
+GNOME Shell returns an empty `a{sv}` dict on success when the
+requested uuid does not exist. That is still a `ReplyMessage`, so the
+current guard misses it. The empty map goes to the `else` branch,
+`info.value("state").toDouble()` returns `0.0` (no such key), and the
+code maps `state != 1.0` to `AppIndicatorDisabled`.
+
+Net effect: every system without the extension installed reports
+"installed but not enabled", and the banner tells the user to run
+`gnome-extensions enable ...` which fails with "Extension does not
+exist".
+
+## Fixes
+
+### 1. Detection
+
+Refactor the existing if/else so the "not installed" branch covers both
+the error-reply case AND the successful-but-empty-dict case. Do not
+read `info` before confirming the reply is a `ReplyMessage` and has at
+least one argument, to avoid UB if the reply is an error without a
+body:
+
+```cpp
+bool installed = false;
+QVariantMap info;
+if (infoReply.type() == QDBusMessage::ReplyMessage && !infoReply.arguments().isEmpty()) {
+    info = qdbus_cast<QVariantMap>(infoReply.arguments().first());
+    installed = !info.isEmpty();
+}
+
+if (!installed) {
+    m_appIndicatorStatus = AppIndicatorNotInstalled;
+    qCWarning(lcFocus) << "AppIndicator extension not installed -- "
+                          "tray icon will not be visible. Install: "
+                          "gnome-shell-extension-appindicator";
+} else {
+    double state = info.value("state").toDouble();
+    if (state == 1.0) {
+        m_appIndicatorStatus = AppIndicatorActive;
+        qCInfo(lcFocus) << "AppIndicator extension active";
+    } else {
+        m_appIndicatorStatus = AppIndicatorDisabled;
+        qCWarning(lcFocus) << "AppIndicator extension installed but not enabled "
+                              "(state:" << state << ") -- run: gnome-extensions "
+                              "enable" << kAppIndicatorUuid;
+    }
+}
+```
+
+`info.isEmpty()` covers both "dict has no entries" and "dict missing
+uuid key", both of which indicate the extension is not on the system.
+
+### 2. Distro-aware banner copy
+
+Add a distro detector that parses `/etc/os-release` and maps the `ID`
+(and `ID_LIKE` fallback) to one of four families: `arch`, `debian`,
+`fedora`, `other`. Expose via a new `DeviceModel` getter so QML can
+render the right install command.
+
+```
+arch family   -> sudo pacman -S gnome-shell-extension-appindicator
+debian family -> sudo apt install gnome-shell-extension-appindicator
+fedora family -> sudo dnf install gnome-shell-extension-appindicator
+other         -> "Install gnome-shell-extension-appindicator via your
+                 package manager."
+```
+
+QML `HomeView.qml` banner reads the new getter instead of hard-coding
+pacman.
+
+### 3. Deb `Recommends`
+
+Add `Recommends: gnome-shell-extension-appindicator` to the deb
+control in `scripts/package-deb.sh`. Debian/Ubuntu install recommended
+packages by default, so `apt install logitune` pulls the extension
+automatically. Users opt out with `--no-install-recommends`.
+
+No change to the RPM spec or pacman PKGBUILD: those package managers
+do not have an equivalent "opt-in-by-default recommendation" that fits
+this use case, and the same distros do not consistently package the
+extension under a stable name anyway.
+
+## Code surface
+
+### `src/core/desktop/GnomeDesktop.cpp`
+
+Patch the detection block as above. No header change (enum already
+includes `AppIndicatorNotInstalled`).
+
+### `src/core/util/DistroDetector.{h,cpp}` (new)
+
+Small utility under `src/core/util/`:
+
+```cpp
+namespace logitune::util {
+
+enum class DistroFamily { Unknown, Arch, Debian, Fedora };
+
+// Parses /etc/os-release once per process. Returns Unknown when
+// the file is missing or malformed.
+DistroFamily detectDistroFamily();
+
+} // namespace logitune::util
+```
+
+Implementation reads `/etc/os-release`, extracts `ID` and `ID_LIKE`
+(space-separated list of additional identities), and matches:
+
+- `ID=arch` or `ID_LIKE` contains `arch` -> `Arch`.
+- `ID=debian`, `ID=ubuntu`, or `ID_LIKE` contains `debian` or `ubuntu` -> `Debian`.
+- `ID=fedora`, `ID=rhel`, `ID=rocky`, `ID=almalinux`, or `ID_LIKE` contains `fedora` or `rhel` -> `Fedora`.
+- Otherwise `Unknown`.
+
+Cached in a function-local static so repeated calls are free.
+
+### `src/app/models/DeviceModel.{h,cpp}`
+
+Add:
+
+```cpp
+Q_INVOKABLE QString appIndicatorInstallCommand() const;
+```
+
+Returns the apt/pacman/dnf command matching the detected family, or a
+generic sentence for `Unknown`. QML reads via
+`DeviceModel.appIndicatorInstallCommand()` instead of the current
+hard-coded string.
+
+### `src/app/qml/HomeView.qml`
+
+Banner's "not installed" text pulls from
+`DeviceModel.appIndicatorInstallCommand()`. The "disabled" text stays
+as is (the `gnome-extensions enable ...` command is distro-agnostic).
+
+### `scripts/package-deb.sh`
+
+Append `Recommends:` line to the Debian control template:
+
+```
+Recommends: gnome-shell-extension-appindicator
+```
+
+## Tests
+
+- `tests/test_distro_detector.cpp` (new): parameterized over a few
+  synthetic `/etc/os-release` contents via a temp-file helper. Asserts
+  the family mapping for Arch, Ubuntu, Debian, Fedora, and Unknown.
+- `tests/test_device_model.cpp`: one test that asserts
+  `appIndicatorInstallCommand()` returns a non-empty string. The exact
+  command depends on the machine running the tests, so do not assert
+  a specific substring. Just assert non-empty and that the word
+  "gnome-shell-extension-appindicator" appears.
+- No GTest for `GnomeDesktop::appIndicatorStatus` itself. DBus mocking
+  is out of proportion for the fix. Manual verification on two VMs:
+  Ubuntu 24.04 without the extension reports "not installed"; CachyOS
+  with the extension enabled reports "active".
+
+## Rollout
+
+Branch `fix-appindicator-detection`. Four commits:
+
+1. `feat(util): DistroDetector for /etc/os-release family mapping`.
+   New file + tests.
+2. `feat(device-model): appIndicatorInstallCommand per distro family`.
+   DeviceModel getter wired to DistroDetector. QML banner reads it.
+3. `fix(gnome): treat empty GetExtensionInfo as not-installed`.
+   One-line guard in GnomeDesktop.cpp + manual VM verification.
+4. `build(deb): Recommends gnome-shell-extension-appindicator`.
+   One-line add in package-deb.sh.
+
+Ships in the next beta release alongside whatever else is in flight.
+
+## Known risks
+
+- **`ID_LIKE` variance.** Not every distro sets `ID_LIKE`; Pop!_OS
+  sets `ID_LIKE=debian`, CachyOS sets `ID_LIKE=arch`, etc. The
+  mapping above should cover the common cases; unknown distros fall
+  through to the generic hint. Low risk.
+- **`appIndicatorInstallCommand()` called before DeviceModel is
+  instantiated**. QML reads the getter at render time; DeviceModel
+  exists before QML loads. No race.
+
+## Out of scope
+
+- Auto-enabling the extension via DBus after installation.
+- Offering to install the extension via the app (one-click install).
+- Changing the extension UUID we depend on.
+- pacman/dnf-package Recommends-equivalent.

--- a/scripts/package-arch.sh
+++ b/scripts/package-arch.sh
@@ -27,7 +27,8 @@ url="https://github.com/mmaher88/logitune"
 license=('GPL-3.0-or-later')
 depends=('qt6-base' 'qt6-declarative' 'qt6-svg' 'qt6-5compat' 'systemd-libs')
 makedepends=('cmake' 'ninja' 'qt6-tools')
-optdepends=('gnome-shell: per-app profile switching on GNOME')
+optdepends=('gnome-shell: per-app profile switching on GNOME'
+            'gnome-shell-extension-appindicator: system tray icon on GNOME')
 source=()
 
 build() {

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -33,6 +33,7 @@ Section: utils
 Priority: optional
 Architecture: $ARCH
 Depends: libqt6core6 (>= 6.4), libqt6qml6, libqt6quick6, libqt6svg6, libqt6dbus6, libqt6widgets6, libudev1, qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-dialogs, qml6-module-qtquick-window, qml6-module-qtquick-templates, qml6-module-qtquick-layouts, qml6-module-qtqml-workerscript, qml6-module-qt5compat-graphicaleffects
+Recommends: gnome-shell-extension-appindicator
 Maintainer: Mina Maher <mina.maher88@hotmail.com>
 Description: Logitech device configurator for Linux
  Configure Logitech HID++ peripherals (MX Master 3S and more).

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -30,6 +30,7 @@ Release:        1%{?dist}
 Summary:        Logitech device configurator for Linux
 License:        GPL-3.0-or-later
 URL:            https://github.com/mmaher88/logitune
+Recommends:     gnome-shell-extension-appindicator
 
 %description
 Configure Logitech HID++ peripherals (MX Master 3S and more).

--- a/src/app/models/DeviceModel.cpp
+++ b/src/app/models/DeviceModel.cpp
@@ -831,9 +831,9 @@ QString DeviceModel::appIndicatorInstallCommand() const
     case logitune::util::DistroFamily::Fedora:
         return QStringLiteral("sudo dnf install gnome-shell-extension-appindicator");
     case logitune::util::DistroFamily::Unknown:
-    default:
         return QStringLiteral("Install gnome-shell-extension-appindicator via your package manager.");
     }
+    Q_UNREACHABLE();
 }
 
 void DeviceModel::setActiveWmClass(const QString &wmClass)

--- a/src/app/models/DeviceModel.cpp
+++ b/src/app/models/DeviceModel.cpp
@@ -2,6 +2,7 @@
 #include "interfaces/IDevice.h"
 #include "devices/JsonDevice.h"
 #include "desktop/GnomeDesktop.h"
+#include "DistroDetector.h"
 #include "logging/LogManager.h"
 #include <QFile>
 #include <QJsonArray>
@@ -817,6 +818,21 @@ QString DeviceModel::gnomeTrayStatus() const
         return QStringLiteral("disabled");
     default:
         return QString();
+    }
+}
+
+QString DeviceModel::appIndicatorInstallCommand() const
+{
+    switch (logitune::util::detectDistroFamily()) {
+    case logitune::util::DistroFamily::Arch:
+        return QStringLiteral("sudo pacman -S gnome-shell-extension-appindicator");
+    case logitune::util::DistroFamily::Debian:
+        return QStringLiteral("sudo apt install gnome-shell-extension-appindicator");
+    case logitune::util::DistroFamily::Fedora:
+        return QStringLiteral("sudo dnf install gnome-shell-extension-appindicator");
+    case logitune::util::DistroFamily::Unknown:
+    default:
+        return QStringLiteral("Install gnome-shell-extension-appindicator via your package manager.");
     }
 }
 

--- a/src/app/models/DeviceModel.h
+++ b/src/app/models/DeviceModel.h
@@ -141,6 +141,7 @@ public:
     bool thumbWheelInvert() const;
     Q_INVOKABLE void setThumbWheelInvert(bool invert);
     Q_INVOKABLE QString gnomeTrayStatus() const;
+    Q_INVOKABLE QString appIndicatorInstallCommand() const;
 
     void loadGesturesFromProfile(const QMap<QString, QPair<QString, QString>> &gestures);
     void setActiveProfileName(const QString &name);

--- a/src/app/qml/HomeView.qml
+++ b/src/app/qml/HomeView.qml
@@ -197,16 +197,14 @@ Item {
         // GNOME AppIndicator notification banner
         Rectangle {
             id: trayBanner
+            readonly property string trayStatus: DeviceModel.gnomeTrayStatus()
             anchors { bottom: parent.bottom; left: parent.left; right: parent.right; margins: 16 }
             height: bannerCol.implicitHeight + 24
             radius: 8
             color: Theme.surface
             border.color: Theme.border
             border.width: 1
-            visible: {
-                var status = DeviceModel.gnomeTrayStatus()
-                return status === "not-installed" || status === "disabled"
-            }
+            visible: trayStatus === "not-installed" || trayStatus === "disabled"
 
             Column {
                 id: bannerCol
@@ -215,10 +213,9 @@ Item {
 
                 Text {
                     text: {
-                        var status = DeviceModel.gnomeTrayStatus()
-                        if (status === "not-installed")
+                        if (trayBanner.trayStatus === "not-installed")
                             return "Tray icon requires the AppIndicator GNOME extension"
-                        if (status === "disabled")
+                        if (trayBanner.trayStatus === "disabled")
                             return "AppIndicator extension is installed but not enabled"
                         return ""
                     }
@@ -231,10 +228,9 @@ Item {
 
                 Text {
                     text: {
-                        var status = DeviceModel.gnomeTrayStatus()
-                        if (status === "not-installed")
+                        if (trayBanner.trayStatus === "not-installed")
                             return "Run: " + DeviceModel.appIndicatorInstallCommand() + "\nThen log out and back in."
-                        if (status === "disabled")
+                        if (trayBanner.trayStatus === "disabled")
                             return "Run: gnome-extensions enable appindicatorsupport@rgcjonas.gmail.com\nThen restart Logitune."
                         return ""
                     }

--- a/src/app/qml/HomeView.qml
+++ b/src/app/qml/HomeView.qml
@@ -233,7 +233,7 @@ Item {
                     text: {
                         var status = DeviceModel.gnomeTrayStatus()
                         if (status === "not-installed")
-                            return "Run: sudo pacman -S gnome-shell-extension-appindicator\nThen log out and back in."
+                            return "Run: " + DeviceModel.appIndicatorInstallCommand() + "\nThen log out and back in."
                         if (status === "disabled")
                             return "Run: gnome-extensions enable appindicatorsupport@rgcjonas.gmail.com\nThen restart Logitune."
                         return ""

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(logitune-core PRIVATE
     logging/LogManager.cpp
     logging/CrashHandler.cpp
     DeviceFetcher.cpp
+    DistroDetector.cpp
 )
 
 target_include_directories(logitune-core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/core/DistroDetector.cpp
+++ b/src/core/DistroDetector.cpp
@@ -1,0 +1,77 @@
+#include "DistroDetector.h"
+
+#include <QFile>
+#include <QTextStream>
+
+namespace logitune::util {
+
+namespace {
+
+// Parses a single line of /etc/os-release into (key, value) where the
+// value has surrounding double quotes stripped.
+bool parseLine(const QString &line, QString &key, QString &value) {
+    const int eq = line.indexOf(QLatin1Char('='));
+    if (eq <= 0) return false;
+    key = line.left(eq).trimmed();
+    QString raw = line.mid(eq + 1).trimmed();
+    if (raw.size() >= 2 && raw.startsWith(QLatin1Char('"')) && raw.endsWith(QLatin1Char('"')))
+        raw = raw.mid(1, raw.size() - 2);
+    value = raw;
+    return true;
+}
+
+DistroFamily classify(const QString &id, const QStringList &idLike) {
+    // Exact-ID matches first.
+    if (id == QLatin1String("arch"))
+        return DistroFamily::Arch;
+    if (id == QLatin1String("debian") || id == QLatin1String("ubuntu"))
+        return DistroFamily::Debian;
+    if (id == QLatin1String("fedora") || id == QLatin1String("rhel")
+        || id == QLatin1String("rocky") || id == QLatin1String("almalinux")
+        || id == QLatin1String("centos"))
+        return DistroFamily::Fedora;
+
+    // Fall back to ID_LIKE (space-separated tokens).
+    for (const QString &like : idLike) {
+        if (like == QLatin1String("arch"))
+            return DistroFamily::Arch;
+        if (like == QLatin1String("debian") || like == QLatin1String("ubuntu"))
+            return DistroFamily::Debian;
+        if (like == QLatin1String("fedora") || like == QLatin1String("rhel"))
+            return DistroFamily::Fedora;
+    }
+    return DistroFamily::Unknown;
+}
+
+DistroFamily parseOsRelease(const QString &path) {
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
+        return DistroFamily::Unknown;
+
+    QString id;
+    QStringList idLike;
+    QTextStream ts(&f);
+    while (!ts.atEnd()) {
+        QString key, value;
+        if (!parseLine(ts.readLine(), key, value)) continue;
+        if (key == QLatin1String("ID")) {
+            id = value;
+        } else if (key == QLatin1String("ID_LIKE")) {
+            idLike = value.split(QLatin1Char(' '), Qt::SkipEmptyParts);
+        }
+    }
+    return classify(id, idLike);
+}
+
+} // namespace
+
+DistroFamily detectDistroFamily() {
+    static const DistroFamily cached = parseOsRelease(QStringLiteral("/etc/os-release"));
+    return cached;
+}
+
+DistroFamily detectDistroFamilyFromFile(const QString &path) {
+    return parseOsRelease(path);
+}
+
+} // namespace logitune::util

--- a/src/core/DistroDetector.cpp
+++ b/src/core/DistroDetector.cpp
@@ -14,7 +14,11 @@ bool parseLine(const QString &line, QString &key, QString &value) {
     if (eq <= 0) return false;
     key = line.left(eq).trimmed();
     QString raw = line.mid(eq + 1).trimmed();
-    if (raw.size() >= 2 && raw.startsWith(QLatin1Char('"')) && raw.endsWith(QLatin1Char('"')))
+    // /etc/os-release per spec allows both double-quoted and single-quoted
+    // values. Historical Alpine and a few embedded distros use single quotes.
+    if (raw.size() >= 2
+        && ((raw.startsWith(QLatin1Char('"'))  && raw.endsWith(QLatin1Char('"')))
+         || (raw.startsWith(QLatin1Char('\'')) && raw.endsWith(QLatin1Char('\'')))))
         raw = raw.mid(1, raw.size() - 2);
     value = raw;
     return true;

--- a/src/core/DistroDetector.h
+++ b/src/core/DistroDetector.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QString>
+
+namespace logitune::util {
+
+enum class DistroFamily {
+    Unknown,
+    Arch,
+    Debian,
+    Fedora,
+};
+
+// Parse /etc/os-release once per process and classify the distro.
+// Result is cached in a function-local static for subsequent calls.
+DistroFamily detectDistroFamily();
+
+// Test hook: classify from a specific file path. Does NOT cache.
+// Intended for unit tests that feed synthetic content.
+DistroFamily detectDistroFamilyFromFile(const QString &path);
+
+} // namespace logitune::util

--- a/src/core/desktop/GnomeDesktop.cpp
+++ b/src/core/desktop/GnomeDesktop.cpp
@@ -44,6 +44,12 @@ void GnomeDesktop::start()
         return;
     }
 
+    // Probe the AppIndicator extension before touching our own focus extension.
+    // The two extensions are independent: a fresh install of logitune-focus
+    // requires a shell reload to register, and we still want the tray-icon
+    // banner to reflect reality on the user's first launch.
+    detectAppIndicatorStatus();
+
     // Install and enable the extension
     if (!ensureExtensionInstalled()) {
         qCWarning(lcFocus) << "GNOME: failed to install/enable extension";
@@ -59,45 +65,44 @@ void GnomeDesktop::start()
 
     m_available = true;
     qCInfo(lcFocus) << "GNOME desktop integration started";
+}
 
-    // Check AppIndicator extension status (needed for tray icon on GNOME).
-    // Emit a signal so the UI can show a one-time notification to the user.
-    {
-        static const QString kAppIndicatorUuid =
-            QStringLiteral("appindicatorsupport@rgcjonas.gmail.com");
+void GnomeDesktop::detectAppIndicatorStatus()
+{
+    static const QString kAppIndicatorUuid =
+        QStringLiteral("appindicatorsupport@rgcjonas.gmail.com");
 
-        // Check if extension exists and its state via GetExtensionInfo
-        QDBusMessage infoMsg = QDBusMessage::createMethodCall(
-            QStringLiteral("org.gnome.Shell.Extensions"),
-            QStringLiteral("/org/gnome/Shell/Extensions"),
-            QStringLiteral("org.gnome.Shell.Extensions"),
-            QStringLiteral("GetExtensionInfo"));
-        infoMsg << kAppIndicatorUuid;
-        QDBusMessage infoReply = QDBusConnection::sessionBus().call(infoMsg, QDBus::Block, 2000);
+    QDBusMessage infoMsg = QDBusMessage::createMethodCall(
+        QStringLiteral("org.gnome.Shell.Extensions"),
+        QStringLiteral("/org/gnome/Shell/Extensions"),
+        QStringLiteral("org.gnome.Shell.Extensions"),
+        QStringLiteral("GetExtensionInfo"));
+    infoMsg << kAppIndicatorUuid;
+    QDBusMessage infoReply = QDBusConnection::sessionBus().call(infoMsg, QDBus::Block, 2000);
 
-        bool installed = false;
-        QVariantMap info;
-        if (infoReply.type() == QDBusMessage::ReplyMessage && !infoReply.arguments().isEmpty()) {
-            info = qdbus_cast<QVariantMap>(infoReply.arguments().first());
-            installed = !info.isEmpty();
-        }
+    bool installed = false;
+    QVariantMap info;
+    if (infoReply.type() == QDBusMessage::ReplyMessage && !infoReply.arguments().isEmpty()) {
+        info = qdbus_cast<QVariantMap>(infoReply.arguments().first());
+        installed = !info.isEmpty();
+    }
 
-        if (!installed) {
-            m_appIndicatorStatus = AppIndicatorNotInstalled;
-            qCWarning(lcFocus) << "AppIndicator extension not installed -- tray icon will not be visible."
-                               << "Install: gnome-shell-extension-appindicator";
-        } else {
-            // GNOME Shell extension states: 1=ENABLED, 2=DISABLED, 3=ERROR, 4=OUT_OF_DATE, 5=DOWNLOADING, 6=INITIALIZED
-            int state = info.value(QStringLiteral("state")).toInt();
-            if (state == 1) {
-                m_appIndicatorStatus = AppIndicatorActive;
-                qCInfo(lcFocus) << "AppIndicator extension active";
-            } else {
-                m_appIndicatorStatus = AppIndicatorDisabled;
-                qCWarning(lcFocus) << "AppIndicator extension installed but not enabled (state:" << state << ")"
-                                   << "-- run: gnome-extensions enable" << kAppIndicatorUuid;
-            }
-        }
+    if (!installed) {
+        m_appIndicatorStatus = AppIndicatorNotInstalled;
+        qCWarning(lcFocus) << "AppIndicator extension not installed -- tray icon will not be visible."
+                           << "Install: gnome-shell-extension-appindicator";
+        return;
+    }
+
+    // GNOME Shell extension states: 1=ENABLED, 2=DISABLED, 3=ERROR, 4=OUT_OF_DATE, 5=DOWNLOADING, 6=INITIALIZED
+    int state = info.value(QStringLiteral("state")).toInt();
+    if (state == 1) {
+        m_appIndicatorStatus = AppIndicatorActive;
+        qCInfo(lcFocus) << "AppIndicator extension active";
+    } else {
+        m_appIndicatorStatus = AppIndicatorDisabled;
+        qCWarning(lcFocus) << "AppIndicator extension installed but not enabled (state:" << state << ")"
+                           << "-- run: gnome-extensions enable" << kAppIndicatorUuid;
     }
 }
 

--- a/src/core/desktop/GnomeDesktop.cpp
+++ b/src/core/desktop/GnomeDesktop.cpp
@@ -75,22 +75,27 @@ void GnomeDesktop::start()
         infoMsg << kAppIndicatorUuid;
         QDBusMessage infoReply = QDBusConnection::sessionBus().call(infoMsg, QDBus::Block, 2000);
 
-        if (infoReply.type() != QDBusMessage::ReplyMessage) {
+        bool installed = false;
+        QVariantMap info;
+        if (infoReply.type() == QDBusMessage::ReplyMessage && !infoReply.arguments().isEmpty()) {
+            info = qdbus_cast<QVariantMap>(infoReply.arguments().first());
+            installed = !info.isEmpty();
+        }
+
+        if (!installed) {
             m_appIndicatorStatus = AppIndicatorNotInstalled;
-            qCWarning(lcFocus) << "AppIndicator extension not installed — tray icon will not be visible."
+            qCWarning(lcFocus) << "AppIndicator extension not installed -- tray icon will not be visible."
                                << "Install: gnome-shell-extension-appindicator";
         } else {
-            // Extension exists — check if enabled (state 1 = ENABLED/ACTIVE)
-            QVariantMap info = qdbus_cast<QVariantMap>(infoReply.arguments().first());
-            double state = info.value(QStringLiteral("state")).toDouble();
             // GNOME Shell extension states: 1=ENABLED, 2=DISABLED, 3=ERROR, 4=OUT_OF_DATE, 5=DOWNLOADING, 6=INITIALIZED
-            if (state == 1.0) {
+            int state = info.value(QStringLiteral("state")).toInt();
+            if (state == 1) {
                 m_appIndicatorStatus = AppIndicatorActive;
                 qCInfo(lcFocus) << "AppIndicator extension active";
             } else {
                 m_appIndicatorStatus = AppIndicatorDisabled;
                 qCWarning(lcFocus) << "AppIndicator extension installed but not enabled (state:" << state << ")"
-                                   << "— run: gnome-extensions enable" << kAppIndicatorUuid;
+                                   << "-- run: gnome-extensions enable" << kAppIndicatorUuid;
             }
         }
     }

--- a/src/core/desktop/GnomeDesktop.h
+++ b/src/core/desktop/GnomeDesktop.h
@@ -25,6 +25,7 @@ public slots:
 private:
     bool ensureExtensionInstalled();
     int detectShellMajorVersion();
+    void detectAppIndicatorStatus();
 
     QString m_lastAppId;
     bool m_available = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(logitune-tests
     test_device_fetcher.cpp
     test_dpi_cycle_ring.cpp
     test_autostart_desktop.cpp
+    test_distro_detector.cpp
 )
 target_include_directories(logitune-tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(logitune-tests PRIVATE SOURCE_ROOT="${CMAKE_SOURCE_DIR}")

--- a/tests/test_device_model.cpp
+++ b/tests/test_device_model.cpp
@@ -163,6 +163,13 @@ TEST_F(DeviceModelTest, SetActiveProfileNameNoOpOnSame) {
     EXPECT_EQ(spy.count(), 0);
 }
 
+TEST_F(DeviceModelTest, AppIndicatorInstallCommandNonEmpty) {
+    const QString cmd = model.appIndicatorInstallCommand();
+    EXPECT_FALSE(cmd.isEmpty());
+    EXPECT_TRUE(cmd.contains(QStringLiteral("gnome-shell-extension-appindicator")))
+        << "command: " << cmd.toStdString();
+}
+
 // ---------------------------------------------------------------------------
 // Fixture with a fake-connected PhysicalDevice, so addPhysicalDevice's
 // per-property relay hooks fire. The session is never driven through HID++

--- a/tests/test_distro_detector.cpp
+++ b/tests/test_distro_detector.cpp
@@ -1,0 +1,99 @@
+#include <gtest/gtest.h>
+#include <QTemporaryFile>
+#include <QTextStream>
+#include "DistroDetector.h"
+
+using logitune::util::DistroFamily;
+
+namespace {
+
+// Writes the given body to a temp file and returns its path. The temp
+// file stays alive for the duration of the test via the caller's
+// std::unique_ptr so QTemporaryFile's destructor does not delete it
+// before the detector reads it.
+std::unique_ptr<QTemporaryFile> writeOsRelease(const QString &body) {
+    auto f = std::make_unique<QTemporaryFile>();
+    f->setAutoRemove(true);
+    EXPECT_TRUE(f->open());
+    QTextStream ts(f.get());
+    ts << body;
+    ts.flush();
+    f->close();
+    return f;
+}
+
+} // namespace
+
+TEST(DistroDetector, ArchLinux) {
+    auto f = writeOsRelease(R"(NAME="Arch Linux"
+ID=arch
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Arch);
+}
+
+TEST(DistroDetector, CachyOSViaIdLike) {
+    auto f = writeOsRelease(R"(NAME="CachyOS Linux"
+ID=cachyos
+ID_LIKE=arch
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Arch);
+}
+
+TEST(DistroDetector, Ubuntu) {
+    auto f = writeOsRelease(R"(NAME="Ubuntu"
+ID=ubuntu
+ID_LIKE=debian
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Debian);
+}
+
+TEST(DistroDetector, PopOsViaIdLike) {
+    auto f = writeOsRelease(R"(NAME="Pop!_OS"
+ID=pop
+ID_LIKE="ubuntu debian"
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Debian);
+}
+
+TEST(DistroDetector, PlainDebian) {
+    auto f = writeOsRelease(R"(NAME="Debian GNU/Linux"
+ID=debian
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Debian);
+}
+
+TEST(DistroDetector, Fedora) {
+    auto f = writeOsRelease(R"(NAME="Fedora Linux"
+ID=fedora
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Fedora);
+}
+
+TEST(DistroDetector, RockyLinuxViaIdLike) {
+    auto f = writeOsRelease(R"(NAME="Rocky Linux"
+ID=rocky
+ID_LIKE="centos rhel fedora"
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Fedora);
+}
+
+TEST(DistroDetector, UnknownDistro) {
+    auto f = writeOsRelease(R"(NAME="Frankendistro"
+ID=frankendistro
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Unknown);
+}
+
+TEST(DistroDetector, MissingFileIsUnknown) {
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(
+                  QStringLiteral("/nonexistent/path/to/os-release")),
+              DistroFamily::Unknown);
+}

--- a/tests/test_distro_detector.cpp
+++ b/tests/test_distro_detector.cpp
@@ -32,6 +32,14 @@ ID=arch
               DistroFamily::Arch);
 }
 
+TEST(DistroDetector, ArchLinuxSingleQuoted) {
+    auto f = writeOsRelease(R"(NAME='Arch Linux'
+ID='arch'
+)");
+    EXPECT_EQ(logitune::util::detectDistroFamilyFromFile(f->fileName()),
+              DistroFamily::Arch);
+}
+
 TEST(DistroDetector, CachyOSViaIdLike) {
     auto f = writeOsRelease(R"(NAME="CachyOS Linux"
 ID=cachyos


### PR DESCRIPTION
## Summary

Closes #70.

- **Detection bug:** GNOME Shell returns a successful reply with an empty `a{sv}` dict when a requested extension uuid does not exist. The old code treated that as "installed but state=0 → disabled" and told users to run `gnome-extensions enable ...`, which then failed with "Extension does not exist". Now the empty dict is correctly treated as *not installed*.
- **Distro-aware banner copy:** the banner's "install command" used to hardcode `sudo pacman -S ...` regardless of distro. A new `DistroDetector` utility reads `/etc/os-release` and maps to apt / pacman / dnf / generic; `DeviceModel::appIndicatorInstallCommand()` exposes the right string to QML.
- **Auto-install on Debian/Ubuntu:** the deb control gains `Recommends: gnome-shell-extension-appindicator`, so `apt install logitune` pulls the extension automatically. Users opt out with `--no-install-recommends`.

## Commits

1. `docs(spec)` + `docs(plan)` — approved design doc and implementation plan
2. `feat(core): DistroDetector for /etc/os-release family mapping`
3. `fix(distro-detector): strip single quotes as well as double` (per /etc/os-release spec)
4. `feat(device-model): appIndicatorInstallCommand per distro family`
5. `refactor(home-view): cache gnomeTrayStatus in local property` (cleanup: one Q_INVOKABLE call instead of three)
6. `fix(gnome): treat empty GetExtensionInfo dict as not-installed`
7. `build(deb): Recommends gnome-shell-extension-appindicator`

## Test plan

- [x] `logitune-tests`: 564/564 pass (was 553; +9 DistroDetector + 1 single-quote regression + 1 DeviceModel getter)
- [x] Ubuntu 24.04 VM: deb install pulls in `gnome-shell-extension-appindicator` via Recommends
- [x] Ubuntu 24.04 VM: `dbus-send org.gnome.Shell.Extensions.GetExtensionInfo` with a missing uuid returns empty `array []` (confirms the case the detection guard now handles)
- [x] App launches from VM-built deb on Ubuntu GNOME Wayland
- [ ] Visual banner text verification post-logout/login on Ubuntu (not gated on this PR; the copy is covered by unit tests)

## Out of scope

- Auto-enabling the extension via DBus after install
- In-app "install extension" button
- Pre-existing dismiss-button banner binding-override (X click permanently destroys the visible binding — separate follow-up)
- RPM / pacman soft-dep equivalents