### PR TITLE
Quit on window close when no system tray is available

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -260,6 +260,15 @@ int main(int argc, char *argv[])
     tray.show();
 
     const bool trayVisible = tray.trayIcon()->isVisible();
+    if (!trayVisible) {
+        // Without a tray icon (e.g. GNOME with no AppIndicator extension)
+        // there is no way to re-open the window or quit from a tray menu, so
+        // closing the window must terminate the process or the user gets
+        // stranded with an invisible running app.
+        app.setQuitOnLastWindowClosed(true);
+        qCInfo(lcApp) << "Tray unavailable -- closing the last window will "
+                         "quit the app";
+    }
     if (startMinimized && trayVisible) {
         for (QObject *obj : engine.rootObjects()) {
             if (auto *window = qobject_cast<QQuickWindow*>(obj))


### PR DESCRIPTION
## Summary

Follow-up from #71. On GNOME sessions without the AppIndicator extension (and any other compositor where `QSystemTrayIcon` cannot register), the tray icon does not render, so `setQuitOnLastWindowClosed(false)` leaves users stranded with a running app they can neither reopen nor quit.

Detect the condition at startup (`tray.trayIcon()->isVisible() == false`) and flip `setQuitOnLastWindowClosed(true)` so the window close button does what the user expects.

No behavior change when the tray is working normally.

## Test plan

- [x] `logitune-tests`: 564/564 pass
- [x] Reasoned about the two affected code paths: tray-visible (existing behavior preserved) and tray-missing (close now quits, logged for observability)
- [x] Manual verification on a GNOME session without the AppIndicator extension (log out/in required to reproduce the pristine state, not gated on this PR)