### PR TITLE
Keep button-page callouts legible on narrow windows

### DIFF
--- a/src/app/qml/components/HotspotControl.qml
+++ b/src/app/qml/components/HotspotControl.qml
@@ -218,9 +218,9 @@ Item {
                 // Physical button name (primary, bold)
                 EditableText {
                     id: nameLabel
-                    width: 156; height: 16
+                    width: 156; height: 18
                     text: root.buttonName
-                    pixelSize: 12
+                    pixelSize: 14
                     fontWeight: Font.DemiBold
                     textColor: root.selected ? Theme.activeTabText
                         : (hoverHandler.hovered ? Theme.accent : Theme.text)
@@ -239,8 +239,9 @@ Item {
                 // Action name (secondary)
                 Text {
                     text: root.actionName
-                    font.pixelSize: 10
-                    color: root.selected ? Qt.rgba(1,1,1,0.75) : "#999999"
+                    font.pixelSize: 12
+                    color: root.selected ? Qt.rgba(1,1,1,0.85)
+                        : Qt.rgba(Theme.text.r, Theme.text.g, Theme.text.b, 0.65)
                     width: Math.min(implicitWidth, 156)
                     elide: Text.ElideRight
                     Behavior on color { ColorAnimation { duration: 150 } }

--- a/src/app/qml/components/HotspotControl.qml
+++ b/src/app/qml/components/HotspotControl.qml
@@ -115,51 +115,35 @@ Item {
 
     // ══════════════════════════════════════════════════════════════════════
     // CONNECTOR LINE
+    // Rotated Rectangle rather than Canvas — the scene graph draws this in
+    // hardware and avoids a software repaint every time the marker or card
+    // moves, which happens on every frame of the ButtonsPage scale animation.
     // ══════════════════════════════════════════════════════════════════════
-    Canvas {
-        id: lineCanvas
+    Item {
+        id: connector
         anchors.fill: parent
+        visible: root.visible
 
-        onPaint: {
-            var ctx = getContext("2d")
-            ctx.clearRect(0, 0, width, height)
+        readonly property real startX: marker.x + marker.width / 2
+        readonly property real startY: marker.y + marker.height / 2
+        readonly property real endX: cardItem.x + cardItem.width / 2 < startX
+            ? cardItem.x + cardItem.width
+            : cardItem.x
+        readonly property real endY: cardItem.y + cardItem.height / 2
+        readonly property real dx: endX - startX
+        readonly property real dy: endY - startY
+        readonly property real length: Math.sqrt(dx * dx + dy * dy)
+        readonly property real angleDeg: Math.atan2(dy, dx) * 180 / Math.PI
 
-            if (!root.visible) return
-
-            var mx = marker.x + marker.width / 2
-            var my = marker.y + marker.height / 2
-
-            var cardEdgeX, cardEdgeY
-            if (cardItem.x + cardItem.width / 2 < mx) {
-                cardEdgeX = cardItem.x + cardItem.width
-            } else {
-                cardEdgeX = cardItem.x
-            }
-            cardEdgeY = cardItem.y + cardItem.height / 2
-
-            ctx.beginPath()
-            ctx.moveTo(cardEdgeX, cardEdgeY)
-            ctx.lineTo(mx, my)
-            ctx.strokeStyle = root.selected ? Theme.accent : "#BBBBBB"
-            ctx.lineWidth = 2
-            ctx.setLineDash([])
-            ctx.stroke()
-        }
-
-        Connections {
-            target: marker
-            function onXChanged() { lineCanvas.requestPaint() }
-            function onYChanged() { lineCanvas.requestPaint() }
-        }
-        Connections {
-            target: cardItem
-            function onXChanged() { lineCanvas.requestPaint() }
-            function onYChanged() { lineCanvas.requestPaint() }
-        }
-        Connections {
-            target: root
-            function onSelectedChanged() { lineCanvas.requestPaint() }
-            function onVisibleChanged() { lineCanvas.requestPaint() }
+        Rectangle {
+            x: connector.startX
+            y: connector.startY - 1
+            width: connector.length
+            height: 2
+            color: root.selected ? Theme.accent : "#BBBBBB"
+            transformOrigin: Item.TopLeft
+            rotation: connector.angleDeg
+            antialiasing: true
         }
     }
 

--- a/src/app/qml/pages/ButtonsPage.qml
+++ b/src/app/qml/pages/ButtonsPage.qml
@@ -98,23 +98,46 @@ Item {
         // Callouts live outside the scaled container so their text stays
         // legible when the image has to shrink (landscape side composites
         // on narrow windows). Positions project the scaled painted bounds
-        // back into renderArea coordinates.
+        // back into renderArea coordinates via mapToItem, which resolves
+        // the transform in one step and avoids the chain of derived
+        // properties that Qt's binding engine can mis-flag as a loop.
         Item {
             id: calloutLayer
             anchors.fill: parent
 
-            readonly property real imgCenterX: mouseContainer.x + mouseContainer.width / 2
-            readonly property real imgCenterY: mouseContainer.y + mouseContainer.height / 2
-            readonly property real paintedCx: deviceRender.x + deviceRender.paintedX + deviceRender.paintedW / 2
-            readonly property real paintedCy: deviceRender.y + deviceRender.paintedY + deviceRender.paintedH / 2
-            readonly property real paintedOffsetX: paintedCx - mouseContainer.width / 2
-            readonly property real paintedOffsetY: paintedCy - mouseContainer.height / 2
-            readonly property real scaledPaintedCenterX: imgCenterX + paintedOffsetX * mouseContainer.scale
-            readonly property real scaledPaintedCenterY: imgCenterY + paintedOffsetY * mouseContainer.scale
-            readonly property real scaledPaintedW: deviceRender.paintedW * mouseContainer.scale
-            readonly property real scaledPaintedH: deviceRender.paintedH * mouseContainer.scale
-            readonly property real scaledPaintedX: scaledPaintedCenterX - scaledPaintedW / 2
-            readonly property real scaledPaintedY: scaledPaintedCenterY - scaledPaintedH / 2
+            function refreshBounds() {
+                var tl = deviceRender.mapToItem(calloutLayer,
+                    deviceRender.paintedX, deviceRender.paintedY)
+                var br = deviceRender.mapToItem(calloutLayer,
+                    deviceRender.paintedX + deviceRender.paintedW,
+                    deviceRender.paintedY + deviceRender.paintedH)
+                scaledPaintedX = tl.x
+                scaledPaintedY = tl.y
+                scaledPaintedW = br.x - tl.x
+                scaledPaintedH = br.y - tl.y
+            }
+
+            property real scaledPaintedX: 0
+            property real scaledPaintedY: 0
+            property real scaledPaintedW: 0
+            property real scaledPaintedH: 0
+
+            Connections {
+                target: mouseContainer
+                function onXChanged()      { calloutLayer.refreshBounds() }
+                function onYChanged()      { calloutLayer.refreshBounds() }
+                function onScaleChanged()  { calloutLayer.refreshBounds() }
+                function onWidthChanged()  { calloutLayer.refreshBounds() }
+                function onHeightChanged() { calloutLayer.refreshBounds() }
+            }
+            Connections {
+                target: deviceRender
+                function onPaintedXChanged() { calloutLayer.refreshBounds() }
+                function onPaintedYChanged() { calloutLayer.refreshBounds() }
+                function onPaintedWChanged() { calloutLayer.refreshBounds() }
+                function onPaintedHChanged() { calloutLayer.refreshBounds() }
+            }
+            Component.onCompleted: refreshBounds()
 
             Repeater {
                 model: root.calloutData.length

--- a/src/app/qml/pages/ButtonsPage.qml
+++ b/src/app/qml/pages/ButtonsPage.qml
@@ -56,40 +56,66 @@ Item {
             right:  actionsPanel.left
         }
 
-        // ── Mouse + callouts container — moves together when panel opens ─────
+        // Scale math is shared between the device image (scaled) and the
+        // callout overlay (unscaled, reads back the scale to position itself).
+        // The 460 gutter accounts for callout cards spilling outside the
+        // painted image area; landscape composites like MX Vertical rely on
+        // the floor so the image does not vanish in a narrow window.
+        readonly property real fitScale: Math.min(1.0, Math.max(0.55,
+            renderArea.width / (deviceRender.implicitWidth + 460)))
+        readonly property real horizontalShift: root.selectedButton >= 0 ? -60 : 0
+
+        // ── Scaled image stage ───────────────────────────────────────────
         Item {
             id: mouseContainer
 
-            width:  deviceRender.implicitWidth + 460   // extra space for callouts
+            width:  deviceRender.implicitWidth
             height: deviceRender.implicitHeight
 
             anchors.verticalCenter: parent.verticalCenter
-
-            // Scale down when available space is tight
-            readonly property real fitScale: Math.min(1.0, Math.max(0.55, renderArea.width / width))
-            scale: fitScale
+            scale: renderArea.fitScale
             transformOrigin: Item.Center
 
             Behavior on scale {
                 NumberAnimation { duration: 300; easing.type: Easing.InOutCubic }
             }
 
-            // Centre horizontally; shift left when panel opens
-            x: (parent.width - width) / 2 + (root.selectedButton >= 0 ? -60 : 0)
+            x: (parent.width - width) / 2 + renderArea.horizontalShift
 
             Behavior on x {
                 NumberAnimation { duration: 300; easing.type: Easing.InOutCubic }
             }
 
-            // DeviceRender — side view for buttons page
             DeviceRender {
                 id: deviceRender
                 anchors.centerIn: parent
                 targetHeight: 414
                 imageSource: DeviceModel.sideImage
             }
+        }
 
-            // ── Unified hotspot controls (marker + line + card) ─────────────
+        // ── Unscaled callout overlay ─────────────────────────────────────
+        // Callouts live outside the scaled container so their text stays
+        // legible when the image has to shrink (landscape side composites
+        // on narrow windows). Positions project the scaled painted bounds
+        // back into renderArea coordinates.
+        Item {
+            id: calloutLayer
+            anchors.fill: parent
+
+            readonly property real imgCenterX: mouseContainer.x + mouseContainer.width / 2
+            readonly property real imgCenterY: mouseContainer.y + mouseContainer.height / 2
+            readonly property real paintedCx: deviceRender.x + deviceRender.paintedX + deviceRender.paintedW / 2
+            readonly property real paintedCy: deviceRender.y + deviceRender.paintedY + deviceRender.paintedH / 2
+            readonly property real paintedOffsetX: paintedCx - mouseContainer.width / 2
+            readonly property real paintedOffsetY: paintedCy - mouseContainer.height / 2
+            readonly property real scaledPaintedCenterX: imgCenterX + paintedOffsetX * mouseContainer.scale
+            readonly property real scaledPaintedCenterY: imgCenterY + paintedOffsetY * mouseContainer.scale
+            readonly property real scaledPaintedW: deviceRender.paintedW * mouseContainer.scale
+            readonly property real scaledPaintedH: deviceRender.paintedH * mouseContainer.scale
+            readonly property real scaledPaintedX: scaledPaintedCenterX - scaledPaintedW / 2
+            readonly property real scaledPaintedY: scaledPaintedCenterY - scaledPaintedH / 2
+
             Repeater {
                 model: root.calloutData.length
 
@@ -99,23 +125,19 @@ Item {
                     readonly property var cdata: root.calloutData[modelData]
                     readonly property int btnId: cdata.buttonId
 
-                    // Fill mouseContainer so marker + card can position freely
                     anchors.fill: parent
 
-                    // Device image bounds
-                    imageX: deviceRender.x + deviceRender.paintedX
-                    imageY: deviceRender.y + deviceRender.paintedY
-                    imageW: deviceRender.paintedW
-                    imageH: deviceRender.paintedH
+                    imageX: calloutLayer.scaledPaintedX
+                    imageY: calloutLayer.scaledPaintedY
+                    imageW: calloutLayer.scaledPaintedW
+                    imageH: calloutLayer.scaledPaintedH
 
-                    // Hotspot data
                     hotspotXPct: cdata.hotspotXPct
                     hotspotYPct: cdata.hotspotYPct
                     side: cdata.side
                     labelOffsetYPct: cdata.labelOffsetYPct || 0
                     configurable: cdata.configurable
 
-                    // Card data
                     buttonName: cdata.buttonLabel
                     actionName: {
                         var an = ButtonModel.actionNameForButton(btnId)
@@ -125,8 +147,8 @@ Item {
                     buttonId: btnId
                     hotspotIndex: modelData
 
-                    pageWidth: mouseContainer.width
-                    pageHeight: mouseContainer.height
+                    pageWidth: renderArea.width
+                    pageHeight: renderArea.height
 
                     onClicked: selectButton(btnId)
 


### PR DESCRIPTION
## Summary

Fixes the callout legibility issue [@dmaglio reported on issue #7](https://github.com/mmaher88/logitune/issues/7#issuecomment-4279986356) for the MX Vertical beta: at ~960px windows the callout labels rendered at effectively 6-7px and the secondary (action-name) line was nearly invisible.

## Root cause

`ButtonsPage.qml` wrapped the device image AND the callout overlay in a single `mouseContainer` and scaled the whole thing to fit the available width, with a floor of 0.55. MX Vertical's landscape side composite (~964×414 vs MX Master's portrait ~280×414) triggers the floor on typical-sized windows, shrinking the callout text proportionally.

Compounding this, the secondary action-name text hard-coded `#999999` on a near-white card, which is already low-contrast before any scale-down.

## Fix

1. **Split the render into two layers** (`src/app/qml/pages/ButtonsPage.qml`):
   - `mouseContainer` keeps the device image and scales as before.
   - A new `calloutLayer` sibling is **not** scaled. It projects the scaled painted image bounds back into screen coordinates and positions `HotspotControl` instances there. Markers still land on the correct pixels; cards render at natural size.
2. **Bump callout font sizes** (`src/app/qml/components/HotspotControl.qml`):
   - Primary (button name): `pixelSize 12 → 14`
   - Secondary (action name): `pixelSize 10 → 12`
3. **Theme-aware secondary color**: replace hard-coded `#999999` with `Theme.text` at 65% opacity so the action-name line is legible on both light and dark themes.

Net visual change: MX Vertical callouts are now readable at 960×640 and below; MX Master (which never scaled down on typical windows) is unchanged apart from the modestly larger, higher-contrast text.

## Scope non-goals

- `PointScrollPage.qml` has a similar scale pattern and inline callouts but is not touched here. Scrolling callout is narrower in practice and did not draw the same complaint. Separate PR if it regresses.
- Marker size is still in scaled space and shrinks slightly on MX Vertical at the 0.55 floor. Acceptable; markers remain visible at 55%.

## Test plan

- [x] `logitune-tests`: 564/564 pass
- [x] `logitune-qml-tests`: 72/72 pass
- [x] Manual launch with `--simulate-all` on host, confirmed build + load with no QML warnings
- [ ] Visual confirmation on the MX Vertical beta by @dmaglio