### PR TITLE
Mark MX Vertical DPI button as non-configurable (firmware-locked)

### DIFF
--- a/devices/mx-vertical-for-business/descriptor.json
+++ b/devices/mx-vertical-for-business/descriptor.json
@@ -38,7 +38,7 @@
         },
         {
             "buttonIndex": 5,
-            "configurable": true,
+            "configurable": false,
             "controlId": "0x00C3",
             "defaultActionType": "dpi-cycle",
             "defaultName": "DPI cycle"

--- a/devices/mx-vertical/descriptor.json
+++ b/devices/mx-vertical/descriptor.json
@@ -38,7 +38,7 @@
         },
         {
             "buttonIndex": 5,
-            "configurable": true,
+            "configurable": false,
             "controlId": "0x00C3",
             "defaultActionType": "dpi-cycle",
             "defaultName": "DPI cycle"

--- a/src/app/qml/components/HotspotControl.qml
+++ b/src/app/qml/components/HotspotControl.qml
@@ -33,7 +33,9 @@ Item {
 
     signal clicked()
 
-    visible: root.configurable
+    // Non-configurable hotspots (firmware-locked buttons like MX Vertical's
+    // DPI cycle, CID 0x00C3) stay visible so the user still sees the button
+    // labeled on the mouse, but the card does not open the action picker.
 
     // ── Computed marker centre ──
     readonly property real markerCenterX: imageX + hotspotXPct * imageW
@@ -77,8 +79,8 @@ Item {
             anchors.centerIn: parent
             width: 0.22 * root.imageW
             height: 0.14 * root.imageH
-            cursorShape: Qt.PointingHandCursor
-            enabled: !markerDrag.enabled
+            cursorShape: root.configurable ? Qt.PointingHandCursor : Qt.ArrowCursor
+            enabled: !markerDrag.enabled && root.configurable
             onClicked: root.clicked()
         }
 
@@ -197,6 +199,7 @@ Item {
             color: root.selected ? Theme.accent : Theme.cardBg
             border.color: root.selected ? Theme.accentHover : Theme.cardBorder
             border.width: 1
+            opacity: root.configurable ? 1.0 : 0.65
 
             Behavior on color { ColorAnimation { duration: 150 } }
             Behavior on border.color { ColorAnimation { duration: 150 } }
@@ -223,7 +226,7 @@ Item {
                     pixelSize: 12
                     fontWeight: Font.DemiBold
                     textColor: root.selected ? Theme.activeTabText
-                        : (hoverHandler.hovered ? Theme.accent : Theme.text)
+                        : ((hoverHandler.hovered && root.configurable) ? Theme.accent : Theme.text)
                     onCommit: function(v) {
                         var ctrls = DeviceModel.controlDescriptors
                         if (!ctrls) return
@@ -251,7 +254,7 @@ Item {
             Rectangle {
                 anchors.fill: parent
                 radius: cardRect.radius
-                color: hoverHandler.hovered && !root.selected
+                color: hoverHandler.hovered && !root.selected && root.configurable
                     ? Qt.rgba(0, 0, 0, 0.04) : "transparent"
                 Behavior on color { ColorAnimation { duration: 100 } }
             }
@@ -260,7 +263,8 @@ Item {
 
             MouseArea {
                 anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
+                cursorShape: root.configurable ? Qt.PointingHandCursor : Qt.ArrowCursor
+                enabled: root.configurable
                 propagateComposedEvents: true
                 onClicked: root.clicked()
                 onDoubleClicked: function(mouse) { mouse.accepted = false }

--- a/tests/test_device_registry.cpp
+++ b/tests/test_device_registry.cpp
@@ -292,6 +292,24 @@ TEST(DeviceRegistry, MxVerticalForBusinessRegistered) {
     EXPECT_EQ(ring[3], 4000);
 }
 
+// MX Vertical's DPI button (CID 0x00C3) is firmware-locked — SetControlReporting
+// is accepted by the device but the firmware still fires the native DPI cycle
+// without emitting a divert event. Mark the descriptor entry as non-configurable
+// so the UI shows the button as informational rather than offering a remap that
+// silently fails. Loaded via JsonDevice::load against the source tree so the
+// assertion tracks the descriptor regardless of whatever is installed at the
+// system path.
+TEST(DeviceRegistry, MxVerticalDpiButtonIsNotConfigurable) {
+    for (const char *slug : {"mx-vertical", "mx-vertical-for-business"}) {
+        const QString dir = QStringLiteral(SOURCE_ROOT "/devices/") + slug;
+        auto dev = logitune::JsonDevice::load(dir);
+        ASSERT_NE(dev, nullptr) << slug;
+        ASSERT_EQ(dev->controls().size(), 6u) << slug;
+        EXPECT_EQ(dev->controls()[5].controlId, 0x00C3) << slug;
+        EXPECT_FALSE(dev->controls()[5].configurable) << slug;
+    }
+}
+
 TEST(DeviceRegistry, MxMaster3sHasNoDpiCycleRing) {
     logitune::DeviceRegistry reg;
     const auto *dev = reg.findByName(QStringLiteral("MX Master 3S"));


### PR DESCRIPTION
Closes #75.

## Why

Reported by @dmaglio in #7. Assigning any non-default action to the MX Vertical DPI cycle button silently fails because the firmware ignores our `SetControlReporting` divert and keeps the internal DPI-cycle action. Log excerpt from the tester:

```
15:33:19.369  button c3 diverted            (our divert call succeeded)
15:33:21.492  02 00 00 02 00 00 00 00       (button press, short report)
```

No `button event: CID c3` or `divertedButtonPressed` dispatch line follows. The firmware accepts our divert but keeps handling this specific CID internally.

## What

1. `devices/mx-vertical/descriptor.json`, `devices/mx-vertical-for-business/descriptor.json`: flip `configurable: true → false` for CID 0x00C3.
2. `src/app/qml/components/HotspotControl.qml`: drop the `visible: configurable` gate so the callout still renders. Gate marker and card `MouseArea` on `configurable`, reduce card opacity, suppress the hover-accent color when not configurable. Net effect: the DPI button still shows its label, but the card is slightly dimmed and does not open the action picker.
3. `tests/test_device_registry.cpp`: regression test `MxVerticalDpiButtonIsNotConfigurable` that asserts `controls[5].configurable == false` on both MX Vertical variants. Uses `JsonDevice::load` against `SOURCE_ROOT` so the test tracks the repo, not whatever is installed at `/usr/share/logitune`.

## Non-goals

- Persistent-remap (feature 0x1B04) fallback. Descriptor reports `persistentRemappableAction: false`; separate investigation would need Options+ / Solaar traces before turning it on.
- Explanatory tooltip on the dimmed card. Follow-up if users ask what the disabled state means.

## Test plan

- [x] `logitune-tests`: 565/565 pass (+1 new regression test)
- [x] `logitune-qml-tests`: 72/72 pass
- [ ] Visual confirmation by @dmaglio that the card still shows the DPI button labeled and that the action picker no longer opens for it.