### PR TITLE
ProfileEngine per-device contexts; fix carousel ButtonModel reseed

### DIFF
--- a/docs/superpowers/plans/2026-04-20-profile-engine-per-device.md
+++ b/docs/superpowers/plans/2026-04-20-profile-engine-per-device.md
@@ -1,0 +1,1619 @@
+# ProfileEngine Per-Device Contexts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace ProfileEngine's hidden global context with per-device contexts keyed by `deviceSerial`, wire `DeviceModel::selectedChanged` to refresh the UI from the selected device's cached profile, and fix the bug where switching the carousel leaves `ButtonModel` displaying the first-seeded device's profile data (issue #77).
+
+**Architecture:** Introduce `DeviceProfileContext` + `QHash<QString, DeviceProfileContext> m_byDevice` on `ProfileEngine`, migrate every public method and signal to take `deviceSerial` as the first argument, and split the work across three commits: (1) add the new API alongside a legacy shim so nothing breaks, (2) migrate every call site and remove the shim, (3) wire the new selection handler + add tests covering the original bug.
+
+**Tech Stack:** Qt 6 (C++20), CMake, GTest. Existing code at `src/core/ProfileEngine.{h,cpp}`, `src/app/AppController.{h,cpp}`, `src/app/models/ProfileModel.{h,cpp}`, `tests/helpers/AppControllerFixture.h`, `tests/test_app_controller.cpp`, `tests/test_profile_engine.cpp`.
+
+---
+
+## File Structure
+
+### Files modified
+
+- `src/core/ProfileEngine.h` — add `DeviceProfileContext`, `m_byDevice`, serial-aware public API and signals. Remove legacy API in commit 2.
+- `src/core/ProfileEngine.cpp` — implement the new API. Legacy wrappers delegate to `"legacy"` serial in commit 1; removed in commit 2.
+- `src/app/AppController.h` — add `onSelectedDeviceChanged` slot. Update `onDisplayProfileChanged` signature.
+- `src/app/AppController.cpp` — migrate ~40 call sites to pass `selectedDevice()->deviceSerial()`. Add selection handler. Re-wire `ProfileModel::profileAdded` / `profileRemoved` through lambdas.
+- `tests/helpers/AppControllerFixture.h` — replace direct `m_currentDevice` assignment + `setDeviceConfigDir` calls with `registerDevice` + `onPhysicalDeviceAdded`. Helpers gain internal serial. Add `addMockDevice` helper for multi-device tests.
+- `tests/test_app_controller.cpp` — three new tests exercising multi-device selection.
+- `tests/test_profile_engine.cpp` — three new tests exercising serial-aware behavior.
+
+### Conventions
+
+- The word **"serial"** throughout this plan means `PhysicalDevice::deviceSerial()` — stable per-device string identifier that survives transport reconnects.
+- `m_profileEngine` is the `ProfileEngine` member on `AppController`.
+- The fixture uses `mock-serial` as the serial for its single mock device, and `mock-serial-B` for the second one in multi-device tests.
+
+---
+
+## Commit 1: Introduce per-device contexts alongside legacy API
+
+**Goal:** Add `DeviceProfileContext`, `m_byDevice`, serial-aware API, and serial-bearing signals. Keep the legacy single-context API working by delegating to a `"legacy"` auto-registered serial. All existing tests pass unchanged.
+
+### Task 1.1: Define `DeviceProfileContext` struct and add `m_byDevice` storage
+
+**Files:**
+- Modify: `src/core/ProfileEngine.h`
+
+- [ ] **Step 1: Add the struct definition above the class declaration**
+
+Open `src/core/ProfileEngine.h` and add this struct immediately after the `ProfileDelta` struct definition (around line 35), before `class ProfileEngine`:
+
+```cpp
+struct DeviceProfileContext {
+    QString configDir;                     // per-device profiles dir
+    QMap<QString, Profile> cache;          // profileName -> Profile
+    QMap<QString, QString> appBindings;    // wmClass -> profileName
+    QString displayProfile;                // currently displayed
+    QString hardwareProfile;               // currently active on hardware
+};
+```
+
+- [ ] **Step 2: Add the `m_byDevice` member and `kLegacySerial` constant**
+
+In the `private:` section of `ProfileEngine`, add this block immediately above the existing `m_configDir` member (around line 69):
+
+```cpp
+    // Per-device contexts. Key is PhysicalDevice::deviceSerial(). Lazy-
+    // registered on first touch; persists for the life of the process.
+    QHash<QString, DeviceProfileContext> m_byDevice;
+
+    // Serial used by the legacy single-context API (setDeviceConfigDir,
+    // non-serial-taking overloads). Allows the legacy API to keep working
+    // during the migration and disappears in commit 2.
+    static constexpr const char *kLegacySerial = "legacy";
+
+    // Lazy-registers a context if absent. Returns a reference to the
+    // live context in m_byDevice.
+    DeviceProfileContext& ctx(const QString &serial);
+    const DeviceProfileContext& ctx(const QString &serial) const;
+```
+
+Also change the `#include <QMap>` line to additionally include `<QHash>`:
+
+```cpp
+#include <QMap>
+#include <QHash>
+```
+
+- [ ] **Step 3: Build to verify the header compiles**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -3`
+Expected: build succeeds; no use of `m_byDevice` yet so nothing breaks.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/ProfileEngine.h
+git commit -m "refactor(profile): add DeviceProfileContext struct skeleton
+
+First step in migrating ProfileEngine away from its hidden single-device
+context. Follow-up commits populate the new API, migrate call sites,
+and wire the selection handler."
+```
+
+### Task 1.2: Implement the `ctx()` helper and `registerDevice`
+
+**Files:**
+- Modify: `src/core/ProfileEngine.h`, `src/core/ProfileEngine.cpp`
+
+- [ ] **Step 1: Declare `registerDevice` and `hasDevice` in the header**
+
+Open `src/core/ProfileEngine.h`. In the `public:` section, immediately above the `// --- Profile cache (Task 1) ---` comment (around line 55), add:
+
+```cpp
+    // Per-device context management
+    void registerDevice(const QString &serial, const QString &configDir);
+    bool hasDevice(const QString &serial) const;
+```
+
+- [ ] **Step 2: Implement `ctx()` and `registerDevice` in the .cpp**
+
+Open `src/core/ProfileEngine.cpp`. Append the following after the existing `appBindingsPath()` method (near end of file, around line 345):
+
+```cpp
+// ---------------------------------------------------------------------------
+// Per-device contexts
+// ---------------------------------------------------------------------------
+
+DeviceProfileContext& ProfileEngine::ctx(const QString &serial)
+{
+    if (!m_byDevice.contains(serial)) {
+        qCWarning(lcProfile)
+            << "ProfileEngine: lazy-registering unknown device" << serial;
+        const QString defaultDir = QStandardPaths::writableLocation(
+            QStandardPaths::AppConfigLocation)
+            + "/devices/" + serial + "/profiles";
+        registerDevice(serial, defaultDir);
+    }
+    return m_byDevice[serial];
+}
+
+const DeviceProfileContext& ProfileEngine::ctx(const QString &serial) const
+{
+    // Const variant: if absent, return a shared empty sentinel. Callers on
+    // the const path are read-only and should tolerate empty contexts for
+    // unknown serials.
+    static const DeviceProfileContext empty{};
+    auto it = m_byDevice.constFind(serial);
+    if (it == m_byDevice.constEnd())
+        return empty;
+    return *it;
+}
+
+void ProfileEngine::registerDevice(const QString &serial, const QString &configDir)
+{
+    DeviceProfileContext &c = m_byDevice[serial];
+    c.configDir = configDir;
+    c.cache.clear();
+    c.appBindings.clear();
+
+    QDir d(configDir);
+    if (!d.exists())
+        QDir().mkpath(configDir);
+
+    if (d.exists()) {
+        for (const auto &f : d.entryList({"*.conf"}, QDir::Files)) {
+            if (f == "app-bindings.conf") continue;
+            QString name = QFileInfo(f).baseName();
+            c.cache[name] = loadProfile(d.filePath(f));
+        }
+    }
+
+    const QString bindingsFile = configDir + "/app-bindings.conf";
+    if (QFileInfo::exists(bindingsFile))
+        c.appBindings = loadAppBindings(bindingsFile);
+}
+
+bool ProfileEngine::hasDevice(const QString &serial) const
+{
+    return m_byDevice.contains(serial);
+}
+```
+
+Also add `#include <QStandardPaths>` near the top of the file if it is not already present (check with `grep QStandardPaths src/core/ProfileEngine.cpp` — the existing file does not include it yet; add it alongside the other `#include <Q...>` lines).
+
+- [ ] **Step 3: Build and run existing tests**
+
+Run: `cmake --build build -j$(nproc) && QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests 2>&1 | tail -3`
+Expected: 565 tests pass, no regressions (the new methods have no callers yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/ProfileEngine.h src/core/ProfileEngine.cpp
+git commit -m "refactor(profile): add registerDevice and ctx() helpers
+
+Lazy-register fallback emits qCWarning so accidental orderings during
+device add are visible in logs; real call sites in commit 2 will
+always register explicitly from onPhysicalDeviceAdded."
+```
+
+### Task 1.3: Add serial-aware read methods
+
+**Files:**
+- Modify: `src/core/ProfileEngine.h`, `src/core/ProfileEngine.cpp`
+
+- [ ] **Step 1: Declare serial-aware read methods in the header**
+
+In `ProfileEngine.h`, within the `public:` section, after `bool hasDevice(...)` from the previous task, add:
+
+```cpp
+    // Read methods (serial-aware)
+    Profile& cachedProfile(const QString &serial, const QString &name);
+    QStringList profileNames(const QString &serial) const;
+    QString displayProfile(const QString &serial) const;
+    QString hardwareProfile(const QString &serial) const;
+    QString profileForApp(const QString &serial, const QString &wmClass) const;
+```
+
+The existing single-arg variants stay for now — they become thin wrappers in Task 1.5.
+
+- [ ] **Step 2: Implement the read methods in the .cpp**
+
+In `ProfileEngine.cpp`, append after `registerDevice` from the previous task:
+
+```cpp
+Profile& ProfileEngine::cachedProfile(const QString &serial, const QString &name)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (!c.cache.contains(name)) {
+        c.cache[name] = Profile{};
+        c.cache[name].name = name;
+    }
+    return c.cache[name];
+}
+
+QStringList ProfileEngine::profileNames(const QString &serial) const
+{
+    const DeviceProfileContext &c = ctx(serial);
+    if (c.configDir.isEmpty())
+        return {};
+    QDir dir(c.configDir);
+    const QStringList files = dir.entryList({"*.conf"}, QDir::Files);
+    QStringList names;
+    names.reserve(files.size());
+    for (const QString &f : files) {
+        const QString base = QFileInfo(f).baseName();
+        if (base != QLatin1String("app-bindings"))
+            names << base;
+    }
+    return names;
+}
+
+QString ProfileEngine::displayProfile(const QString &serial) const
+{
+    return ctx(serial).displayProfile;
+}
+
+QString ProfileEngine::hardwareProfile(const QString &serial) const
+{
+    return ctx(serial).hardwareProfile;
+}
+
+QString ProfileEngine::profileForApp(const QString &serial, const QString &wmClass) const
+{
+    const DeviceProfileContext &c = ctx(serial);
+    for (auto it = c.appBindings.cbegin(); it != c.appBindings.cend(); ++it) {
+        if (it.key().compare(wmClass, Qt::CaseInsensitive) == 0)
+            return it.value();
+    }
+    return QStringLiteral("default");
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -3`
+Expected: builds clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/ProfileEngine.h src/core/ProfileEngine.cpp
+git commit -m "refactor(profile): add serial-aware read methods
+
+cachedProfile, profileNames, displayProfile, hardwareProfile,
+profileForApp now accept a device serial. Existing single-arg
+variants still work; they become thin wrappers over the serial
+variants in a follow-up commit."
+```
+
+### Task 1.4: Add serial-aware write methods and serial-bearing signals
+
+**Files:**
+- Modify: `src/core/ProfileEngine.h`, `src/core/ProfileEngine.cpp`
+
+- [ ] **Step 1: Declare serial-aware write methods and new signals**
+
+In `ProfileEngine.h`, after the serial-aware read declarations, add:
+
+```cpp
+    // Write methods (serial-aware)
+    void setDisplayProfile(const QString &serial, const QString &name);
+    void setHardwareProfile(const QString &serial, const QString &name);
+    void saveProfileToDisk(const QString &serial, const QString &name);
+    void createProfileForApp(const QString &serial,
+                             const QString &wmClass,
+                             const QString &profileName);
+    void removeAppProfile(const QString &serial, const QString &wmClass);
+```
+
+In the `signals:` section, immediately after the existing `hardwareProfileChanged(const Profile &)` signal (around line 66), add:
+
+```cpp
+    // Per-device variants. Both legacy and new signals fire during commit 1;
+    // the legacy ones are removed in commit 2.
+    void deviceDisplayProfileChanged(const QString &serial, const Profile &profile);
+    void deviceHardwareProfileChanged(const QString &serial, const Profile &profile);
+```
+
+- [ ] **Step 2: Implement the write methods in the .cpp**
+
+Append to `ProfileEngine.cpp` after the read implementations:
+
+```cpp
+void ProfileEngine::setDisplayProfile(const QString &serial, const QString &name)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (c.displayProfile == name) return;
+    c.displayProfile = name;
+    emit deviceDisplayProfileChanged(serial, cachedProfile(serial, name));
+    if (serial == QLatin1String(kLegacySerial))
+        emit displayProfileChanged(cachedProfile(serial, name));
+}
+
+void ProfileEngine::setHardwareProfile(const QString &serial, const QString &name)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (c.hardwareProfile == name) return;
+    c.hardwareProfile = name;
+    emit deviceHardwareProfileChanged(serial, cachedProfile(serial, name));
+    if (serial == QLatin1String(kLegacySerial))
+        emit hardwareProfileChanged(cachedProfile(serial, name));
+}
+
+void ProfileEngine::saveProfileToDisk(const QString &serial, const QString &name)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (!c.cache.contains(name) || c.configDir.isEmpty()) return;
+    saveProfile(c.configDir + "/" + name + ".conf", c.cache[name]);
+}
+
+void ProfileEngine::createProfileForApp(const QString &serial,
+                                        const QString &wmClass,
+                                        const QString &profileName)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (c.configDir.isEmpty() || wmClass.isEmpty() || profileName.isEmpty())
+        return;
+    if (!c.cache.contains(profileName)) {
+        c.cache[profileName] = c.cache.value(QStringLiteral("default"));
+        c.cache[profileName].name = profileName;
+        saveProfile(c.configDir + "/" + profileName + ".conf",
+                    c.cache[profileName]);
+    }
+    c.appBindings[wmClass] = profileName;
+    saveAppBindings(c.configDir + "/app-bindings.conf", c.appBindings);
+}
+
+void ProfileEngine::removeAppProfile(const QString &serial, const QString &wmClass)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (c.configDir.isEmpty() || wmClass.isEmpty()) return;
+
+    const QString profileName = c.appBindings.value(wmClass);
+    if (profileName.isEmpty()) return;
+
+    QFile::remove(c.configDir + "/" + profileName + ".conf");
+    c.cache.remove(profileName);
+    c.appBindings.remove(wmClass);
+    saveAppBindings(c.configDir + "/app-bindings.conf", c.appBindings);
+
+    if (c.displayProfile == profileName)
+        setDisplayProfile(serial, QStringLiteral("default"));
+    if (c.hardwareProfile == profileName)
+        setHardwareProfile(serial, QStringLiteral("default"));
+
+    qCDebug(lcProfile) << "removed profile" << profileName
+                       << "for app" << wmClass << "on device" << serial;
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -3`
+Expected: builds clean (still no callers of the new API).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/ProfileEngine.h src/core/ProfileEngine.cpp
+git commit -m "refactor(profile): add serial-aware write methods and signals
+
+Emit both the legacy and the new serial-bearing displayProfileChanged /
+hardwareProfileChanged during the migration window. Legacy signal only
+fires for the 'legacy' serial so the existing single-context flow stays
+functional."
+```
+
+### Task 1.5: Make legacy single-arg methods delegate to `"legacy"` serial
+
+**Files:**
+- Modify: `src/core/ProfileEngine.h`, `src/core/ProfileEngine.cpp`
+
+- [ ] **Step 1: Replace `setDeviceConfigDir` body to call `registerDevice`**
+
+In `ProfileEngine.cpp`, replace the existing `setDeviceConfigDir` implementation (lines ~197-215) with:
+
+```cpp
+void ProfileEngine::setDeviceConfigDir(const QString &dir)
+{
+    // Legacy entry point. Route through the per-device API with the
+    // kLegacySerial context so existing callers keep working.
+    registerDevice(QLatin1String(kLegacySerial), dir);
+    m_configDir = dir;  // keep the legacy field in sync for old readers
+}
+```
+
+- [ ] **Step 2: Rewrite the legacy single-arg methods as wrappers**
+
+Replace the existing bodies of `cachedProfile(name)`, `profileNames()`, `displayProfile()`, `hardwareProfile()`, `setDisplayProfile(name)`, `setHardwareProfile(name)`, `saveProfileToDisk(name)`, `createProfileForApp(wmClass, name)`, `removeAppProfile(wmClass)`, and `profileForApp(wmClass)` in `ProfileEngine.cpp` with wrappers that delegate to the serial-taking variant using `kLegacySerial`:
+
+```cpp
+QStringList ProfileEngine::profileNames() const
+{
+    return profileNames(QLatin1String(kLegacySerial));
+}
+
+Profile& ProfileEngine::cachedProfile(const QString &name)
+{
+    return cachedProfile(QLatin1String(kLegacySerial), name);
+}
+
+QString ProfileEngine::displayProfile() const
+{
+    return displayProfile(QLatin1String(kLegacySerial));
+}
+
+QString ProfileEngine::hardwareProfile() const
+{
+    return hardwareProfile(QLatin1String(kLegacySerial));
+}
+
+void ProfileEngine::setDisplayProfile(const QString &name)
+{
+    setDisplayProfile(QLatin1String(kLegacySerial), name);
+}
+
+void ProfileEngine::setHardwareProfile(const QString &name)
+{
+    setHardwareProfile(QLatin1String(kLegacySerial), name);
+}
+
+void ProfileEngine::saveProfileToDisk(const QString &name)
+{
+    saveProfileToDisk(QLatin1String(kLegacySerial), name);
+}
+
+void ProfileEngine::createProfileForApp(const QString &wmClass,
+                                        const QString &profileName)
+{
+    createProfileForApp(QLatin1String(kLegacySerial), wmClass, profileName);
+}
+
+void ProfileEngine::removeAppProfile(const QString &wmClass)
+{
+    removeAppProfile(QLatin1String(kLegacySerial), wmClass);
+}
+
+QString ProfileEngine::profileForApp(const QString &wmClass) const
+{
+    return profileForApp(QLatin1String(kLegacySerial), wmClass);
+}
+```
+
+Delete the old helper `profilePath(const QString &name) const` — its callers are now all gone (the new write methods inline the path construction). Same for `appBindingsPath()`.
+
+- [ ] **Step 3: Remove now-unused private members**
+
+In `ProfileEngine.h` private section, the following fields are now dead:
+- `QString m_configDir;`
+- `QMap<QString, QString> m_appBindings;`
+- `QMap<QString, Profile> m_cache;`
+- `QString m_displayProfile;`
+- `QString m_hardwareProfile;`
+- `QFileSystemWatcher m_fileWatcher;` (was already unused)
+- `bool m_selfWrite = false;` (was already unused)
+- declarations of `profilePath` and `appBindingsPath`
+
+**Keep `m_configDir`** because the legacy wrapper above still touches it for stray readers. Remove the rest.
+
+Final `private:` section should look like:
+
+```cpp
+private:
+    QString m_configDir;  // legacy mirror of kLegacySerial context.configDir
+
+    QHash<QString, DeviceProfileContext> m_byDevice;
+
+    static constexpr const char *kLegacySerial = "legacy";
+
+    DeviceProfileContext& ctx(const QString &serial);
+    const DeviceProfileContext& ctx(const QString &serial) const;
+```
+
+Remove the corresponding `#include <QFileSystemWatcher>` and `#include <QSettings>` if nothing else uses them (they were used by removed code).
+
+- [ ] **Step 4: Build and run the full test suite**
+
+Run: `cmake --build build -j$(nproc) && QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests 2>&1 | tail -3 && QT_QPA_PLATFORM=offscreen ./build/tests/qml/logitune-qml-tests 2>&1 | tail -3`
+Expected: 565/565 core + 72/72 QML pass. The legacy API now routes through per-device contexts, but functional behavior is unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/ProfileEngine.h src/core/ProfileEngine.cpp
+git commit -m "refactor(profile): legacy API now delegates to 'legacy' serial
+
+Single-context methods become thin wrappers over the serial-aware
+variants using a constant 'legacy' serial. Functional behavior is
+preserved; a follow-up commit migrates call sites and removes the
+wrappers entirely."
+```
+
+### Task 1.6: Unit tests for serial-aware ProfileEngine API
+
+**Files:**
+- Modify: `tests/test_profile_engine.cpp`
+
+- [ ] **Step 1: Write the three new ProfileEngine tests**
+
+Append the following to the end of `tests/test_profile_engine.cpp`, before the closing namespace (if any) / end of file:
+
+```cpp
+// --- Per-device contexts ---
+
+TEST(ProfileEngine, MultipleDevicesKeepSeparateCaches) {
+    QTemporaryDir tmpA, tmpB;
+    ASSERT_TRUE(tmpA.isValid());
+    ASSERT_TRUE(tmpB.isValid());
+
+    logitune::ProfileEngine eng;
+    eng.registerDevice(QStringLiteral("A"), tmpA.path());
+    eng.registerDevice(QStringLiteral("B"), tmpB.path());
+
+    auto &pa = eng.cachedProfile(QStringLiteral("A"), QStringLiteral("default"));
+    auto &pb = eng.cachedProfile(QStringLiteral("B"), QStringLiteral("default"));
+
+    pa.dpi = 1234;
+    pb.dpi = 5678;
+
+    EXPECT_EQ(eng.cachedProfile(QStringLiteral("A"),
+                                QStringLiteral("default")).dpi, 1234);
+    EXPECT_EQ(eng.cachedProfile(QStringLiteral("B"),
+                                QStringLiteral("default")).dpi, 5678);
+}
+
+TEST(ProfileEngine, UnknownDeviceLazyRegisters) {
+    logitune::ProfileEngine eng;
+    EXPECT_FALSE(eng.hasDevice(QStringLiteral("ghost")));
+
+    auto &p = eng.cachedProfile(QStringLiteral("ghost"),
+                                QStringLiteral("default"));
+    EXPECT_EQ(p.dpi, 1000);                  // struct default
+    EXPECT_EQ(p.name, QStringLiteral("default"));
+    EXPECT_TRUE(eng.hasDevice(QStringLiteral("ghost")));
+}
+
+TEST(ProfileEngine, SetDisplayProfileScopedToDevice) {
+    QTemporaryDir tmpA, tmpB;
+    ASSERT_TRUE(tmpA.isValid());
+    ASSERT_TRUE(tmpB.isValid());
+
+    logitune::ProfileEngine eng;
+    eng.registerDevice(QStringLiteral("A"), tmpA.path());
+    eng.registerDevice(QStringLiteral("B"), tmpB.path());
+
+    eng.setDisplayProfile(QStringLiteral("A"), QStringLiteral("chrome"));
+
+    EXPECT_EQ(eng.displayProfile(QStringLiteral("A")),
+              QStringLiteral("chrome"));
+    EXPECT_EQ(eng.displayProfile(QStringLiteral("B")), QString());
+}
+```
+
+If `tests/test_profile_engine.cpp` does not already include the required headers, add near the top:
+
+```cpp
+#include "ProfileEngine.h"
+#include <QTemporaryDir>
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `cmake --build build -j$(nproc) && QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests --gtest_filter='ProfileEngine.*' 2>&1 | tail -10`
+Expected: all three new tests pass. (Other existing `ButtonAction.*` tests in the same file continue to pass.)
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests 2>&1 | tail -3`
+Expected: 568/568 pass (3 new tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_profile_engine.cpp
+git commit -m "test(profile): unit tests for per-device contexts
+
+Covers: separate caches per serial, lazy-registration of unknown
+serials, per-device display-profile scoping."
+```
+
+---
+
+## Commit 2: Migrate call sites and remove legacy API
+
+**Goal:** Update every `m_profileEngine.*` call in `AppController` and the `ProfileModel::profileAdded` / `profileRemoved` wiring to pass `selectedDevice()->deviceSerial()`. Rework the test fixture. Delete the legacy wrappers, `setDeviceConfigDir`, and the legacy signals. Existing test suite passes end-to-end with no behavioral change.
+
+### Task 2.1: Add a helper for the selected device's serial
+
+**Files:**
+- Modify: `src/app/AppController.h`, `src/app/AppController.cpp`
+
+- [ ] **Step 1: Declare the helper in the header**
+
+In `src/app/AppController.h`, in the `private:` section near the other small helpers (around line 79), add:
+
+```cpp
+    QString selectedSerial() const;  // PhysicalDevice::deviceSerial() of the selected device, or empty
+```
+
+- [ ] **Step 2: Implement the helper**
+
+In `src/app/AppController.cpp`, append after `selectedSession()` (find its definition with `grep -n "selectedSession" src/app/AppController.cpp`):
+
+```cpp
+QString AppController::selectedSerial() const
+{
+    auto *d = selectedDevice();
+    return d ? d->deviceSerial() : QString();
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -3`
+Expected: builds clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/AppController.h src/app/AppController.cpp
+git commit -m "refactor(app): add selectedSerial() helper
+
+Convenience for upcoming migration of ProfileEngine call sites that
+need the currently-selected device's deviceSerial."
+```
+
+### Task 2.2: Migrate `setupProfileForDevice` to serial-aware API
+
+**Files:**
+- Modify: `src/app/AppController.cpp`
+
+- [ ] **Step 1: Rewrite the body to use `registerDevice` and serial arguments**
+
+In `src/app/AppController.cpp`, locate `setupProfileForDevice` (around line 228). The current body uses `m_profileEngine.setDeviceConfigDir(profilesDir)` and then later calls `setHardwareProfile(hwName)` / `setDisplayProfile(hwName)` / `cachedProfile(hwName)` with no serial.
+
+Replace the function body with the serial-aware version. The full function after the edit:
+
+```cpp
+void AppController::setupProfileForDevice(PhysicalDevice *device)
+{
+    m_currentDevice = device->descriptor();
+
+    const QString serial = device->deviceSerial();
+    const QString configBase = QStandardPaths::writableLocation(
+        QStandardPaths::AppConfigLocation);
+    const QString profilesDir = configBase
+        + QStringLiteral("/devices/") + serial
+        + QStringLiteral("/profiles");
+
+    QDir().mkpath(profilesDir);
+    m_profileEngine.registerDevice(serial, profilesDir);
+    qCDebug(lcApp) << "profile dir:" << profilesDir;
+
+    const QString defaultConf = profilesDir + QStringLiteral("/default.conf");
+    if (!QFile::exists(defaultConf)) {
+        Profile seed;
+        seed.name                = QStringLiteral("Default");
+        seed.dpi                 = device->currentDPI();
+        seed.smartShiftEnabled   = device->smartShiftEnabled();
+        seed.smartShiftThreshold = device->smartShiftThreshold();
+        seed.hiResScroll         = device->scrollHiRes();
+        seed.scrollDirection     = device->scrollInvert()
+            ? QStringLiteral("natural") : QStringLiteral("standard");
+        seed.smoothScrolling     = !device->scrollRatchet();
+        if (m_currentDevice) {
+            const auto controls = m_currentDevice->controls();
+            for (int i = 0;
+                 i < static_cast<int>(controls.size()) &&
+                 i < static_cast<int>(seed.buttons.size()); ++i) {
+                const auto &ctrl = controls[i];
+                if (ctrl.defaultActionType == "gesture-trigger")
+                    seed.buttons[i] = {ButtonAction::GestureTrigger, {}};
+                else if (ctrl.defaultActionType == "smartshift-toggle")
+                    seed.buttons[i] = {ButtonAction::SmartShiftToggle, {}};
+                else if (ctrl.defaultActionType == "dpi-cycle")
+                    seed.buttons[i] = {ButtonAction::DpiCycle, {}};
+            }
+            const auto defaultGestures = m_currentDevice->defaultGestures();
+            for (auto it = defaultGestures.begin();
+                 it != defaultGestures.end(); ++it) {
+                seed.gestures[it.key()] = it.value();
+            }
+        }
+        ProfileEngine::saveProfile(defaultConf, seed);
+        m_profileEngine.registerDevice(serial, profilesDir);  // reload cache
+        qCDebug(lcApp) << "created default profile at" << defaultConf;
+    }
+
+    const QString bindingsFile = profilesDir + QStringLiteral("/app-bindings.conf");
+    if (QFile::exists(bindingsFile)) {
+        const auto bindings = ProfileEngine::loadAppBindings(bindingsFile);
+        QMap<QString, QString> iconLookup;
+        const auto apps = m_desktop->runningApplications();
+        for (const auto &app : apps) {
+            auto map = app.toMap();
+            iconLookup[map[QStringLiteral("wmClass")].toString().toLower()]
+                = map[QStringLiteral("icon")].toString();
+        }
+        for (auto it = bindings.cbegin(); it != bindings.cend(); ++it) {
+            QString icon = iconLookup.value(it.key().toLower());
+            m_profileModel.restoreProfile(it.key(), it.value(), icon);
+        }
+    }
+
+    QString hwName = m_profileEngine.hardwareProfile(serial);
+    bool isFirstConnect = hwName.isEmpty();
+    if (isFirstConnect) {
+        hwName = QStringLiteral("default");
+        m_profileModel.setHwActiveIndex(0);
+        m_profileEngine.setHardwareProfile(serial, hwName);
+        m_profileEngine.setDisplayProfile(serial, hwName);
+    }
+
+    Profile &p = m_profileEngine.cachedProfile(serial, hwName);
+    qCDebug(lcApp) << "setupProfileForDevice: applying profile" << hwName
+                   << "thumbWheelMode=" << p.thumbWheelMode;
+    applyProfileToHardware(p);
+}
+```
+
+- [ ] **Step 2: Build and run tests**
+
+Run: `cmake --build build -j$(nproc) && QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests 2>&1 | tail -3`
+Expected: 568/568 pass. The rewritten function still uses `deviceSerial` on PhysicalDevice, which is stable.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/AppController.cpp
+git commit -m "refactor(app): setupProfileForDevice uses serial-aware ProfileEngine
+
+Calls registerDevice instead of setDeviceConfigDir and passes the
+device serial to setHardwareProfile, setDisplayProfile, cachedProfile,
+and hardwareProfile. Behavior unchanged."
+```
+
+### Task 2.3: Migrate the remaining `AppController` call sites
+
+**Files:**
+- Modify: `src/app/AppController.cpp`
+
+- [ ] **Step 1: Update `onPhysicalDeviceAdded`'s transport-setup lambda**
+
+Find the lambda connected to `PhysicalDevice::transportSetupComplete` (around line 196). The current body reads:
+
+```cpp
+m_currentDevice = device->descriptor();
+Profile &p = m_profileEngine.cachedProfile(m_profileEngine.hardwareProfile());
+qCDebug(lcApp) << "device transport ready, applying profile:"
+                << m_profileEngine.hardwareProfile();
+applyProfileToHardware(p);
+```
+
+Replace with:
+
+```cpp
+m_currentDevice = device->descriptor();
+const QString serial = device->deviceSerial();
+Profile &p = m_profileEngine.cachedProfile(serial,
+                                           m_profileEngine.hardwareProfile(serial));
+qCDebug(lcApp) << "device transport ready, applying profile:"
+                << m_profileEngine.hardwareProfile(serial);
+applyProfileToHardware(p);
+```
+
+- [ ] **Step 2: Update `onUserButtonChanged`**
+
+Find the line `if (m_profileEngine.displayProfile() != m_profileEngine.hardwareProfile())` (around line 325) and replace with:
+
+```cpp
+const QString serial = selectedSerial();
+if (serial.isEmpty()) return;
+if (m_profileEngine.displayProfile(serial) != m_profileEngine.hardwareProfile(serial))
+    return;
+```
+
+- [ ] **Step 3: Update `onTabSwitched`**
+
+Find the body of `onTabSwitched` (around line 345). Replace:
+
+```cpp
+void AppController::onTabSwitched(const QString &profileName)
+{
+    m_profileEngine.setDisplayProfile(profileName);
+}
+```
+
+with:
+
+```cpp
+void AppController::onTabSwitched(const QString &profileName)
+{
+    const QString serial = selectedSerial();
+    if (serial.isEmpty()) return;
+    m_profileEngine.setDisplayProfile(serial, profileName);
+}
+```
+
+- [ ] **Step 4: Update `onWindowFocusChanged`**
+
+Find the block that reads `QString profileName = m_profileEngine.profileForApp(wmClass);` (around line 381). Replace the full block (through `applyProfileToHardware(p);`) with:
+
+```cpp
+const QString serial = selectedSerial();
+if (serial.isEmpty()) return;
+
+QString profileName = m_profileEngine.profileForApp(serial, wmClass);
+if (profileName == m_profileEngine.hardwareProfile(serial))
+    return;
+
+Profile &p = m_profileEngine.cachedProfile(serial, profileName);
+m_profileEngine.setHardwareProfile(serial, profileName);
+applyProfileToHardware(p);
+m_profileModel.setHwActiveByProfileName(profileName);
+```
+
+- [ ] **Step 5: Update `saveCurrentProfile`**
+
+Find the function body (around line 514). Replace the entire function with:
+
+```cpp
+void AppController::saveCurrentProfile()
+{
+    const QString serial = selectedSerial();
+    if (serial.isEmpty()) return;
+
+    const QString name = m_profileEngine.displayProfile(serial);
+    if (name.isEmpty()) return;
+
+    Profile &p = m_profileEngine.cachedProfile(serial, name);
+    if (p.name.isEmpty()) p.name = name;
+
+    if (m_currentDevice) {
+        const auto controls = m_currentDevice->controls();
+        for (int i = 0; i < static_cast<int>(controls.size()); ++i) {
+            if (controls[i].controlId == 0) continue;
+            if (static_cast<std::size_t>(i) < p.buttons.size())
+                p.buttons[static_cast<std::size_t>(i)] = buttonEntryToAction(
+                    m_buttonModel.actionTypeForButton(i),
+                    m_buttonModel.actionNameForButton(i));
+        }
+    }
+
+    for (const auto &dir : {"up", "down", "left", "right", "click"}) {
+        QString ks = m_deviceModel.gestureKeystroke(dir);
+        if (!ks.isEmpty())
+            p.gestures[dir] = {ButtonAction::Keystroke, ks};
+    }
+
+    m_profileEngine.saveProfileToDisk(serial, name);
+}
+```
+
+- [ ] **Step 6: Update the six `onXxxChangeRequested` handlers**
+
+There are six handlers, all structured identically: `onDpiChangeRequested`, `onSmartShiftChangeRequested`, `onScrollConfigChangeRequested`, `onThumbWheelModeChangeRequested`, `onThumbWheelInvertChangeRequested`, and (if present) `applyProfileToHardware` helpers. Each starts with the pattern:
+
+```cpp
+QString name = m_profileEngine.displayProfile();
+if (name.isEmpty()) return;
+Profile &p = m_profileEngine.cachedProfile(name);
+// ... modifies p
+m_profileEngine.saveProfileToDisk(name);
+if (name == m_profileEngine.hardwareProfile()) {
+    // ... apply to hardware
+}
+```
+
+In each handler, change the opening to:
+
+```cpp
+const QString serial = selectedSerial();
+if (serial.isEmpty()) return;
+const QString name = m_profileEngine.displayProfile(serial);
+if (name.isEmpty()) return;
+Profile &p = m_profileEngine.cachedProfile(serial, name);
+```
+
+And the final lines to:
+
+```cpp
+m_profileEngine.saveProfileToDisk(serial, name);
+if (name == m_profileEngine.hardwareProfile(serial)) {
+    // ... apply to hardware (body unchanged)
+}
+```
+
+Apply this mechanical edit in all six handlers. Find them with:
+
+```bash
+grep -nE "^(void AppController::on(Dpi|SmartShift|ScrollConfig|ThumbWheelMode|ThumbWheelInvert))" src/app/AppController.cpp
+```
+
+- [ ] **Step 7: Update `onDivertedButtonPressed`**
+
+Find `const Profile &hwProfile = m_profileEngine.cachedProfile(m_profileEngine.hardwareProfile());` (around line 638). Replace with:
+
+```cpp
+const QString serial = selectedSerial();
+if (serial.isEmpty()) return;
+const Profile &hwProfile = m_profileEngine.cachedProfile(
+    serial, m_profileEngine.hardwareProfile(serial));
+```
+
+- [ ] **Step 8: Re-wire `ProfileModel::profileAdded` and `profileRemoved` through lambdas**
+
+In `wireSignals` (around lines 137-140), replace:
+
+```cpp
+connect(&m_profileModel, &ProfileModel::profileAdded,
+        &m_profileEngine, &ProfileEngine::createProfileForApp);
+connect(&m_profileModel, &ProfileModel::profileRemoved,
+        &m_profileEngine, &ProfileEngine::removeAppProfile);
+```
+
+with:
+
+```cpp
+connect(&m_profileModel, &ProfileModel::profileAdded, this,
+        [this](const QString &wmClass, const QString &profileName) {
+    const QString serial = selectedSerial();
+    if (!serial.isEmpty())
+        m_profileEngine.createProfileForApp(serial, wmClass, profileName);
+});
+connect(&m_profileModel, &ProfileModel::profileRemoved, this,
+        [this](const QString &wmClass) {
+    const QString serial = selectedSerial();
+    if (!serial.isEmpty())
+        m_profileEngine.removeAppProfile(serial, wmClass);
+});
+```
+
+- [ ] **Step 9: Build and run tests**
+
+Run: `cmake --build build -j$(nproc) && QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests 2>&1 | tail -3`
+
+Expected: the fixture-based tests may now fail because the fixture still uses the legacy API. That's expected and fixed in Task 2.4. If there are compile errors, they point to call sites this task missed — fix them the same way (add `serial` as the first argument) and re-run.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/app/AppController.cpp src/app/AppController.h
+git commit -m "refactor(app): migrate AppController to serial-aware ProfileEngine
+
+Routes every cachedProfile / displayProfile / hardwareProfile /
+setDisplayProfile / setHardwareProfile / saveProfileToDisk /
+profileForApp call through selectedSerial(). ProfileModel signals are
+now mediated by AppController lambdas so they can inject the serial.
+
+Legacy single-context ProfileEngine wrappers are untouched and may
+still be called by fixtures; they are removed after the fixture
+rework in the next commit."
+```
+
+### Task 2.4: Rework `AppControllerFixture` to use the new API
+
+**Files:**
+- Modify: `tests/helpers/AppControllerFixture.h`
+
+- [ ] **Step 1: Replace the fixture SetUp body**
+
+In `tests/helpers/AppControllerFixture.h`, locate the `SetUp()` method (around line 23). Replace the block from line 47 (`m_ctrl->m_profileEngine.setDeviceConfigDir(m_profilesDir);`) through line 70 (`m_ctrl->m_profileEngine.setHardwareProfile(QStringLiteral("default"));`) with:
+
+```cpp
+        const QString kSerial = QStringLiteral("mock-serial");
+
+        // Pre-register the mock device with the fixture's temp profile dir
+        // BEFORE onPhysicalDeviceAdded runs. setupProfileForDevice would
+        // otherwise point the engine at AppConfigLocation, bypassing the
+        // temp dir the fixture wrote default.conf into.
+        m_ctrl->m_profileEngine.registerDevice(kSerial, m_profilesDir);
+
+        m_device.setupMxControls();
+
+        // Create a mock DeviceSession wrapped in a PhysicalDevice. Mark
+        // the session connected so DeviceModel shows its row.
+        auto mockHidraw = std::make_unique<hidpp::HidrawDevice>("/dev/null");
+        m_session = new DeviceSession(std::move(mockHidraw), 0xFF, "Bluetooth",
+                                       nullptr, m_ctrl.get());
+        m_session->m_connected = true;
+        m_session->m_deviceName = QStringLiteral("Mock Device");
+
+        m_physicalDevice = new PhysicalDevice(kSerial, m_ctrl.get());
+        m_physicalDevice->attachTransport(m_session);
+
+        // Drive through the normal device-added flow. This sets
+        // m_currentDevice, registers the device again (idempotent), and
+        // sets displayProfile + hardwareProfile to "default" which
+        // triggers onDisplayProfileChanged -> the UI is populated from
+        // the already-loaded cached profile.
+        m_ctrl->onPhysicalDeviceAdded(m_physicalDevice);
+```
+
+Also remove the line `m_ctrl->m_profileEngine.setDeviceConfigDir(m_profilesDir);` from earlier in SetUp if it survives.
+
+- [ ] **Step 2: Update fixture helpers to pass serial internally**
+
+The helpers `createAppProfile`, `setProfileButton`, and `setProfileGesture` all currently operate on the legacy single-context engine. Update each to use `kSerial`:
+
+In `createAppProfile` (the first overload, around line 86), change:
+
+```cpp
+Profile p = m_ctrl->m_profileEngine.cachedProfile(QStringLiteral("default"));
+// ...
+m_ctrl->m_profileEngine.createProfileForApp(wmClass, profileName);
+```
+
+to:
+
+```cpp
+const QString kSerial = QStringLiteral("mock-serial");
+Profile p = m_ctrl->m_profileEngine.cachedProfile(
+    kSerial, QStringLiteral("default"));
+// ...
+m_ctrl->m_profileEngine.createProfileForApp(kSerial, wmClass, profileName);
+```
+
+Apply the same pattern to the second `createAppProfile` overload and to `setProfileButton`, `setProfileGesture`. In each helper, the first line of the body should define `const QString kSerial = QStringLiteral("mock-serial");` and every `m_profileEngine.*` call gains `kSerial` as its first argument.
+
+- [ ] **Step 3: Build and run tests**
+
+Run: `cmake --build build -j$(nproc) && QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests 2>&1 | tail -3`
+
+Expected: 568/568 pass. Any compile error points to a fixture helper still using the legacy API.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/helpers/AppControllerFixture.h
+git commit -m "test(fixture): AppControllerFixture uses serial-aware ProfileEngine
+
+Fixture registers the mock device with the engine explicitly, then
+drives onPhysicalDeviceAdded to go through the same flow production
+uses. Replaces the previous direct m_currentDevice assignment and
+setDeviceConfigDir call.
+
+Helper methods now pass 'mock-serial' into the engine internally so
+existing test call sites are unchanged."
+```
+
+### Task 2.5: Migrate `onDisplayProfileChanged` to the serial-bearing signal
+
+**Files:**
+- Modify: `src/app/AppController.h`, `src/app/AppController.cpp`
+
+- [ ] **Step 1: Update the slot signature in the header**
+
+In `src/app/AppController.h`, find `void onDisplayProfileChanged(const Profile &profile);` (around line 60). Replace with:
+
+```cpp
+    void onDisplayProfileChanged(const QString &serial, const Profile &profile);
+```
+
+- [ ] **Step 2: Update the slot implementation**
+
+In `AppController.cpp`, find `void AppController::onDisplayProfileChanged(const Profile &profile)` (around line 382). Replace with:
+
+```cpp
+void AppController::onDisplayProfileChanged(const QString &serial, const Profile &profile)
+{
+    if (serial != selectedSerial())
+        return;
+
+    m_deviceModel.setActiveProfileName(profile.name);
+
+    m_deviceModel.setDisplayValues(
+        profile.dpi, profile.smartShiftEnabled, profile.smartShiftThreshold,
+        profile.hiResScroll, profile.scrollDirection == "natural",
+        profile.thumbWheelMode, profile.thumbWheelInvert);
+
+    restoreButtonModelFromProfile(profile);
+}
+```
+
+- [ ] **Step 3: Update the wiring to connect the new signal**
+
+In `AppController::wireSignals` (around line 121), find:
+
+```cpp
+connect(&m_profileEngine, &ProfileEngine::displayProfileChanged,
+        this, &AppController::onDisplayProfileChanged);
+```
+
+Replace with:
+
+```cpp
+connect(&m_profileEngine, &ProfileEngine::deviceDisplayProfileChanged,
+        this, &AppController::onDisplayProfileChanged);
+```
+
+- [ ] **Step 4: Build and run tests**
+
+Run: `cmake --build build -j$(nproc) && QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests 2>&1 | tail -3`
+Expected: 568/568 pass. The filter is now active but there's only one device in the fixture, so `serial != selectedSerial()` never triggers.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/AppController.h src/app/AppController.cpp
+git commit -m "refactor(app): onDisplayProfileChanged subscribes to per-device signal
+
+Uses deviceDisplayProfileChanged which carries the source device
+serial, and filters out changes for non-selected devices. Legacy
+displayProfileChanged signal is no longer consumed and is removed
+in the next commit."
+```
+
+### Task 2.6: Delete legacy single-context API and signals
+
+**Files:**
+- Modify: `src/core/ProfileEngine.h`, `src/core/ProfileEngine.cpp`
+
+- [ ] **Step 1: Delete the legacy signal declarations**
+
+In `ProfileEngine.h`, delete the two legacy signals:
+
+```cpp
+    void displayProfileChanged(const Profile &profile);       // DELETE
+    void hardwareProfileChanged(const Profile &profile);      // DELETE
+```
+
+The `deviceDisplayProfileChanged` / `deviceHardwareProfileChanged` signals remain.
+
+- [ ] **Step 2: Delete the legacy single-arg method declarations**
+
+In `ProfileEngine.h`, delete these method declarations (all from the migration-era wrappers):
+
+```cpp
+    void setDeviceConfigDir(const QString &dir);
+    QStringList profileNames() const;
+    void createProfileForApp(const QString &wmClass, const QString &profileName);
+    void removeAppProfile(const QString &wmClass);
+    Profile& cachedProfile(const QString &name);
+    QString displayProfile() const;
+    QString hardwareProfile() const;
+    void setDisplayProfile(const QString &name);
+    void setHardwareProfile(const QString &name);
+    void saveProfileToDisk(const QString &name);
+    QString profileForApp(const QString &wmClass) const;
+```
+
+- [ ] **Step 3: Delete the corresponding implementations in the .cpp**
+
+In `ProfileEngine.cpp`, delete the implementation bodies of all eleven methods listed above. Also delete the `m_configDir` field and any remaining `kLegacySerial`-emitting branch in `setDisplayProfile(serial, name)` / `setHardwareProfile(serial, name)` — the conditional legacy signal emission goes away with the legacy signals.
+
+Final bodies of `setDisplayProfile` and `setHardwareProfile` after this task:
+
+```cpp
+void ProfileEngine::setDisplayProfile(const QString &serial, const QString &name)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (c.displayProfile == name) return;
+    c.displayProfile = name;
+    emit deviceDisplayProfileChanged(serial, cachedProfile(serial, name));
+}
+
+void ProfileEngine::setHardwareProfile(const QString &serial, const QString &name)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (c.hardwareProfile == name) return;
+    c.hardwareProfile = name;
+    emit deviceHardwareProfileChanged(serial, cachedProfile(serial, name));
+}
+```
+
+Also remove the `m_configDir` line from the private section and from the constructor / `setDeviceConfigDir` body (both of which are now deleted).
+
+Remove the `kLegacySerial` constant if no code references it anymore.
+
+- [ ] **Step 4: Build and run the full suite**
+
+Run: `cmake --build build -j$(nproc) && QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests 2>&1 | tail -3 && QT_QPA_PLATFORM=offscreen ./build/tests/qml/logitune-qml-tests 2>&1 | tail -3`
+Expected: 568/568 core + 72/72 QML. Any compile error points to a call site still using the legacy API; fix it to use `selectedSerial()` or the fixture's `kSerial`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/ProfileEngine.h src/core/ProfileEngine.cpp
+git commit -m "refactor(profile): remove legacy single-context API and signals
+
+ProfileEngine is now exclusively serial-aware. setDeviceConfigDir is
+replaced by registerDevice; displayProfileChanged(Profile) is replaced
+by deviceDisplayProfileChanged(serial, Profile); same for the
+hardware variant.
+
+All call sites migrated in the previous commits; this one drops the
+scaffolding."
+```
+
+---
+
+## Commit 3: Wire the selection handler and add integration tests
+
+**Goal:** `DeviceModel::selectedChanged` now updates the UI from the newly-selected device's cached profile. Add the six tests from the spec.
+
+### Task 3.1: Add `onSelectedDeviceChanged` slot
+
+**Files:**
+- Modify: `src/app/AppController.h`, `src/app/AppController.cpp`
+
+- [ ] **Step 1: Declare the slot in the header**
+
+In `src/app/AppController.h`, add to the `private slots:` section (after the existing slots, around line 70):
+
+```cpp
+    void onSelectedDeviceChanged();
+```
+
+- [ ] **Step 2: Implement the slot**
+
+In `AppController.cpp`, insert after `onPhysicalDeviceRemoved` (around line 225):
+
+```cpp
+// Carousel selection changed. Refresh the UI from the newly-selected
+// device's cached profile. No file I/O, no seeding, no hardware apply —
+// one-time device provisioning happens in onPhysicalDeviceAdded.
+void AppController::onSelectedDeviceChanged()
+{
+    auto *device = selectedDevice();
+    if (!device) return;
+
+    m_currentDevice = device->descriptor();
+
+    const QString serial = device->deviceSerial();
+    const QString name = m_profileEngine.displayProfile(serial);
+    if (name.isEmpty()) return;  // device not yet fully set up
+
+    const Profile &p = m_profileEngine.cachedProfile(serial, name);
+    restoreButtonModelFromProfile(p);
+    pushDisplayValues(p);
+}
+```
+
+- [ ] **Step 3: Wire the slot in `wireSignals`**
+
+In `AppController::wireSignals`, immediately after the `deviceDisplayProfileChanged` connection, add:
+
+```cpp
+connect(&m_deviceModel, &DeviceModel::selectedChanged,
+        this, &AppController::onSelectedDeviceChanged);
+```
+
+- [ ] **Step 4: Build and run the full suite**
+
+Run: `cmake --build build -j$(nproc) && QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests 2>&1 | tail -3`
+Expected: 568/568 pass. Fixture flow: `onPhysicalDeviceAdded` calls `m_deviceModel.addPhysicalDevice` which auto-selects and fires `selectedChanged`; the new handler runs, reads the just-registered profile, and pushes it to `ButtonModel` + `DeviceModel`. Functional result matches the previous behavior where `onDisplayProfileChanged` did the push via `setDisplayProfile("default")`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/AppController.h src/app/AppController.cpp
+git commit -m "feat(app): refresh UI on carousel device selection change
+
+New onSelectedDeviceChanged slot reads the selected device's cached
+display profile and pushes it to ButtonModel + DeviceModel display
+values. No file I/O or hardware apply — pure read-and-refresh,
+idempotent over selection state.
+
+Fixes the case where switching devices in the carousel (either in
+--simulate-all or with multiple real devices connected) left the UI
+showing the first-seeded device's profile data."
+```
+
+### Task 3.2: Add `addMockDevice` helper to the fixture
+
+**Files:**
+- Modify: `tests/helpers/AppControllerFixture.h`
+
+- [ ] **Step 1: Declare and implement the helper**
+
+In `tests/helpers/AppControllerFixture.h`, add the following member function in the `protected:` section after the existing helpers (e.g., after `thumbWheel`, around line 184):
+
+```cpp
+    // Add a second mock device and register it through the normal flow.
+    // Returns the new PhysicalDevice for test-level manipulation.
+    PhysicalDevice* addMockDevice(const QString &serialSuffix,
+                                  int seedDpi = 1000) {
+        const QString serial = QStringLiteral("mock-serial-") + serialSuffix;
+        const QString devProfilesDir = m_tmpDir.path()
+            + "/" + serial + "/profiles";
+        QDir().mkpath(devProfilesDir);
+
+        Profile seed;
+        seed.name = QStringLiteral("Default");
+        seed.dpi  = seedDpi;
+        ProfileEngine::saveProfile(
+            devProfilesDir + "/default.conf", seed);
+
+        m_ctrl->m_profileEngine.registerDevice(serial, devProfilesDir);
+
+        auto mockHidraw = std::make_unique<hidpp::HidrawDevice>("/dev/null");
+        auto *session = new DeviceSession(std::move(mockHidraw), 0xFF,
+                                          "Bluetooth", nullptr, m_ctrl.get());
+        session->m_connected = true;
+        session->m_deviceName = QStringLiteral("Mock Device ") + serialSuffix;
+
+        auto *device = new PhysicalDevice(serial, m_ctrl.get());
+        device->attachTransport(session);
+
+        m_ctrl->onPhysicalDeviceAdded(device);
+        return device;
+    }
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cmake --build build -j$(nproc) 2>&1 | tail -3`
+Expected: builds clean; no tests use the helper yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/helpers/AppControllerFixture.h
+git commit -m "test(fixture): addMockDevice helper for multi-device tests
+
+Creates a second PhysicalDevice with an isolated profile dir under
+the fixture's temp root, seeds a default.conf with the given DPI,
+and drives it through onPhysicalDeviceAdded. Returns the pointer so
+tests can manipulate per-device state."
+```
+
+### Task 3.3: Integration test — carousel switch swaps ButtonModel
+
+**Files:**
+- Modify: `tests/test_app_controller.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_app_controller.cpp`:
+
+```cpp
+TEST_F(AppControllerFixture, CarouselSwitchSwapsButtonModel) {
+    // The existing fixture sets up device "mock-serial" with a default
+    // profile. Set its button 3 action explicitly.
+    setProfileButton("default", 3,
+                     {ButtonAction::Keystroke, QStringLiteral("Alt+Left")});
+    // Force the UI to reflect it.
+    m_ctrl->m_deviceModel.setSelectedIndex(0);
+
+    // Add a second device with a DIFFERENT button 3 action on disk.
+    auto *secondary = addMockDevice(QStringLiteral("B"));
+    {
+        const QString serialB = QStringLiteral("mock-serial-B");
+        Profile &pB = m_ctrl->m_profileEngine.cachedProfile(
+            serialB, QStringLiteral("default"));
+        pB.buttons[3] = {ButtonAction::Media, QStringLiteral("Play")};
+        m_ctrl->m_profileEngine.saveProfileToDisk(
+            serialB, QStringLiteral("default"));
+    }
+
+    // Sanity: ButtonModel currently reflects the first device.
+    EXPECT_EQ(buttonModel().actionTypeForButton(3),
+              QStringLiteral("keystroke"));
+
+    // Switch carousel to the second device.
+    const int idxB = m_ctrl->m_deviceModel.devices().indexOf(secondary);
+    ASSERT_GE(idxB, 0);
+    m_ctrl->m_deviceModel.setSelectedIndex(idxB);
+
+    // ButtonModel now reflects the second device.
+    EXPECT_EQ(buttonModel().actionTypeForButton(3),
+              QStringLiteral("media-controls"));
+}
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `cmake --build build -j$(nproc) && QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests --gtest_filter='AppControllerFixture.CarouselSwitchSwapsButtonModel' 2>&1 | tail -10`
+Expected: PASS. (The selection handler from Task 3.1 is already in place.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_app_controller.cpp
+git commit -m "test(app): carousel switch swaps ButtonModel data
+
+Covers issue #77: two mock devices with different button 3 actions;
+setSelectedIndex pivots ButtonModel from device A's action to
+device B's."
+```
+
+### Task 3.4: Integration test — carousel switch swaps display values
+
+**Files:**
+- Modify: `tests/test_app_controller.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_app_controller.cpp`:
+
+```cpp
+TEST_F(AppControllerFixture, CarouselSwitchSwapsDisplayValues) {
+    // Fixture device has DPI 1000 (seeded in SetUp).
+    m_ctrl->m_deviceModel.setSelectedIndex(0);
+    EXPECT_EQ(deviceModel().currentDPI(), 1000);
+
+    auto *secondary = addMockDevice(QStringLiteral("B"), /*seedDpi=*/2500);
+
+    const int idxB = m_ctrl->m_deviceModel.devices().indexOf(secondary);
+    ASSERT_GE(idxB, 0);
+    m_ctrl->m_deviceModel.setSelectedIndex(idxB);
+
+    EXPECT_EQ(deviceModel().currentDPI(), 2500);
+
+    m_ctrl->m_deviceModel.setSelectedIndex(0);
+    EXPECT_EQ(deviceModel().currentDPI(), 1000);
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests --gtest_filter='AppControllerFixture.CarouselSwitchSwapsDisplayValues' 2>&1 | tail -10`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_app_controller.cpp
+git commit -m "test(app): carousel switch swaps DeviceModel display values
+
+Two devices with different seed DPIs. setSelectedIndex pivots the
+DeviceModel's currentDPI between the two values in both directions."
+```
+
+### Task 3.5: Integration test — display profile change ignored for non-selected device
+
+**Files:**
+- Modify: `tests/test_app_controller.cpp`
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/test_app_controller.cpp`:
+
+```cpp
+TEST_F(AppControllerFixture, DisplayProfileChangedIgnoredForNonSelectedDevice) {
+    // Fixture selects device "mock-serial" (index 0).
+    m_ctrl->m_deviceModel.setSelectedIndex(0);
+    EXPECT_EQ(deviceModel().currentDPI(), 1000);
+
+    // Add a second device without switching to it.
+    addMockDevice(QStringLiteral("B"), /*seedDpi=*/2500);
+    EXPECT_EQ(m_ctrl->m_deviceModel.selectedIndex(), 0);
+
+    // Modify device B's profile and fire its display-profile-changed
+    // signal. Device A is still selected, so the DeviceModel should
+    // not swap to device B's 2500 DPI.
+    const QString serialB = QStringLiteral("mock-serial-B");
+    Profile &pB = m_ctrl->m_profileEngine.cachedProfile(
+        serialB, QStringLiteral("default"));
+    pB.dpi = 9999;
+    m_ctrl->m_profileEngine.setDisplayProfile(
+        serialB, QStringLiteral("default"));
+    // setDisplayProfile is a no-op if the name didn't change; force an
+    // emission by changing then restoring.
+    m_ctrl->m_profileEngine.setDisplayProfile(
+        serialB, QStringLiteral("other"));
+    m_ctrl->m_profileEngine.setDisplayProfile(
+        serialB, QStringLiteral("default"));
+
+    // DeviceModel should still reflect device A.
+    EXPECT_EQ(deviceModel().currentDPI(), 1000);
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests --gtest_filter='AppControllerFixture.DisplayProfileChangedIgnoredForNonSelectedDevice' 2>&1 | tail -10`
+Expected: PASS. Filter on `serial != selectedSerial()` in `onDisplayProfileChanged` keeps device A's values.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_app_controller.cpp
+git commit -m "test(app): onDisplayProfileChanged filters by selected device
+
+Profile changes on a non-selected device do not affect the
+DeviceModel's display values. Guards against stale UI updates in
+multi-device setups."
+```
+
+### Task 3.6: Final verification and cleanup
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `cmake --build build -j$(nproc) && QT_QPA_PLATFORM=offscreen ./build/tests/logitune-tests 2>&1 | tail -3 && QT_QPA_PLATFORM=offscreen ./build/tests/qml/logitune-qml-tests 2>&1 | tail -3`
+Expected: 571/571 core (568 baseline + 3 integration) + 72/72 QML. All passing.
+
+- [ ] **Step 2: Manual verification in simulate-all mode**
+
+Run on the host:
+
+```bash
+pkill -9 -f 'build/src/app/logitune' 2>/dev/null
+rm -rf ~/.config/Logitune/Logitune/devices/sim-*
+nohup ./build/src/app/logitune --simulate-all > /tmp/logitune-sim.log 2>&1 & disown
+sleep 4
+```
+
+Navigate to MX Vertical's Buttons page. Verify the DPI cycle card's secondary line reads "DPI cycle" (not "Shift wheel mode"). Switch to MX Master 3S, verify button assignments reflect MX Master 3S. Switch back to MX Vertical, verify it is still correct.
+
+- [ ] **Step 3: Kill the running process**
+
+Run: `pkill -9 -f 'build/src/app/logitune'`
+
+- [ ] **Step 4: Inspect final branch state**
+
+Run: `git log --oneline origin/master..HEAD`
+Expected: 3 commits on the branch (or the three commit groups noted in the spec, depending on how the implementer chose to organize them). Each commit has a descriptive message; no test failures at any intermediate commit.
+
+- [ ] **Step 5: Push the branch**
+
+Run: `git push -u origin fix-carousel-reseed-buttonmodel`
+Expected: push succeeds; the repo's pre-push hook runs tests and confirms pass.
+
+- [ ] **Step 6: Open the pull request**
+
+```bash
+gh pr create --title "ProfileEngine per-device contexts; fix carousel ButtonModel reseed" --body "$(cat <<'EOF'
+Closes #77.
+
+## Summary
+
+Replaces ProfileEngine's hidden global context with a map keyed by
+deviceSerial. Wires DeviceModel::selectedChanged to refresh the UI
+from the newly-selected device's cached profile.
+
+Fixes the case where switching the carousel to a different device left
+ButtonModel and DeviceModel display values stuck on the first-seeded
+device's profile. On real single-device hardware the bug was
+invisible; it surfaced in --simulate-all and on multi-device setups.
+
+## Change breakdown
+
+1. `refactor(profile)` commits: introduce DeviceProfileContext,
+   per-device API, serial-bearing signals. Legacy API stays during
+   the migration then is deleted.
+2. `refactor(app)` commits: migrate all AppController call sites to
+   pass selectedSerial(). Rework AppControllerFixture to go through
+   onPhysicalDeviceAdded.
+3. `feat(app)` + `test(app)` commits: new onSelectedDeviceChanged
+   slot + three integration tests covering the bug.
+
+## Test plan
+
+- [x] logitune-tests: 571/571 pass (568 baseline + 3 integration)
+- [x] logitune-qml-tests: 72/72 pass
+- [x] --simulate-all manual check: MX Vertical's Buttons page shows
+      "DPI cycle" as the secondary on the DPI card even when MX
+      Anywhere 3 is seeded first; carousel switches swap action
+      labels and DPI values correctly.
+EOF
+)"
+```
+
+- [ ] **Step 7: Confirm PR opened**
+
+Expected: `gh pr create` prints a PR URL. Paste it in the session output.
+
+---
+
+## Self-review summary
+
+Every section of the spec has at least one corresponding task:
+
+- **Architecture + registration** → Tasks 1.1, 1.2.
+- **Public API (read)** → Task 1.3.
+- **Public API (write) + signals** → Task 1.4.
+- **Legacy wrappers during migration** → Task 1.5.
+- **Engine-level unit tests** → Task 1.6.
+- **Call-site migration (AppController)** → Tasks 2.1, 2.2, 2.3.
+- **Call-site migration (ProfileModel routing)** → Task 2.3 Step 8.
+- **Fixture rework** → Task 2.4.
+- **Signal migration** → Task 2.5.
+- **Legacy deletion** → Task 2.6.
+- **Selection handler** → Task 3.1.
+- **addMockDevice helper** → Task 3.2.
+- **Three integration tests** → Tasks 3.3, 3.4, 3.5.
+- **Final verification + PR** → Task 3.6.
+
+All code snippets are complete; no placeholders or TBDs remain.

--- a/docs/superpowers/specs/2026-04-20-profile-engine-per-device-design.md
+++ b/docs/superpowers/specs/2026-04-20-profile-engine-per-device-design.md
@@ -1,0 +1,343 @@
+# ProfileEngine Per-Device Contexts Design
+
+**Status:** approved, ready for implementation plan
+**Issue:** #77 (ButtonModel not re-seeded when carousel selection changes)
+**Target release:** next beta
+**Author:** Mina Maher (brainstormed with Claude)
+**Date:** 2026-04-20
+
+## Summary
+
+`ProfileEngine` currently holds profile state for exactly one device at a
+time via a hidden global context (`m_configDir`, `m_cache`,
+`m_displayProfile`, `m_hardwareProfile`, `m_appBindings`). Switching the
+carousel to a different device does not swap that context, so the UI
+continues to display the previously-loaded device's profile data.
+
+Replace the single hidden context with a map keyed by `deviceSerial`, gain
+a per-device API, and wire `DeviceModel::selectedChanged` to refresh the
+UI from the selected device's cached profile.
+
+## Motivation
+
+In `--simulate-all` mode (and on real multi-device setups), the first
+seeded device's profile loads into `ButtonModel` and `DeviceModel`
+display values. No code path updates these when the user clicks a
+different device in the carousel, because:
+
+- `onPhysicalDeviceAdded` calls `setupProfileForDevice`, which ends in
+  `setDisplayProfile("default")`.
+- `ProfileEngine::setDisplayProfile(name)` short-circuits when the name
+  has not changed.
+- All sim devices (and most real-world setups) use `"default"` as the
+  profile name, so after the first device's setup, subsequent
+  `setDisplayProfile("default")` calls are no-ops.
+- No signal fires, so `onDisplayProfileChanged` never runs, so
+  `ButtonModel::loadFromProfile` never re-runs.
+
+Net effect: MX Vertical's Buttons page in the full sim displays
+"Shift wheel mode" on the DPI cycle card because MX Anywhere 3 happened
+to be seeded first. On real hardware with a single Logitech device the
+bug is invisible; it surfaces as soon as a user has two supported
+devices connected or works in simulate-all mode.
+
+## Approach
+
+Three alternatives considered:
+
+1. **Wire `selectedChanged` to a handler that re-applies the profile**
+   (minimal). Required a "last-applied device" tracker and adjustments
+   to `AppControllerFixture`. Previous attempt broke ~17 tests because
+   the fixture bypasses the production device-add flow.
+2. **Split `setupProfileForDevice` into one-time provisioning plus a
+   repeatable `applyProfileToUI`**. Cleaner than (1) but still relies
+   on the hidden global context; the UI-refresh method must swap
+   `setDeviceConfigDir` and clear the cache every selection change.
+3. **Per-device contexts in `ProfileEngine`** (chosen). Eliminates the
+   hidden global; every profile read/write explicitly names a device.
+   Selection-change handler becomes a pure read-and-push. Larger diff
+   than (1) or (2) but aligns the data model with reality: profiles
+   are per-device.
+
+Going with (3). The refactor is the right long-term direction (enables
+future multi-device UI like side-by-side Easy-Switch or profile
+import/export). Ships the bug fix and removes an architectural smell
+in one PR.
+
+## Architecture
+
+Replace the implicit context in `ProfileEngine` with:
+
+```cpp
+struct DeviceProfileContext {
+    QString configDir;                    // per-device profiles dir
+    QHash<QString, Profile> cache;        // profileName -> Profile
+    QHash<QString, QString> appBindings;  // wmClass -> profileName
+    QString displayProfile;               // currently displayed
+    QString hardwareProfile;              // currently active on hardware
+};
+
+class ProfileEngine {
+    QHash<QString, DeviceProfileContext> m_byDevice;  // key: deviceSerial
+    // ...
+};
+```
+
+### Registration / lifecycle
+
+- `registerDevice(serial, configDir)` is the explicit entry point called
+  from `AppController::onPhysicalDeviceAdded` (and from the test
+  fixture). Creates the context, `mkpath`s the dir, loads every
+  `*.conf` into the cache, loads `app-bindings.conf`. Idempotent.
+- If a call arrives with an unknown serial, the engine lazily creates a
+  context using `AppConfigLocation/devices/<serial>/profiles` so the
+  API is robust against ordering bugs.
+- Contexts persist for the life of the process. On device disconnect
+  the context stays in memory; reconnection reuses it.
+
+## Public API
+
+Every method that touches profile state takes `deviceSerial` as its
+first parameter:
+
+```cpp
+// Registration
+void registerDevice(const QString &serial, const QString &configDir);
+bool hasDevice(const QString &serial) const;
+
+// Reads
+Profile& cachedProfile(const QString &serial, const QString &name);
+QStringList profileNames(const QString &serial) const;
+QString displayProfile(const QString &serial) const;
+QString hardwareProfile(const QString &serial) const;
+QString profileForApp(const QString &serial, const QString &wmClass) const;
+
+// Writes
+void setDisplayProfile(const QString &serial, const QString &name);
+void setHardwareProfile(const QString &serial, const QString &name);
+void saveProfileToDisk(const QString &serial, const QString &name);
+void createProfileForApp(const QString &serial,
+                         const QString &wmClass,
+                         const QString &name);
+void removeAppProfile(const QString &serial, const QString &wmClass);
+
+// Static helpers (serial-free, stay as-is)
+static Profile loadProfile(const QString &path);
+static void saveProfile(const QString &path, const Profile &p);
+```
+
+`setDeviceConfigDir` is deleted. Its one legitimate use becomes
+`registerDevice(serial, dir)`.
+
+## Signal semantics
+
+Signals carry the device serial so consumers can filter:
+
+```cpp
+void displayProfileChanged(const QString &serial, const Profile &profile);
+void hardwareProfileChanged(const QString &serial, const Profile &profile);
+```
+
+`AppController::onDisplayProfileChanged` compares the incoming serial
+against `selectedDevice()->deviceSerial()`. Changes for non-selected
+devices early-return; UI updates reflect only the currently-selected
+device.
+
+No "current device" hidden state in the engine. Selection awareness
+lives in the controller where it belongs.
+
+## Selection handler
+
+New slot `AppController::onSelectedDeviceChanged`, wired in
+`wireSignals`:
+
+```cpp
+connect(&m_deviceModel, &DeviceModel::selectedChanged,
+        this, &AppController::onSelectedDeviceChanged);
+```
+
+Body:
+
+```cpp
+void AppController::onSelectedDeviceChanged()
+{
+    auto *device = selectedDevice();
+    if (!device) return;
+
+    m_currentDevice = device->descriptor();
+
+    const QString serial = device->deviceSerial();
+    const QString name = m_profileEngine.displayProfile(serial);
+    const Profile &p = m_profileEngine.cachedProfile(serial, name);
+
+    restoreButtonModelFromProfile(p);
+    pushDisplayValues(p);
+}
+```
+
+No `setupProfileForDevice` call here. One-time provisioning happens in
+`onPhysicalDeviceAdded`; this handler is pure read-and-push. Idempotent,
+no file I/O, no seed.
+
+`onPhysicalDeviceAdded` calls `m_deviceModel.addPhysicalDevice(device)`
+which auto-selects the first device, firing `selectedChanged`. The new
+handler runs and pushes the freshly-registered context's profile into
+the UI. Correct first-attach behavior falls out naturally.
+
+## Code surface
+
+### `src/core/ProfileEngine.{h,cpp}`
+
+- Introduce `DeviceProfileContext` struct.
+- Replace `m_configDir`, `m_cache`, `m_displayProfile`,
+  `m_hardwareProfile`, `m_appBindings` with `m_byDevice`.
+- Rewrite every method to accept `deviceSerial` and look up the
+  context. Lazy-register when missing.
+- `registerDevice(serial, configDir)` new method.
+- Delete `setDeviceConfigDir`.
+- Emit new serial-bearing signals.
+
+### `src/app/AppController.{h,cpp}`
+
+- Add `onSelectedDeviceChanged` slot and wire it in `wireSignals`.
+- Update every `m_profileEngine.*` call to pass
+  `selectedDevice()->deviceSerial()`. Grep identifies ~15 sites.
+- `setupProfileForDevice` now calls `registerDevice` instead of
+  `setDeviceConfigDir`. The rest of its body (seed default profile,
+  set hw/display) uses the serial-aware API.
+- `onDisplayProfileChanged` gains a `QString serial` parameter, filters
+  to the selected device.
+
+### `src/app/models/ProfileModel.*`
+
+- `profileAdded` / `profileRemoved` signals route through `AppController`
+  rather than directly into `ProfileEngine`, so the controller can
+  inject the serial. Minor rewiring in `AppController::wireSignals`.
+
+### `src/app/models/ButtonModel.*`
+
+No change. Already per-UI-state, not per-device.
+
+### `tests/helpers/AppControllerFixture.h`
+
+Replace the three shortcuts:
+
+```cpp
+// REMOVE: m_ctrl->m_currentDevice = &m_device;
+// REMOVE: m_ctrl->m_profileEngine.setDeviceConfigDir(m_profilesDir);
+// REMOVE: m_ctrl->m_profileEngine.setDisplayProfile(...) / setHardwareProfile(...)
+```
+
+With:
+
+```cpp
+const QString kSerial = QStringLiteral("mock-serial");
+m_ctrl->m_profileEngine.registerDevice(kSerial, m_profilesDir);
+
+// Session + PhysicalDevice setup (unchanged)
+// ...
+m_physicalDevice = new PhysicalDevice(kSerial, m_ctrl.get());
+m_physicalDevice->attachTransport(m_session);
+
+// Drive through the normal device-added path
+m_ctrl->onPhysicalDeviceAdded(m_physicalDevice);
+```
+
+Fixture helpers (`createAppProfile`, `setProfileButton`,
+`setProfileGesture`) take serial internally; single-device test call
+sites unchanged. Multi-device tests (Section 6, tests 1-3) add a
+helper `addMockDevice(serialSuffix)` that constructs a second
+`PhysicalDevice` / `DeviceSession` pair with its own serial and drives
+it through the same `onPhysicalDeviceAdded` flow, returning a pointer
+so the test can manipulate per-device profiles.
+
+## Tests
+
+### New
+
+Added to `tests/test_app_controller.cpp`:
+
+1. **`CarouselSwitchSwapsButtonModel`** — two mock devices A and B with
+   different button-5 actions. After `setSelectedIndex(1)`,
+   `ButtonModel::actionNameForButton(5)` returns B's action.
+2. **`CarouselSwitchSwapsDisplayValues`** — same setup with different
+   DPI values per device. `deviceModel().currentDPI()` reflects the
+   newly-selected device.
+3. **`DisplayProfileChangedIgnoredForNonSelectedDevice`** — fire
+   `displayProfileChanged(serialB, ...)` while A is selected; assert
+   ButtonModel and DeviceModel unchanged.
+
+Added to `tests/test_profile_engine.cpp` (create if absent):
+
+4. **`MultipleDevicesKeepSeparateCaches`** — register A and B, assert
+   `cachedProfile("A", "default")` and `cachedProfile("B", "default")`
+   are independent.
+5. **`UnknownDeviceLazyRegisters`** — call `cachedProfile("unknown",
+   "default")` before `registerDevice`; assert a context is created
+   and a default-constructed Profile is returned.
+6. **`SetDisplayProfileScopedToDevice`** — set display profile to "X"
+   on A, verify B's display profile is unchanged.
+
+### Existing
+
+- `AppControllerFixture` tests (~30) recompile cleanly via the helper
+  updates. Run the full suite to confirm no behavioral drift.
+- `ProfileEngine` existing tests get serial parameters added.
+
+### Manual verification
+
+In `--simulate-all`: MX Vertical's Buttons page now shows "DPI cycle"
+as the secondary on the DPI card even when MX Anywhere 3 is seeded
+first. Switching between devices in the carousel updates the displayed
+actions and DPI values correctly.
+
+## Rollout
+
+Branch `fix-carousel-reseed-buttonmodel`. Three commits:
+
+1. `refactor(profile): introduce per-device contexts in ProfileEngine` —
+   add `DeviceProfileContext` + `m_byDevice` + serial-aware API and
+   signals. Keep legacy single-context wrappers that auto-register a
+   `"legacy"` serial and preserve the old `displayProfileChanged(Profile)`
+   /`hardwareProfileChanged(Profile)` signals so callers compile
+   unchanged. All tests pass.
+2. `refactor(app): route ProfileEngine calls through device serial` —
+   update every call site in `AppController` and `ProfileModel` to pass
+   a serial. Delete the legacy wrappers, `setDeviceConfigDir`, and the
+   legacy single-arg signals. Migrate `onDisplayProfileChanged` to the
+   new two-arg signal. Rework `AppControllerFixture` + helpers. Existing
+   test suite passes end-to-end with behavior unchanged.
+3. `fix(app): re-seed ButtonModel when carousel selection changes` —
+   wire `DeviceModel::selectedChanged` to `onSelectedDeviceChanged`.
+   Update `onDisplayProfileChanged` to filter by selected device. Add
+   the six new tests. Closes #77.
+
+Splitting the mechanical refactor (1, 2) from the behavior change (3)
+keeps review tractable. Commits 1 and 2 have zero behavioral delta.
+
+## Known risks
+
+- **Call-site coverage.** Commit 2 touches ~15 call sites across two
+  files. A missed site fails to compile (not a runtime bug) and is
+  caught immediately.
+- **Lazy registration surprises.** If code paths hit `cachedProfile`
+  with an unexpected serial before `registerDevice` runs, the engine
+  creates a default context pointing at
+  `AppConfigLocation/devices/<serial>/profiles` and emits a
+  `qCWarning(lcApp) << "ProfileEngine: lazy-registering unknown device"
+  << serial` so the condition is visible in logs. Low risk because
+  `onPhysicalDeviceAdded` registers before any other code gets the
+  serial; the warning is a safety net for regressions in device-add
+  ordering.
+- **Signal subscribers outside this change.** `displayProfileChanged`
+  signal subscribers outside `AppController` would break on the new
+  arity. Grep confirms only `AppController::onDisplayProfileChanged`
+  consumes it today.
+
+## Out of scope
+
+- QML-level profile-switcher UI (single "default" profile stays the
+  norm; per-app profiles already exist).
+- Renaming `deviceSerial` to `deviceId` across the codebase.
+- Per-device profile history / undo.
+- Cross-device profile copy or import.

--- a/src/app/AppController.cpp
+++ b/src/app/AppController.cpp
@@ -134,17 +134,18 @@ void AppController::wireSignals()
             saveCurrentProfile();
         });
 
-    // TEMPORARY during migration to per-device ProfileEngine contexts:
-    // qOverload pins to the legacy single-context overloads of
-    // createProfileForApp/removeAppProfile. These rewire to the
-    // serial-aware overloads via lambdas in the Commit 2 migration.
-    connect(&m_profileModel, &ProfileModel::profileAdded,
-            &m_profileEngine,
-            qOverload<const QString &, const QString &>(
-                &ProfileEngine::createProfileForApp));
-    connect(&m_profileModel, &ProfileModel::profileRemoved,
-            &m_profileEngine,
-            qOverload<const QString &>(&ProfileEngine::removeAppProfile));
+    connect(&m_profileModel, &ProfileModel::profileAdded, this,
+            [this](const QString &wmClass, const QString &profileName) {
+        const QString serial = selectedSerial();
+        if (!serial.isEmpty())
+            m_profileEngine.createProfileForApp(serial, wmClass, profileName);
+    });
+    connect(&m_profileModel, &ProfileModel::profileRemoved, this,
+            [this](const QString &wmClass) {
+        const QString serial = selectedSerial();
+        if (!serial.isEmpty())
+            m_profileEngine.removeAppProfile(serial, wmClass);
+    });
 
     connect(&m_deviceFetcher, &DeviceFetcher::descriptorsUpdated,
             this, [this]() {
@@ -202,9 +203,11 @@ void AppController::onPhysicalDeviceAdded(PhysicalDevice *device)
     connect(device, &PhysicalDevice::transportSetupComplete, this,
             [this, device]() {
         m_currentDevice = device->descriptor();
-        Profile &p = m_profileEngine.cachedProfile(m_profileEngine.hardwareProfile());
+        const QString serial = device->deviceSerial();
+        Profile &p = m_profileEngine.cachedProfile(serial,
+                                                   m_profileEngine.hardwareProfile(serial));
         qCDebug(lcApp) << "device transport ready, applying profile:"
-                        << m_profileEngine.hardwareProfile();
+                        << m_profileEngine.hardwareProfile(serial);
         applyProfileToHardware(p);
     });
 
@@ -335,7 +338,9 @@ void AppController::onUserButtonChanged(int buttonId, const QString &actionName,
 
     saveCurrentProfile();
 
-    if (m_profileEngine.displayProfile() != m_profileEngine.hardwareProfile())
+    const QString serial = selectedSerial();
+    if (serial.isEmpty()) return;
+    if (m_profileEngine.displayProfile(serial) != m_profileEngine.hardwareProfile(serial))
         return;
 
     if (!m_currentDevice) return;
@@ -356,7 +361,9 @@ void AppController::onUserButtonChanged(int buttonId, const QString &actionName,
 
 void AppController::onTabSwitched(const QString &profileName)
 {
-    m_profileEngine.setDisplayProfile(profileName);
+    const QString serial = selectedSerial();
+    if (serial.isEmpty()) return;
+    m_profileEngine.setDisplayProfile(serial, profileName);
 }
 
 void AppController::onDisplayProfileChanged(const Profile &profile)
@@ -391,12 +398,15 @@ void AppController::onWindowFocusChanged(const QString &wmClass, const QString &
 
     m_deviceModel.setActiveWmClass(wmClass);
 
-    QString profileName = m_profileEngine.profileForApp(wmClass);
-    if (profileName == m_profileEngine.hardwareProfile())
+    const QString serial = selectedSerial();
+    if (serial.isEmpty()) return;
+
+    QString profileName = m_profileEngine.profileForApp(serial, wmClass);
+    if (profileName == m_profileEngine.hardwareProfile(serial))
         return;
 
-    Profile &p = m_profileEngine.cachedProfile(profileName);
-    m_profileEngine.setHardwareProfile(profileName);
+    Profile &p = m_profileEngine.cachedProfile(serial, profileName);
+    m_profileEngine.setHardwareProfile(serial, profileName);
     applyProfileToHardware(p);
     m_profileModel.setHwActiveByProfileName(profileName);
 }
@@ -526,10 +536,13 @@ void AppController::applyProfileToHardware(const Profile &p)
 
 void AppController::saveCurrentProfile()
 {
-    QString name = m_profileEngine.displayProfile();
+    const QString serial = selectedSerial();
+    if (serial.isEmpty()) return;
+
+    const QString name = m_profileEngine.displayProfile(serial);
     if (name.isEmpty()) return;
 
-    Profile &p = m_profileEngine.cachedProfile(name);
+    Profile &p = m_profileEngine.cachedProfile(serial, name);
     if (p.name.isEmpty()) p.name = name;
 
     if (m_currentDevice) {
@@ -549,7 +562,7 @@ void AppController::saveCurrentProfile()
             p.gestures[dir] = {ButtonAction::Keystroke, ks};
     }
 
-    m_profileEngine.saveProfileToDisk(name);
+    m_profileEngine.saveProfileToDisk(serial, name);
 }
 
 void AppController::pushDisplayValues(const Profile &p)
@@ -562,13 +575,15 @@ void AppController::pushDisplayValues(const Profile &p)
 
 void AppController::onDpiChangeRequested(int value)
 {
-    QString name = m_profileEngine.displayProfile();
+    const QString serial = selectedSerial();
+    if (serial.isEmpty()) return;
+    const QString name = m_profileEngine.displayProfile(serial);
     if (name.isEmpty()) return;
-    Profile &p = m_profileEngine.cachedProfile(name);
+    Profile &p = m_profileEngine.cachedProfile(serial, name);
     p.dpi = value;
-    m_profileEngine.saveProfileToDisk(name);
+    m_profileEngine.saveProfileToDisk(serial, name);
     pushDisplayValues(p);
-    if (name == m_profileEngine.hardwareProfile()) {
+    if (name == m_profileEngine.hardwareProfile(serial)) {
         auto *session = selectedSession();
         if (session) session->setDPI(value);
     }
@@ -576,14 +591,16 @@ void AppController::onDpiChangeRequested(int value)
 
 void AppController::onSmartShiftChangeRequested(bool enabled, int threshold)
 {
-    QString name = m_profileEngine.displayProfile();
+    const QString serial = selectedSerial();
+    if (serial.isEmpty()) return;
+    const QString name = m_profileEngine.displayProfile(serial);
     if (name.isEmpty()) return;
-    Profile &p = m_profileEngine.cachedProfile(name);
+    Profile &p = m_profileEngine.cachedProfile(serial, name);
     p.smartShiftEnabled = enabled;
     p.smartShiftThreshold = threshold;
-    m_profileEngine.saveProfileToDisk(name);
+    m_profileEngine.saveProfileToDisk(serial, name);
     pushDisplayValues(p);
-    if (name == m_profileEngine.hardwareProfile()) {
+    if (name == m_profileEngine.hardwareProfile(serial)) {
         auto *session = selectedSession();
         if (session) session->setSmartShift(enabled, threshold);
     }
@@ -591,14 +608,16 @@ void AppController::onSmartShiftChangeRequested(bool enabled, int threshold)
 
 void AppController::onScrollConfigChangeRequested(bool hiRes, bool invert)
 {
-    QString name = m_profileEngine.displayProfile();
+    const QString serial = selectedSerial();
+    if (serial.isEmpty()) return;
+    const QString name = m_profileEngine.displayProfile(serial);
     if (name.isEmpty()) return;
-    Profile &p = m_profileEngine.cachedProfile(name);
+    Profile &p = m_profileEngine.cachedProfile(serial, name);
     p.hiResScroll = hiRes;
     p.scrollDirection = invert ? QStringLiteral("natural") : QStringLiteral("standard");
-    m_profileEngine.saveProfileToDisk(name);
+    m_profileEngine.saveProfileToDisk(serial, name);
     pushDisplayValues(p);
-    if (name == m_profileEngine.hardwareProfile()) {
+    if (name == m_profileEngine.hardwareProfile(serial)) {
         auto *session = selectedSession();
         if (session) session->setScrollConfig(hiRes, invert);
     }
@@ -611,26 +630,30 @@ void AppController::onThumbWheelModeChangeRequested(const QString &mode)
         auto &state = m_perDeviceState[session->deviceId()];
         state.thumbAccum = 0;
     }
-    QString name = m_profileEngine.displayProfile();
+    const QString serial = selectedSerial();
+    if (serial.isEmpty()) return;
+    const QString name = m_profileEngine.displayProfile(serial);
     qCDebug(lcApp) << "thumbWheelMode requested:" << mode << "for profile:" << name;
     if (name.isEmpty()) return;
-    Profile &p = m_profileEngine.cachedProfile(name);
+    Profile &p = m_profileEngine.cachedProfile(serial, name);
     p.thumbWheelMode = mode;
-    m_profileEngine.saveProfileToDisk(name);
+    m_profileEngine.saveProfileToDisk(serial, name);
     pushDisplayValues(p);
-    if (name == m_profileEngine.hardwareProfile() && session)
+    if (name == m_profileEngine.hardwareProfile(serial) && session)
         session->setThumbWheelMode(mode, p.thumbWheelInvert);
 }
 
 void AppController::onThumbWheelInvertChangeRequested(bool invert)
 {
-    QString name = m_profileEngine.displayProfile();
+    const QString serial = selectedSerial();
+    if (serial.isEmpty()) return;
+    const QString name = m_profileEngine.displayProfile(serial);
     if (name.isEmpty()) return;
-    Profile &p = m_profileEngine.cachedProfile(name);
+    Profile &p = m_profileEngine.cachedProfile(serial, name);
     p.thumbWheelInvert = invert;
-    m_profileEngine.saveProfileToDisk(name);
+    m_profileEngine.saveProfileToDisk(serial, name);
     pushDisplayValues(p);
-    if (name == m_profileEngine.hardwareProfile()) {
+    if (name == m_profileEngine.hardwareProfile(serial)) {
         auto *session = selectedSession();
         if (session) session->setThumbWheelMode(p.thumbWheelMode, invert);
     }
@@ -648,7 +671,10 @@ void AppController::onDivertedButtonPressed(uint16_t controlId, bool pressed)
     if (!session) return;
     auto &state = m_perDeviceState[session->deviceId()];
 
-    const Profile &hwProfile = m_profileEngine.cachedProfile(m_profileEngine.hardwareProfile());
+    const QString serial = selectedSerial();
+    if (serial.isEmpty()) return;
+    const Profile &hwProfile = m_profileEngine.cachedProfile(
+        serial, m_profileEngine.hardwareProfile(serial));
 
     if (!pressed && state.gestureActive
         && (controlId == 0 || controlId == state.gestureControlId)) {

--- a/src/app/AppController.cpp
+++ b/src/app/AppController.cpp
@@ -134,6 +134,10 @@ void AppController::wireSignals()
             saveCurrentProfile();
         });
 
+    // TEMPORARY during migration to per-device ProfileEngine contexts:
+    // qOverload pins to the legacy single-context overloads of
+    // createProfileForApp/removeAppProfile. These rewire to the
+    // serial-aware overloads via lambdas in the Commit 2 migration.
     connect(&m_profileModel, &ProfileModel::profileAdded,
             &m_profileEngine,
             qOverload<const QString &, const QString &>(

--- a/src/app/AppController.cpp
+++ b/src/app/AppController.cpp
@@ -321,6 +321,12 @@ DeviceSession *AppController::selectedSession() const
     return d ? d->primary() : nullptr;
 }
 
+QString AppController::selectedSerial() const
+{
+    auto *d = selectedDevice();
+    return d ? d->deviceSerial() : QString();
+}
+
 // Slot implementations -------------------------------------------------------
 
 void AppController::onUserButtonChanged(int buttonId, const QString &actionName, const QString &actionType)

--- a/src/app/AppController.cpp
+++ b/src/app/AppController.cpp
@@ -118,7 +118,7 @@ void AppController::wireSignals()
     connect(&m_profileModel, &ProfileModel::profileSwitched,
             this, &AppController::onTabSwitched);
 
-    connect(&m_profileEngine, &ProfileEngine::displayProfileChanged,
+    connect(&m_profileEngine, &ProfileEngine::deviceDisplayProfileChanged,
             this, &AppController::onDisplayProfileChanged);
 
     // Physical device lifecycle — one per unique serial, survives transport
@@ -366,14 +366,17 @@ void AppController::onTabSwitched(const QString &profileName)
     m_profileEngine.setDisplayProfile(serial, profileName);
 }
 
-void AppController::onDisplayProfileChanged(const Profile &profile)
+void AppController::onDisplayProfileChanged(const QString &serial, const Profile &profile)
 {
+    if (serial != selectedSerial())
+        return;
+
     m_deviceModel.setActiveProfileName(profile.name);
 
     m_deviceModel.setDisplayValues(
         profile.dpi, profile.smartShiftEnabled, profile.smartShiftThreshold,
-        profile.hiResScroll, profile.scrollDirection == "natural", profile.thumbWheelMode,
-        profile.thumbWheelInvert);
+        profile.hiResScroll, profile.scrollDirection == "natural",
+        profile.thumbWheelMode, profile.thumbWheelInvert);
 
     restoreButtonModelFromProfile(profile);
 }

--- a/src/app/AppController.cpp
+++ b/src/app/AppController.cpp
@@ -229,15 +229,15 @@ void AppController::setupProfileForDevice(PhysicalDevice *device)
 {
     m_currentDevice = device->descriptor();
 
-    const QString configBase =
-        QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+    const QString serial = device->deviceSerial();
+    const QString configBase = QStandardPaths::writableLocation(
+        QStandardPaths::AppConfigLocation);
     const QString profilesDir = configBase
-        + QStringLiteral("/devices/")
-        + device->deviceSerial()
+        + QStringLiteral("/devices/") + serial
         + QStringLiteral("/profiles");
 
     QDir().mkpath(profilesDir);
-    m_profileEngine.setDeviceConfigDir(profilesDir);
+    m_profileEngine.registerDevice(serial, profilesDir);
     qCDebug(lcApp) << "profile dir:" << profilesDir;
 
     const QString defaultConf = profilesDir + QStringLiteral("/default.conf");
@@ -253,7 +253,9 @@ void AppController::setupProfileForDevice(PhysicalDevice *device)
         seed.smoothScrolling     = !device->scrollRatchet();
         if (m_currentDevice) {
             const auto controls = m_currentDevice->controls();
-            for (int i = 0; i < static_cast<int>(controls.size()) && i < static_cast<int>(seed.buttons.size()); ++i) {
+            for (int i = 0;
+                 i < static_cast<int>(controls.size()) &&
+                 i < static_cast<int>(seed.buttons.size()); ++i) {
                 const auto &ctrl = controls[i];
                 if (ctrl.defaultActionType == "gesture-trigger")
                     seed.buttons[i] = {ButtonAction::GestureTrigger, {}};
@@ -263,19 +265,19 @@ void AppController::setupProfileForDevice(PhysicalDevice *device)
                     seed.buttons[i] = {ButtonAction::DpiCycle, {}};
             }
             const auto defaultGestures = m_currentDevice->defaultGestures();
-            for (auto it = defaultGestures.begin(); it != defaultGestures.end(); ++it) {
+            for (auto it = defaultGestures.begin();
+                 it != defaultGestures.end(); ++it) {
                 seed.gestures[it.key()] = it.value();
             }
         }
         ProfileEngine::saveProfile(defaultConf, seed);
-        m_profileEngine.setDeviceConfigDir(profilesDir);
+        m_profileEngine.registerDevice(serial, profilesDir);  // reload cache after seeding
         qCDebug(lcApp) << "created default profile at" << defaultConf;
     }
 
     const QString bindingsFile = profilesDir + QStringLiteral("/app-bindings.conf");
     if (QFile::exists(bindingsFile)) {
         const auto bindings = ProfileEngine::loadAppBindings(bindingsFile);
-
         QMap<QString, QString> iconLookup;
         const auto apps = m_desktop->runningApplications();
         for (const auto &app : apps) {
@@ -283,26 +285,24 @@ void AppController::setupProfileForDevice(PhysicalDevice *device)
             iconLookup[map[QStringLiteral("wmClass")].toString().toLower()]
                 = map[QStringLiteral("icon")].toString();
         }
-
         for (auto it = bindings.cbegin(); it != bindings.cend(); ++it) {
             QString icon = iconLookup.value(it.key().toLower());
             m_profileModel.restoreProfile(it.key(), it.value(), icon);
         }
     }
 
-    QString hwName = m_profileEngine.hardwareProfile();
+    QString hwName = m_profileEngine.hardwareProfile(serial);
     bool isFirstConnect = hwName.isEmpty();
-
     if (isFirstConnect) {
         hwName = QStringLiteral("default");
         m_profileModel.setHwActiveIndex(0);
-        m_profileEngine.setHardwareProfile(hwName);
-        m_profileEngine.setDisplayProfile(hwName);
+        m_profileEngine.setHardwareProfile(serial, hwName);
+        m_profileEngine.setDisplayProfile(serial, hwName);
     }
 
-    Profile &p = m_profileEngine.cachedProfile(hwName);
+    Profile &p = m_profileEngine.cachedProfile(serial, hwName);
     qCDebug(lcApp) << "setupProfileForDevice: applying profile" << hwName
-                    << "thumbWheelMode=" << p.thumbWheelMode;
+                   << "thumbWheelMode=" << p.thumbWheelMode;
     applyProfileToHardware(p);
 }
 

--- a/src/app/AppController.cpp
+++ b/src/app/AppController.cpp
@@ -135,9 +135,12 @@ void AppController::wireSignals()
         });
 
     connect(&m_profileModel, &ProfileModel::profileAdded,
-            &m_profileEngine, &ProfileEngine::createProfileForApp);
+            &m_profileEngine,
+            qOverload<const QString &, const QString &>(
+                &ProfileEngine::createProfileForApp));
     connect(&m_profileModel, &ProfileModel::profileRemoved,
-            &m_profileEngine, &ProfileEngine::removeAppProfile);
+            &m_profileEngine,
+            qOverload<const QString &>(&ProfileEngine::removeAppProfile));
 
     connect(&m_deviceFetcher, &DeviceFetcher::descriptorsUpdated,
             this, [this]() {

--- a/src/app/AppController.cpp
+++ b/src/app/AppController.cpp
@@ -121,6 +121,9 @@ void AppController::wireSignals()
     connect(&m_profileEngine, &ProfileEngine::deviceDisplayProfileChanged,
             this, &AppController::onDisplayProfileChanged);
 
+    connect(&m_deviceModel, &DeviceModel::selectedChanged,
+            this, &AppController::onSelectedDeviceChanged);
+
     // Physical device lifecycle — one per unique serial, survives transport
     // switches. Per-transport events are routed through PhysicalDevice
     // (which fans in signals from all its transports).
@@ -226,6 +229,25 @@ void AppController::onPhysicalDeviceRemoved(PhysicalDevice *device)
 
     if (m_deviceModel.count() > 0 && m_deviceModel.selectedIndex() < 0)
         m_deviceModel.setSelectedIndex(0);
+}
+
+// Carousel selection changed. Refresh the UI from the newly-selected
+// device's cached profile. No file I/O, no seeding, no hardware apply —
+// one-time device provisioning happens in onPhysicalDeviceAdded.
+void AppController::onSelectedDeviceChanged()
+{
+    auto *device = selectedDevice();
+    if (!device) return;
+
+    m_currentDevice = device->descriptor();
+
+    const QString serial = device->deviceSerial();
+    const QString name = m_profileEngine.displayProfile(serial);
+    if (name.isEmpty()) return;  // device not yet fully set up
+
+    const Profile &p = m_profileEngine.cachedProfile(serial, name);
+    restoreButtonModelFromProfile(p);
+    pushDisplayValues(p);
 }
 
 void AppController::setupProfileForDevice(PhysicalDevice *device)

--- a/src/app/AppController.cpp
+++ b/src/app/AppController.cpp
@@ -662,12 +662,6 @@ void AppController::onThumbWheelInvertChangeRequested(bool invert)
     }
 }
 
-void AppController::onGestureRawXY(int16_t dx, int16_t dy)
-{
-    Q_UNUSED(dx); Q_UNUSED(dy);
-    // Handled by per-session lambda in onSessionAdded
-}
-
 void AppController::onDivertedButtonPressed(uint16_t controlId, bool pressed)
 {
     auto *session = selectedSession();

--- a/src/app/AppController.h
+++ b/src/app/AppController.h
@@ -57,7 +57,7 @@ private slots:
     void onUserButtonChanged(int buttonId, const QString &actionName, const QString &actionType);
     void onWindowFocusChanged(const QString &wmClass, const QString &title);
     void onTabSwitched(const QString &profileName);
-    void onDisplayProfileChanged(const Profile &profile);
+    void onDisplayProfileChanged(const QString &serial, const Profile &profile);
     void onPhysicalDeviceAdded(PhysicalDevice *device);
     void onPhysicalDeviceRemoved(PhysicalDevice *device);
     void onGestureRawXY(int16_t dx, int16_t dy);

--- a/src/app/AppController.h
+++ b/src/app/AppController.h
@@ -60,7 +60,6 @@ private slots:
     void onDisplayProfileChanged(const QString &serial, const Profile &profile);
     void onPhysicalDeviceAdded(PhysicalDevice *device);
     void onPhysicalDeviceRemoved(PhysicalDevice *device);
-    void onGestureRawXY(int16_t dx, int16_t dy);
     void onDivertedButtonPressed(uint16_t controlId, bool pressed);
     void onThumbWheelRotation(int delta);
     void onDpiChangeRequested(int value);

--- a/src/app/AppController.h
+++ b/src/app/AppController.h
@@ -67,6 +67,7 @@ private slots:
     void onScrollConfigChangeRequested(bool hiRes, bool invert);
     void onThumbWheelModeChangeRequested(const QString &mode);
     void onThumbWheelInvertChangeRequested(bool invert);
+    void onSelectedDeviceChanged();
 
 private:
     void wireSignals();

--- a/src/app/AppController.h
+++ b/src/app/AppController.h
@@ -78,6 +78,7 @@ private:
     void setupProfileForDevice(PhysicalDevice *device);
     PhysicalDevice *selectedDevice() const;
     DeviceSession *selectedSession() const;  // convenience — selectedDevice()->primary()
+    QString selectedSerial() const;  // PhysicalDevice::deviceSerial() of the selected device, or empty
     QString buttonActionToName(const ButtonAction &ba) const;
     ButtonAction buttonEntryToAction(const QString &actionType, const QString &actionName) const;
 

--- a/src/core/ProfileEngine.cpp
+++ b/src/core/ProfileEngine.cpp
@@ -275,8 +275,12 @@ const DeviceProfileContext& ProfileEngine::ctx(const QString &serial) const
 {
     static const DeviceProfileContext empty{};
     auto it = m_byDevice.constFind(serial);
-    if (it == m_byDevice.constEnd())
+    if (it == m_byDevice.constEnd()) {
+        qCWarning(lcProfile)
+            << "ProfileEngine: const lookup for unknown device" << serial
+            << "- returning empty context";
         return empty;
+    }
     return *it;
 }
 

--- a/src/core/ProfileEngine.cpp
+++ b/src/core/ProfileEngine.cpp
@@ -400,4 +400,51 @@ bool ProfileEngine::hasDevice(const QString &serial) const
     return m_byDevice.contains(serial);
 }
 
+Profile& ProfileEngine::cachedProfile(const QString &serial, const QString &name)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (!c.cache.contains(name)) {
+        c.cache[name] = Profile{};
+        c.cache[name].name = name;
+    }
+    return c.cache[name];
+}
+
+QStringList ProfileEngine::profileNames(const QString &serial) const
+{
+    const DeviceProfileContext &c = ctx(serial);
+    if (c.configDir.isEmpty())
+        return {};
+    QDir dir(c.configDir);
+    const QStringList files = dir.entryList({"*.conf"}, QDir::Files);
+    QStringList names;
+    names.reserve(files.size());
+    for (const QString &f : files) {
+        const QString base = QFileInfo(f).baseName();
+        if (base != QLatin1String("app-bindings"))
+            names << base;
+    }
+    return names;
+}
+
+QString ProfileEngine::displayProfile(const QString &serial) const
+{
+    return ctx(serial).displayProfile;
+}
+
+QString ProfileEngine::hardwareProfile(const QString &serial) const
+{
+    return ctx(serial).hardwareProfile;
+}
+
+QString ProfileEngine::profileForApp(const QString &serial, const QString &wmClass) const
+{
+    const DeviceProfileContext &c = ctx(serial);
+    for (auto it = c.appBindings.cbegin(); it != c.appBindings.cend(); ++it) {
+        if (it.key().compare(wmClass, Qt::CaseInsensitive) == 0)
+            return it.value();
+    }
+    return QStringLiteral("default");
+}
+
 } // namespace logitune

--- a/src/core/ProfileEngine.cpp
+++ b/src/core/ProfileEngine.cpp
@@ -447,4 +447,70 @@ QString ProfileEngine::profileForApp(const QString &serial, const QString &wmCla
     return QStringLiteral("default");
 }
 
+void ProfileEngine::setDisplayProfile(const QString &serial, const QString &name)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (c.displayProfile == name) return;
+    c.displayProfile = name;
+    emit deviceDisplayProfileChanged(serial, cachedProfile(serial, name));
+    if (serial == QLatin1String(kLegacySerial))
+        emit displayProfileChanged(cachedProfile(serial, name));
+}
+
+void ProfileEngine::setHardwareProfile(const QString &serial, const QString &name)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (c.hardwareProfile == name) return;
+    c.hardwareProfile = name;
+    emit deviceHardwareProfileChanged(serial, cachedProfile(serial, name));
+    if (serial == QLatin1String(kLegacySerial))
+        emit hardwareProfileChanged(cachedProfile(serial, name));
+}
+
+void ProfileEngine::saveProfileToDisk(const QString &serial, const QString &name)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (!c.cache.contains(name) || c.configDir.isEmpty()) return;
+    saveProfile(c.configDir + "/" + name + ".conf", c.cache[name]);
+}
+
+void ProfileEngine::createProfileForApp(const QString &serial,
+                                        const QString &wmClass,
+                                        const QString &profileName)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (c.configDir.isEmpty() || wmClass.isEmpty() || profileName.isEmpty())
+        return;
+    if (!c.cache.contains(profileName)) {
+        c.cache[profileName] = c.cache.value(QStringLiteral("default"));
+        c.cache[profileName].name = profileName;
+        saveProfile(c.configDir + "/" + profileName + ".conf",
+                    c.cache[profileName]);
+    }
+    c.appBindings[wmClass] = profileName;
+    saveAppBindings(c.configDir + "/app-bindings.conf", c.appBindings);
+}
+
+void ProfileEngine::removeAppProfile(const QString &serial, const QString &wmClass)
+{
+    DeviceProfileContext &c = ctx(serial);
+    if (c.configDir.isEmpty() || wmClass.isEmpty()) return;
+
+    const QString profileName = c.appBindings.value(wmClass);
+    if (profileName.isEmpty()) return;
+
+    QFile::remove(c.configDir + "/" + profileName + ".conf");
+    c.cache.remove(profileName);
+    c.appBindings.remove(wmClass);
+    saveAppBindings(c.configDir + "/app-bindings.conf", c.appBindings);
+
+    if (c.displayProfile == profileName)
+        setDisplayProfile(serial, QStringLiteral("default"));
+    if (c.hardwareProfile == profileName)
+        setHardwareProfile(serial, QStringLiteral("default"));
+
+    qCDebug(lcProfile) << "removed profile" << profileName
+                       << "for app" << wmClass << "on device" << serial;
+}
+
 } // namespace logitune

--- a/src/core/ProfileEngine.cpp
+++ b/src/core/ProfileEngine.cpp
@@ -197,63 +197,6 @@ ProfileEngine::ProfileEngine(QObject *parent)
 {
 }
 
-void ProfileEngine::setDeviceConfigDir(const QString &dir)
-{
-    registerDevice(QLatin1String(kLegacySerial), dir);
-    m_configDir = dir;
-}
-
-QStringList ProfileEngine::profileNames() const
-{
-    return profileNames(QLatin1String(kLegacySerial));
-}
-
-Profile& ProfileEngine::cachedProfile(const QString &name)
-{
-    return cachedProfile(QLatin1String(kLegacySerial), name);
-}
-
-QString ProfileEngine::displayProfile() const
-{
-    return displayProfile(QLatin1String(kLegacySerial));
-}
-
-QString ProfileEngine::hardwareProfile() const
-{
-    return hardwareProfile(QLatin1String(kLegacySerial));
-}
-
-void ProfileEngine::setDisplayProfile(const QString &name)
-{
-    setDisplayProfile(QLatin1String(kLegacySerial), name);
-}
-
-void ProfileEngine::setHardwareProfile(const QString &name)
-{
-    setHardwareProfile(QLatin1String(kLegacySerial), name);
-}
-
-void ProfileEngine::saveProfileToDisk(const QString &name)
-{
-    saveProfileToDisk(QLatin1String(kLegacySerial), name);
-}
-
-void ProfileEngine::createProfileForApp(const QString &wmClass,
-                                        const QString &profileName)
-{
-    createProfileForApp(QLatin1String(kLegacySerial), wmClass, profileName);
-}
-
-void ProfileEngine::removeAppProfile(const QString &wmClass)
-{
-    removeAppProfile(QLatin1String(kLegacySerial), wmClass);
-}
-
-QString ProfileEngine::profileForApp(const QString &wmClass) const
-{
-    return profileForApp(QLatin1String(kLegacySerial), wmClass);
-}
-
 // ---------------------------------------------------------------------------
 // Per-device contexts
 // ---------------------------------------------------------------------------
@@ -366,8 +309,6 @@ void ProfileEngine::setDisplayProfile(const QString &serial, const QString &name
     if (c.displayProfile == name) return;
     c.displayProfile = name;
     emit deviceDisplayProfileChanged(serial, cachedProfile(serial, name));
-    if (serial == QLatin1String(kLegacySerial))
-        emit displayProfileChanged(cachedProfile(serial, name));
 }
 
 void ProfileEngine::setHardwareProfile(const QString &serial, const QString &name)
@@ -376,8 +317,6 @@ void ProfileEngine::setHardwareProfile(const QString &serial, const QString &nam
     if (c.hardwareProfile == name) return;
     c.hardwareProfile = name;
     emit deviceHardwareProfileChanged(serial, cachedProfile(serial, name));
-    if (serial == QLatin1String(kLegacySerial))
-        emit hardwareProfileChanged(cachedProfile(serial, name));
 }
 
 void ProfileEngine::saveProfileToDisk(const QString &serial, const QString &name)

--- a/src/core/ProfileEngine.cpp
+++ b/src/core/ProfileEngine.cpp
@@ -1,7 +1,9 @@
 #include "ProfileEngine.h"
 #include "logging/LogManager.h"
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
+#include <QSettings>
 #include <QStandardPaths>
 
 namespace logitune {
@@ -197,152 +199,59 @@ ProfileEngine::ProfileEngine(QObject *parent)
 
 void ProfileEngine::setDeviceConfigDir(const QString &dir)
 {
+    registerDevice(QLatin1String(kLegacySerial), dir);
     m_configDir = dir;
-    m_cache.clear();
-
-    QDir d(dir);
-    if (d.exists()) {
-        for (const auto &f : d.entryList({"*.conf"}, QDir::Files)) {
-            if (f == "app-bindings.conf") continue;
-            QString name = QFileInfo(f).baseName();
-            m_cache[name] = loadProfile(d.filePath(f));
-        }
-    }
-
-    // Load app bindings if the file exists
-    const QString bindingsFile = appBindingsPath();
-    if (QFileInfo::exists(bindingsFile))
-        m_appBindings = loadAppBindings(bindingsFile);
 }
 
 QStringList ProfileEngine::profileNames() const
 {
-    if (m_configDir.isEmpty())
-        return {};
-
-    QDir dir(m_configDir);
-    const QStringList files = dir.entryList({"*.conf"}, QDir::Files);
-
-    QStringList names;
-    names.reserve(files.size());
-    for (const QString &f : files)
-        names << QFileInfo(f).baseName();
-    return names;
+    return profileNames(QLatin1String(kLegacySerial));
 }
-
-void ProfileEngine::createProfileForApp(const QString &wmClass, const QString &profileName)
-{
-    if (m_configDir.isEmpty() || wmClass.isEmpty() || profileName.isEmpty())
-        return;
-
-    // Only create if the profile doesn't already exist (loaded from disk at startup).
-    // Without this guard, every app restart would overwrite saved customizations.
-    if (!m_cache.contains(profileName)) {
-        m_cache[profileName] = m_cache.value(QStringLiteral("default"));
-        m_cache[profileName].name = profileName;
-        saveProfile(profilePath(profileName), m_cache[profileName]);
-    }
-
-    m_appBindings[wmClass] = profileName;
-    saveAppBindings(appBindingsPath(), m_appBindings);
-}
-
-void ProfileEngine::removeAppProfile(const QString &wmClass)
-{
-    if (m_configDir.isEmpty() || wmClass.isEmpty())
-        return;
-
-    const QString profileName = m_appBindings.value(wmClass);
-    if (profileName.isEmpty())
-        return;
-
-    // Remove the profile file
-    QFile::remove(profilePath(profileName));
-
-    // Remove from cache
-    m_cache.remove(profileName);
-
-    // Remove from app bindings and save
-    m_appBindings.remove(wmClass);
-    saveAppBindings(appBindingsPath(), m_appBindings);
-
-    // If the removed profile was displayed or on hardware, switch back to default
-    if (m_displayProfile == profileName)
-        setDisplayProfile(QStringLiteral("default"));
-    if (m_hardwareProfile == profileName)
-        setHardwareProfile(QStringLiteral("default"));
-
-    qCDebug(lcProfile) << "removed profile" << profileName << "for app" << wmClass;
-}
-
-// ---------------------------------------------------------------------------
-// Profile cache (Task 1)
-// ---------------------------------------------------------------------------
 
 Profile& ProfileEngine::cachedProfile(const QString &name)
 {
-    if (!m_cache.contains(name)) {
-        m_cache[name] = Profile{};
-        m_cache[name].name = name;
-    }
-    return m_cache[name];
+    return cachedProfile(QLatin1String(kLegacySerial), name);
 }
 
 QString ProfileEngine::displayProfile() const
 {
-    return m_displayProfile;
+    return displayProfile(QLatin1String(kLegacySerial));
 }
 
 QString ProfileEngine::hardwareProfile() const
 {
-    return m_hardwareProfile;
+    return hardwareProfile(QLatin1String(kLegacySerial));
 }
 
 void ProfileEngine::setDisplayProfile(const QString &name)
 {
-    if (m_displayProfile == name) return;
-    m_displayProfile = name;
-    emit displayProfileChanged(cachedProfile(name));
+    setDisplayProfile(QLatin1String(kLegacySerial), name);
 }
 
 void ProfileEngine::setHardwareProfile(const QString &name)
 {
-    if (m_hardwareProfile == name) return;
-    m_hardwareProfile = name;
-    emit hardwareProfileChanged(cachedProfile(name));
+    setHardwareProfile(QLatin1String(kLegacySerial), name);
 }
 
 void ProfileEngine::saveProfileToDisk(const QString &name)
 {
-    if (!m_cache.contains(name) || m_configDir.isEmpty()) return;
-    saveProfile(profilePath(name), m_cache[name]);
+    saveProfileToDisk(QLatin1String(kLegacySerial), name);
 }
 
-QString ProfileEngine::profileForApp(const QString &appId) const
+void ProfileEngine::createProfileForApp(const QString &wmClass,
+                                        const QString &profileName)
 {
-    // Simple case-insensitive lookup. The caller (KDeDesktop) is responsible
-    // for resolving window identity to a canonical app ID that matches
-    // .desktop file names used as binding keys.
-    for (auto it = m_appBindings.cbegin(); it != m_appBindings.cend(); ++it) {
-        if (it.key().compare(appId, Qt::CaseInsensitive) == 0)
-            return it.value();
-    }
-
-    return QStringLiteral("default");
+    createProfileForApp(QLatin1String(kLegacySerial), wmClass, profileName);
 }
 
-// ---------------------------------------------------------------------------
-// Private helpers
-// ---------------------------------------------------------------------------
-
-QString ProfileEngine::profilePath(const QString &name) const
+void ProfileEngine::removeAppProfile(const QString &wmClass)
 {
-    return m_configDir + "/" + name + ".conf";
+    removeAppProfile(QLatin1String(kLegacySerial), wmClass);
 }
 
-QString ProfileEngine::appBindingsPath() const
+QString ProfileEngine::profileForApp(const QString &wmClass) const
 {
-    return m_configDir + "/app-bindings.conf";
+    return profileForApp(QLatin1String(kLegacySerial), wmClass);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/ProfileEngine.cpp
+++ b/src/core/ProfileEngine.cpp
@@ -2,6 +2,7 @@
 #include "logging/LogManager.h"
 #include <QDir>
 #include <QFileInfo>
+#include <QStandardPaths>
 
 namespace logitune {
 
@@ -342,6 +343,61 @@ QString ProfileEngine::profilePath(const QString &name) const
 QString ProfileEngine::appBindingsPath() const
 {
     return m_configDir + "/app-bindings.conf";
+}
+
+// ---------------------------------------------------------------------------
+// Per-device contexts
+// ---------------------------------------------------------------------------
+
+DeviceProfileContext& ProfileEngine::ctx(const QString &serial)
+{
+    if (!m_byDevice.contains(serial)) {
+        qCWarning(lcProfile)
+            << "ProfileEngine: lazy-registering unknown device" << serial;
+        const QString defaultDir = QStandardPaths::writableLocation(
+            QStandardPaths::AppConfigLocation)
+            + "/devices/" + serial + "/profiles";
+        registerDevice(serial, defaultDir);
+    }
+    return m_byDevice[serial];
+}
+
+const DeviceProfileContext& ProfileEngine::ctx(const QString &serial) const
+{
+    static const DeviceProfileContext empty{};
+    auto it = m_byDevice.constFind(serial);
+    if (it == m_byDevice.constEnd())
+        return empty;
+    return *it;
+}
+
+void ProfileEngine::registerDevice(const QString &serial, const QString &configDir)
+{
+    DeviceProfileContext &c = m_byDevice[serial];
+    c.configDir = configDir;
+    c.cache.clear();
+    c.appBindings.clear();
+
+    QDir d(configDir);
+    if (!d.exists())
+        QDir().mkpath(configDir);
+
+    if (d.exists()) {
+        for (const auto &f : d.entryList({"*.conf"}, QDir::Files)) {
+            if (f == "app-bindings.conf") continue;
+            QString name = QFileInfo(f).baseName();
+            c.cache[name] = loadProfile(d.filePath(f));
+        }
+    }
+
+    const QString bindingsFile = configDir + "/app-bindings.conf";
+    if (QFileInfo::exists(bindingsFile))
+        c.appBindings = loadAppBindings(bindingsFile);
+}
+
+bool ProfileEngine::hasDevice(const QString &serial) const
+{
+    return m_byDevice.contains(serial);
 }
 
 } // namespace logitune

--- a/src/core/ProfileEngine.h
+++ b/src/core/ProfileEngine.h
@@ -70,6 +70,14 @@ public:
     QString hardwareProfile(const QString &serial) const;
     QString profileForApp(const QString &serial, const QString &wmClass) const;
 
+    void setDisplayProfile(const QString &serial, const QString &name);
+    void setHardwareProfile(const QString &serial, const QString &name);
+    void saveProfileToDisk(const QString &serial, const QString &name);
+    void createProfileForApp(const QString &serial,
+                             const QString &wmClass,
+                             const QString &profileName);
+    void removeAppProfile(const QString &serial, const QString &wmClass);
+
     // --- Profile cache (Task 1) ---
     Profile& cachedProfile(const QString &name);
     QString displayProfile() const;
@@ -82,6 +90,8 @@ public:
 signals:
     void displayProfileChanged(const Profile &profile);
     void hardwareProfileChanged(const Profile &profile);
+    void deviceDisplayProfileChanged(const QString &serial, const Profile &profile);
+    void deviceHardwareProfileChanged(const QString &serial, const Profile &profile);
 
 private:
     // Per-device contexts. Key is PhysicalDevice::deviceSerial(). Lazy-

--- a/src/core/ProfileEngine.h
+++ b/src/core/ProfileEngine.h
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QString>
 #include <QMap>
+#include <QHash>
 #include <QFileSystemWatcher>
 #include <QSettings>
 #include <array>
@@ -32,6 +33,14 @@ struct ProfileDelta {
     bool scrollChanged = false;
     bool buttonsChanged = false;
     bool gesturesChanged = false;
+};
+
+struct DeviceProfileContext {
+    QString configDir;
+    QMap<QString, Profile> cache;
+    QMap<QString, QString> appBindings;
+    QString displayProfile;
+    QString hardwareProfile;
 };
 
 class ProfileEngine : public QObject {
@@ -66,6 +75,16 @@ signals:
     void hardwareProfileChanged(const Profile &profile);
 
 private:
+    // Per-device contexts. Key is PhysicalDevice::deviceSerial(). Lazy-
+    // registered on first touch; persists for the life of the process.
+    QHash<QString, DeviceProfileContext> m_byDevice;
+
+    // Serial used by the legacy single-context API during migration.
+    static constexpr const char *kLegacySerial = "legacy";
+
+    DeviceProfileContext& ctx(const QString &serial);
+    const DeviceProfileContext& ctx(const QString &serial) const;
+
     QString m_configDir;
     QMap<QString, QString> m_appBindings;
     QMap<QString, Profile> m_cache;

--- a/src/core/ProfileEngine.h
+++ b/src/core/ProfileEngine.h
@@ -61,6 +61,9 @@ public:
     void createProfileForApp(const QString &wmClass, const QString &profileName);
     void removeAppProfile(const QString &wmClass);
 
+    void registerDevice(const QString &serial, const QString &configDir);
+    bool hasDevice(const QString &serial) const;
+
     // --- Profile cache (Task 1) ---
     Profile& cachedProfile(const QString &name);
     QString displayProfile() const;

--- a/src/core/ProfileEngine.h
+++ b/src/core/ProfileEngine.h
@@ -4,8 +4,6 @@
 #include <QString>
 #include <QMap>
 #include <QHash>
-#include <QFileSystemWatcher>
-#include <QSettings>
 #include <array>
 #include <map>
 
@@ -105,15 +103,6 @@ private:
     const DeviceProfileContext& ctx(const QString &serial) const;
 
     QString m_configDir;
-    QMap<QString, QString> m_appBindings;
-    QMap<QString, Profile> m_cache;
-    QString m_displayProfile;
-    QString m_hardwareProfile;
-    QFileSystemWatcher m_fileWatcher;
-    bool m_selfWrite = false;  // suppress reload during our own save
-
-    QString profilePath(const QString &name) const;
-    QString appBindingsPath() const;
 };
 
 } // namespace logitune

--- a/src/core/ProfileEngine.h
+++ b/src/core/ProfileEngine.h
@@ -64,6 +64,12 @@ public:
     void registerDevice(const QString &serial, const QString &configDir);
     bool hasDevice(const QString &serial) const;
 
+    Profile& cachedProfile(const QString &serial, const QString &name);
+    QStringList profileNames(const QString &serial) const;
+    QString displayProfile(const QString &serial) const;
+    QString hardwareProfile(const QString &serial) const;
+    QString profileForApp(const QString &serial, const QString &wmClass) const;
+
     // --- Profile cache (Task 1) ---
     Profile& cachedProfile(const QString &name);
     QString displayProfile() const;

--- a/src/core/ProfileEngine.h
+++ b/src/core/ProfileEngine.h
@@ -54,11 +54,6 @@ public:
     static ProfileDelta diff(const Profile &a, const Profile &b);
 
     // Instance methods
-    void setDeviceConfigDir(const QString &dir);
-    QStringList profileNames() const;
-    void createProfileForApp(const QString &wmClass, const QString &profileName);
-    void removeAppProfile(const QString &wmClass);
-
     void registerDevice(const QString &serial, const QString &configDir);
     bool hasDevice(const QString &serial) const;
 
@@ -76,18 +71,7 @@ public:
                              const QString &profileName);
     void removeAppProfile(const QString &serial, const QString &wmClass);
 
-    // --- Profile cache (Task 1) ---
-    Profile& cachedProfile(const QString &name);
-    QString displayProfile() const;
-    QString hardwareProfile() const;
-    void setDisplayProfile(const QString &name);
-    void setHardwareProfile(const QString &name);
-    void saveProfileToDisk(const QString &name);
-    QString profileForApp(const QString &wmClass) const;
-
 signals:
-    void displayProfileChanged(const Profile &profile);
-    void hardwareProfileChanged(const Profile &profile);
     void deviceDisplayProfileChanged(const QString &serial, const Profile &profile);
     void deviceHardwareProfileChanged(const QString &serial, const Profile &profile);
 
@@ -96,13 +80,8 @@ private:
     // registered on first touch; persists for the life of the process.
     QHash<QString, DeviceProfileContext> m_byDevice;
 
-    // Serial used by the legacy single-context API during migration.
-    static constexpr const char *kLegacySerial = "legacy";
-
     DeviceProfileContext& ctx(const QString &serial);
     const DeviceProfileContext& ctx(const QString &serial) const;
-
-    QString m_configDir;
 };
 
 } // namespace logitune

--- a/tests/helpers/AppControllerFixture.h
+++ b/tests/helpers/AppControllerFixture.h
@@ -22,6 +22,7 @@ class AppControllerFixture : public ::testing::Test {
 protected:
     void SetUp() override {
         ensureApp();
+        clearTestAppConfig();
         ASSERT_TRUE(m_tmpDir.isValid());
 
         m_desktop  = new MockDesktop();
@@ -66,10 +67,14 @@ protected:
         m_ctrl->onPhysicalDeviceAdded(m_physicalDevice);
 
         // setupProfileForDevice points the engine at AppConfigLocation
-        // (the real config dir), but tests need their temp dir. Re-register
-        // after the added flow runs so the cache reloads from m_profilesDir
-        // where the fixture wrote default.conf.
+        // (the real config dir, scoped to test mode). Tests need their
+        // temp dir instead, so re-register here and force a display
+        // profile refresh. setDisplayProfile short-circuits when the
+        // name matches its current value, so bounce through "" to make
+        // the engine re-emit with the freshly loaded cache values.
         m_ctrl->m_profileEngine.registerDevice(kSerial, m_profilesDir);
+        m_ctrl->m_profileEngine.setDisplayProfile(kSerial, QString());
+        m_ctrl->m_profileEngine.setHardwareProfile(kSerial, QString());
         m_ctrl->m_profileEngine.setDisplayProfile(kSerial, QStringLiteral("default"));
         m_ctrl->m_profileEngine.setHardwareProfile(kSerial, QStringLiteral("default"));
     }

--- a/tests/helpers/AppControllerFixture.h
+++ b/tests/helpers/AppControllerFixture.h
@@ -44,30 +44,34 @@ protected:
         defaultProfile.thumbWheelMode      = QStringLiteral("scroll");
         ProfileEngine::saveProfile(m_profilesDir + QStringLiteral("/default.conf"), defaultProfile);
 
-        m_ctrl->m_profileEngine.setDeviceConfigDir(m_profilesDir);
+        const QString kSerial = QStringLiteral("mock-serial");
 
         m_device.setupMxControls();
-        m_ctrl->m_currentDevice = &m_device;
 
-        // Create a mock DeviceSession wrapped in a PhysicalDevice and add it
-        // to the model so selectedSession()/selectedDevice() work.
         auto mockHidraw = std::make_unique<hidpp::HidrawDevice>("/dev/null");
         m_session = new DeviceSession(std::move(mockHidraw), 0xFF, "Bluetooth",
                                        nullptr, m_ctrl.get());
-        // Mark the mock session connected so DeviceModel shows its row.
-        // The real enumerateAndSetup would do this after reading state
-        // from the device; tests don't talk to real hardware.
         m_session->m_connected = true;
         m_session->m_deviceName = QStringLiteral("Mock Device");
+        // PhysicalDevice::descriptor() forwards to its primary session's
+        // descriptor(). onPhysicalDeviceAdded writes that into AppController's
+        // m_currentDevice, so the mock session must already know which
+        // IDevice it's backing before we drive the added flow.
+        m_session->m_activeDevice = &m_device;
 
-        m_physicalDevice = new PhysicalDevice(QStringLiteral("mock-serial"), m_ctrl.get());
+        m_physicalDevice = new PhysicalDevice(kSerial, m_ctrl.get());
         m_physicalDevice->attachTransport(m_session);
-        m_ctrl->m_deviceModel.addPhysicalDevice(m_physicalDevice);
-        m_ctrl->m_deviceModel.setSelectedIndex(0);
 
-        // Set profiles AFTER session selection (setSelectedIndex resets display values)
-        m_ctrl->m_profileEngine.setDisplayProfile(QStringLiteral("default"));
-        m_ctrl->m_profileEngine.setHardwareProfile(QStringLiteral("default"));
+        // Drive through the normal device-added flow.
+        m_ctrl->onPhysicalDeviceAdded(m_physicalDevice);
+
+        // setupProfileForDevice points the engine at AppConfigLocation
+        // (the real config dir), but tests need their temp dir. Re-register
+        // after the added flow runs so the cache reloads from m_profilesDir
+        // where the fixture wrote default.conf.
+        m_ctrl->m_profileEngine.registerDevice(kSerial, m_profilesDir);
+        m_ctrl->m_profileEngine.setDisplayProfile(kSerial, QStringLiteral("default"));
+        m_ctrl->m_profileEngine.setHardwareProfile(kSerial, QStringLiteral("default"));
     }
 
     void TearDown() override {
@@ -88,13 +92,14 @@ protected:
                           int dpi = 1000,
                           const QString &thumbMode = QStringLiteral("scroll"))
     {
-        Profile p = m_ctrl->m_profileEngine.cachedProfile(QStringLiteral("default"));
+        const QString kSerial = QStringLiteral("mock-serial");
+        Profile p = m_ctrl->m_profileEngine.cachedProfile(kSerial, QStringLiteral("default"));
         p.name           = profileName;
         p.dpi            = dpi;
         p.thumbWheelMode = thumbMode;
 
         ProfileEngine::saveProfile(m_profilesDir + "/" + profileName + ".conf", p);
-        m_ctrl->m_profileEngine.createProfileForApp(wmClass, profileName);
+        m_ctrl->m_profileEngine.createProfileForApp(kSerial, wmClass, profileName);
         m_ctrl->m_profileModel.restoreProfile(wmClass, profileName);
     }
 
@@ -108,7 +113,8 @@ protected:
                           const QString &scrollDirection = "standard",
                           bool hiResScroll = true)
     {
-        Profile p = m_ctrl->m_profileEngine.cachedProfile(QStringLiteral("default"));
+        const QString kSerial = QStringLiteral("mock-serial");
+        Profile p = m_ctrl->m_profileEngine.cachedProfile(kSerial, QStringLiteral("default"));
         p.name                = profileName;
         p.dpi                 = dpi;
         p.thumbWheelMode      = thumbMode;
@@ -118,32 +124,34 @@ protected:
         p.scrollDirection     = scrollDirection;
         p.hiResScroll         = hiResScroll;
 
-        m_ctrl->m_profileEngine.createProfileForApp(wmClass, profileName);
-        Profile &cached = m_ctrl->m_profileEngine.cachedProfile(profileName);
+        m_ctrl->m_profileEngine.createProfileForApp(kSerial, wmClass, profileName);
+        Profile &cached = m_ctrl->m_profileEngine.cachedProfile(kSerial, profileName);
         cached = p;
         ProfileEngine::saveProfile(m_profilesDir + "/" + profileName + ".conf", p);
         m_ctrl->m_profileModel.restoreProfile(wmClass, profileName);
     }
 
     void setProfileButton(const QString &profileName, int buttonIdx, const ButtonAction &action) {
-        Profile &p = m_ctrl->m_profileEngine.cachedProfile(profileName);
+        const QString kSerial = QStringLiteral("mock-serial");
+        Profile &p = m_ctrl->m_profileEngine.cachedProfile(kSerial, profileName);
         if (buttonIdx >= 0 && buttonIdx < static_cast<int>(p.buttons.size()))
             p.buttons[static_cast<std::size_t>(buttonIdx)] = action;
-        m_ctrl->m_profileEngine.saveProfileToDisk(profileName);
+        m_ctrl->m_profileEngine.saveProfileToDisk(kSerial, profileName);
     }
 
     void setProfileGesture(const QString &profileName,
                            const QString &direction,
                            const QString &keystroke)
     {
-        Profile &p = m_ctrl->m_profileEngine.cachedProfile(profileName);
+        const QString kSerial = QStringLiteral("mock-serial");
+        Profile &p = m_ctrl->m_profileEngine.cachedProfile(kSerial, profileName);
         p.gestures[direction] = ButtonAction{ButtonAction::Keystroke, keystroke};
-        m_ctrl->m_profileEngine.saveProfileToDisk(profileName);
+        m_ctrl->m_profileEngine.saveProfileToDisk(kSerial, profileName);
     }
 
     void focusApp(const QString &wmClass) {
         m_desktop->simulateFocus(wmClass, wmClass);
-        const QString hwProfile = m_ctrl->m_profileEngine.hardwareProfile();
+        const QString hwProfile = m_ctrl->m_profileEngine.hardwareProfile(QStringLiteral("mock-serial"));
         int hwIndex = 0;
         const int count = m_ctrl->m_profileModel.rowCount();
         for (int i = 0; i < count; ++i) {

--- a/tests/helpers/AppControllerFixture.h
+++ b/tests/helpers/AppControllerFixture.h
@@ -195,6 +195,47 @@ protected:
         m_ctrl->onThumbWheelRotation(delta);
     }
 
+    // Adds a second mock device and registers it through the normal flow.
+    // Returns the new PhysicalDevice for test-level manipulation.
+    PhysicalDevice* addMockDevice(const QString &serialSuffix,
+                                  int seedDpi = 1000) {
+        const QString serial = QStringLiteral("mock-serial-") + serialSuffix;
+        const QString devProfilesDir = m_tmpDir.path()
+            + "/" + serial + "/profiles";
+        QDir().mkpath(devProfilesDir);
+
+        Profile seed;
+        seed.name = QStringLiteral("Default");
+        seed.dpi  = seedDpi;
+        ProfileEngine::saveProfile(devProfilesDir + "/default.conf", seed);
+
+        m_ctrl->m_profileEngine.registerDevice(serial, devProfilesDir);
+
+        auto mockHidraw = std::make_unique<hidpp::HidrawDevice>("/dev/null");
+        auto *session = new DeviceSession(std::move(mockHidraw), 0xFF,
+                                          "Bluetooth", nullptr, m_ctrl.get());
+        session->m_connected = true;
+        session->m_deviceName = QStringLiteral("Mock Device ") + serialSuffix;
+        session->m_activeDevice = &m_device;  // reuse the fixture's MockDevice descriptor
+
+        auto *device = new PhysicalDevice(serial, m_ctrl.get());
+        device->attachTransport(session);
+
+        m_ctrl->onPhysicalDeviceAdded(device);
+
+        // Same bounce as SetUp: setupProfileForDevice wrote a stale
+        // default.conf into AppConfigLocation using the mock's zero DPI;
+        // re-register at our temp dir and force a display-profile emit
+        // with the properly seeded cache.
+        m_ctrl->m_profileEngine.registerDevice(serial, devProfilesDir);
+        m_ctrl->m_profileEngine.setDisplayProfile(serial, QString());
+        m_ctrl->m_profileEngine.setHardwareProfile(serial, QString());
+        m_ctrl->m_profileEngine.setDisplayProfile(serial, QStringLiteral("default"));
+        m_ctrl->m_profileEngine.setHardwareProfile(serial, QStringLiteral("default"));
+
+        return device;
+    }
+
     // -----------------------------------------------------------------------
     // Accessors
     // -----------------------------------------------------------------------

--- a/tests/helpers/TestFixtures.h
+++ b/tests/helpers/TestFixtures.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <gtest/gtest.h>
 #include <QCoreApplication>
+#include <QDir>
+#include <QStandardPaths>
 #include <QTemporaryDir>
 #include "ProfileEngine.h"
 
@@ -8,12 +10,26 @@ namespace logitune::test {
 
 /// Returns a static QCoreApplication, creating it on first call.
 /// Required for QSignalSpy and other Qt event-loop facilities in tests.
+/// Also enables QStandardPaths test mode so production code paths that
+/// write to AppConfigLocation (e.g. setupProfileForDevice) don't pollute
+/// the real user config.
 inline QCoreApplication *ensureApp() {
     static int argc = 0;
     static QCoreApplication *app = nullptr;
-    if (!app)
+    if (!app) {
+        QStandardPaths::setTestModeEnabled(true);
         app = new QCoreApplication(argc, nullptr);
+    }
     return app;
+}
+
+/// Wipes the AppConfigLocation subtree so tests that drive through
+/// setupProfileForDevice (which writes to AppConfigLocation) start from
+/// a clean slate. Must be called AFTER ensureApp() so test mode is on.
+inline void clearTestAppConfig() {
+    const QString dir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+    if (!dir.isEmpty())
+        QDir(dir).removeRecursively();
 }
 
 /// GTest fixture providing a temporary directory and a default Profile helper.

--- a/tests/test_app_controller.cpp
+++ b/tests/test_app_controller.cpp
@@ -467,3 +467,19 @@ TEST_F(AppControllerFixture, CarouselSwitchSwapsButtonModel) {
     EXPECT_EQ(buttonModel().actionTypeForButton(3),
               QStringLiteral("media-controls"));
 }
+
+TEST_F(AppControllerFixture, CarouselSwitchSwapsDisplayValues) {
+    // Fixture primary has DPI 1000 (seeded in SetUp).
+    deviceModel().setSelectedIndex(0);
+    EXPECT_EQ(deviceModel().currentDPI(), 1000);
+
+    auto *secondary = addMockDevice(QStringLiteral("B"), /*seedDpi=*/2500);
+
+    const int idxB = deviceModel().devices().indexOf(secondary);
+    ASSERT_GE(idxB, 0);
+    deviceModel().setSelectedIndex(idxB);
+    EXPECT_EQ(deviceModel().currentDPI(), 2500);
+
+    deviceModel().setSelectedIndex(0);
+    EXPECT_EQ(deviceModel().currentDPI(), 1000);
+}

--- a/tests/test_app_controller.cpp
+++ b/tests/test_app_controller.cpp
@@ -435,3 +435,35 @@ TEST_F(AppControllerFixture, MediaActionPerProfileSwitching) {
     EXPECT_TRUE(m_injector->hasCalled("injectKeystroke"));
     EXPECT_EQ(m_injector->lastArg("injectKeystroke"), "Next");
 }
+
+TEST_F(AppControllerFixture, CarouselSwitchSwapsButtonModel) {
+    // Fixture's primary device "mock-serial" is selected (index 0). Set
+    // its button 3 to a distinctive action.
+    setProfileButton("default", 3,
+                     {ButtonAction::Keystroke, QStringLiteral("Alt+Left")});
+    deviceModel().setSelectedIndex(0);
+
+    auto *secondary = addMockDevice(QStringLiteral("B"));
+    {
+        const QString serialB = QStringLiteral("mock-serial-B");
+        Profile &pB = profileEngine().cachedProfile(
+            serialB, QStringLiteral("default"));
+        pB.buttons[3] = {ButtonAction::Media, QStringLiteral("Play")};
+        profileEngine().saveProfileToDisk(
+            serialB, QStringLiteral("default"));
+    }
+
+    // Select device A explicitly and confirm ButtonModel reflects A.
+    deviceModel().setSelectedIndex(0);
+    EXPECT_EQ(buttonModel().actionTypeForButton(3),
+              QStringLiteral("keystroke"));
+
+    // Switch carousel to device B.
+    const int idxB = deviceModel().devices().indexOf(secondary);
+    ASSERT_GE(idxB, 0);
+    deviceModel().setSelectedIndex(idxB);
+
+    // ButtonModel now reflects device B.
+    EXPECT_EQ(buttonModel().actionTypeForButton(3),
+              QStringLiteral("media-controls"));
+}

--- a/tests/test_app_controller.cpp
+++ b/tests/test_app_controller.cpp
@@ -10,8 +10,8 @@ using namespace logitune::test;
 
 TEST_F(AppControllerFixture, Smoke) {
     EXPECT_NE(m_ctrl.get(), nullptr);
-    EXPECT_EQ(profileEngine().displayProfile(), "default");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "default");
+    EXPECT_EQ(profileEngine().displayProfile(QStringLiteral("mock-serial")), "default");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "default");
 }
 
 // =============================================================================
@@ -24,26 +24,26 @@ TEST_F(AppControllerFixture, FocusAppWithProfileSwitchesHardware) {
 
     focusApp("google-chrome");
 
-    EXPECT_EQ(profileEngine().hardwareProfile(), "Chrome");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "Chrome");
 }
 
 TEST_F(AppControllerFixture, FocusAppWithoutProfileSwitchesToDefault) {
     // No profile for "firefox" — should stay on default
     focusApp("firefox");
 
-    EXPECT_EQ(profileEngine().hardwareProfile(), "default");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "default");
 }
 
 TEST_F(AppControllerFixture, FocusSameAppTwiceNoDoubleApply) {
     createAppProfile("google-chrome", "Chrome", 1600);
 
     focusApp("google-chrome");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "Chrome");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "Chrome");
 
     // Focus same app again — hardware profile already "Chrome", should be a no-op.
     // We verify by checking that profileForApp still returns "Chrome" and no crash.
     focusApp("google-chrome");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "Chrome");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "Chrome");
 }
 
 TEST_F(AppControllerFixture, DesktopComponentsFiltered) {
@@ -52,13 +52,13 @@ TEST_F(AppControllerFixture, DesktopComponentsFiltered) {
     focusApp("org.kde.plasmashell");
 
     // plasmashell is in the ignore list — hardware profile must NOT change
-    EXPECT_EQ(profileEngine().hardwareProfile(), "default");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "default");
 }
 
 TEST_F(AppControllerFixture, KwinWaylandFiltered) {
     focusApp("kwin_wayland");
 
-    EXPECT_EQ(profileEngine().hardwareProfile(), "default");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "default");
 }
 
 TEST_F(AppControllerFixture, FocusUpdatesHwIndicator) {
@@ -80,14 +80,14 @@ TEST_F(AppControllerFixture, TabSwitchChangesDisplayNotHardware) {
 
     // Focus Chrome so hardware is on Chrome
     focusApp("google-chrome");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "Chrome");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "Chrome");
 
     // User clicks the default tab (index 0)
     profileModel().selectTab(0);
 
     // Display should be default, but hardware stays on Chrome
-    EXPECT_EQ(profileEngine().displayProfile(), "default");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "Chrome");
+    EXPECT_EQ(profileEngine().displayProfile(QStringLiteral("mock-serial")), "default");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "Chrome");
 }
 
 TEST_F(AppControllerFixture, TabSwitchPushesDisplayValues) {
@@ -107,14 +107,14 @@ TEST_F(AppControllerFixture, SettingsSaveToDisplayedProfile) {
     createAppProfile("google-chrome", "Chrome", 1600);
 
     // Display Chrome profile
-    profileEngine().setDisplayProfile("Chrome");
+    profileEngine().setDisplayProfile(QStringLiteral("mock-serial"), "Chrome");
 
     // Set a button action on button 3 (Back) via ButtonModel — simulates UI action
     buttonModel().setAction(3, "Copy", "keystroke");
 
     // Trigger save via saveCurrentProfile (this is what happens after userActionChanged)
     // The action should be saved to the Chrome profile
-    Profile &chromeP = profileEngine().cachedProfile("Chrome");
+    Profile &chromeP = profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Chrome");
     // After save, the Chrome profile should reflect the displayed edit
     // Note: saveCurrentProfile writes from ButtonModel to the displayed profile.
     // buttonModel().setAction emits userActionChanged -> onUserButtonChanged -> saveCurrentProfile
@@ -131,13 +131,13 @@ TEST_F(AppControllerFixture, SettingsDontSaveToOtherProfile) {
     focusApp("google-chrome");
     profileModel().selectTab(0); // switch display to default
 
-    EXPECT_EQ(profileEngine().displayProfile(), "default");
+    EXPECT_EQ(profileEngine().displayProfile(QStringLiteral("mock-serial")), "default");
 
     // Change a button on displayed (default) profile
     buttonModel().setAction(3, "Paste", "keystroke");
 
     // Chrome profile button 3 should still be Alt+Left, not Paste
-    const Profile &chromeP = profileEngine().cachedProfile("Chrome");
+    const Profile &chromeP = profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Chrome");
     EXPECT_EQ(chromeP.buttons[3].type, ButtonAction::Keystroke);
     EXPECT_EQ(chromeP.buttons[3].payload, "Alt+Left");
 }
@@ -167,8 +167,8 @@ TEST_F(AppControllerFixture, DispatchReadsHwNotDisplayProfile) {
 
     // User switches display tab to default
     profileModel().selectTab(0);
-    EXPECT_EQ(profileEngine().displayProfile(), "default");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "Chrome");
+    EXPECT_EQ(profileEngine().displayProfile(QStringLiteral("mock-serial")), "default");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "Chrome");
 
     // Press button 3 — should dispatch Chrome's action (Alt+Left), not default's
     pressButton(0x53);
@@ -314,11 +314,11 @@ TEST_F(AppControllerFixture, GestureUsesHardwareProfileGestures) {
 
     // Focus Chrome — hardware profile is now Chrome
     focusApp("google-chrome");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "Chrome");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "Chrome");
 
     // Switch display to default
     profileModel().selectTab(0);
-    EXPECT_EQ(profileEngine().displayProfile(), "default");
+    EXPECT_EQ(profileEngine().displayProfile(QStringLiteral("mock-serial")), "default");
 
     // Gesture right — should use Chrome's (hardware) gesture, not default's (display)
     pressButton(0xC3);

--- a/tests/test_app_controller.cpp
+++ b/tests/test_app_controller.cpp
@@ -483,3 +483,28 @@ TEST_F(AppControllerFixture, CarouselSwitchSwapsDisplayValues) {
     deviceModel().setSelectedIndex(0);
     EXPECT_EQ(deviceModel().currentDPI(), 1000);
 }
+
+TEST_F(AppControllerFixture, DisplayProfileChangedIgnoredForNonSelectedDevice) {
+    deviceModel().setSelectedIndex(0);
+    EXPECT_EQ(deviceModel().currentDPI(), 1000);
+
+    // Add a second device without switching to it. Primary stays selected.
+    addMockDevice(QStringLiteral("B"), /*seedDpi=*/2500);
+    EXPECT_EQ(deviceModel().selectedIndex(), 0);
+
+    // Modify device B's cached profile and fire its displayProfile signal.
+    // setDisplayProfile short-circuits on unchanged name, so bounce through
+    // an intermediate value to force emission.
+    const QString serialB = QStringLiteral("mock-serial-B");
+    Profile &pB = profileEngine().cachedProfile(
+        serialB, QStringLiteral("default"));
+    pB.dpi = 9999;
+    profileEngine().setDisplayProfile(
+        serialB, QStringLiteral("other"));
+    profileEngine().setDisplayProfile(
+        serialB, QStringLiteral("default"));
+
+    // DeviceModel should still reflect device A's 1000 DPI — the
+    // onDisplayProfileChanged filter rejected device B's signal.
+    EXPECT_EQ(deviceModel().currentDPI(), 1000);
+}

--- a/tests/test_device_reconnect.cpp
+++ b/tests/test_device_reconnect.cpp
@@ -7,17 +7,17 @@ using namespace logitune::test;
 
 TEST_F(AppControllerFixture, FirstConnectSetsDefaultProfile) {
     // Fresh controller — hw profile should be "default" after setup
-    EXPECT_EQ(profileEngine().hardwareProfile(), "default");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "default");
 }
 
 TEST_F(AppControllerFixture, ReconnectPreservesHwProfile) {
     createAppProfile("google-chrome", "Google Chrome", 2000, "zoom");
     focusApp("google-chrome");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "Google Chrome");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "Google Chrome");
 
     // Simulate reconnect: onDeviceSetupComplete re-runs
     // The hw profile should stay "Google Chrome", not reset to "default"
-    QString hwBefore = profileEngine().hardwareProfile();
+    QString hwBefore = profileEngine().hardwareProfile(QStringLiteral("mock-serial"));
 
     // We can't fully simulate onDeviceSetupComplete without DeviceManager,
     // but we can verify the logic: if hwProfile is non-empty, it should be preserved
@@ -35,13 +35,13 @@ TEST(DeviceReconnect, HwProfileEmptyOnFirstConnect) {
 TEST_F(AppControllerFixture, ProfileDataIntactAcrossReconnect) {
     createAppProfile("google-chrome", "Google Chrome");
     // Explicitly set dpi and thumbWheelMode in the cache (createAppProfile copies from default)
-    profileEngine().cachedProfile("Google Chrome").dpi = 2000;
-    profileEngine().cachedProfile("Google Chrome").thumbWheelMode = "zoom";
+    profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Google Chrome").dpi = 2000;
+    profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Google Chrome").thumbWheelMode = "zoom";
     setProfileButton("Google Chrome", 3, {ButtonAction::Keystroke, "Alt+Left"});
     focusApp("google-chrome");
 
     // Verify profile data is intact
-    auto &p = profileEngine().cachedProfile("Google Chrome");
+    auto &p = profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Google Chrome");
     EXPECT_EQ(p.dpi, 2000);
     EXPECT_EQ(p.thumbWheelMode, "zoom");
     EXPECT_EQ(p.buttons[3].type, ButtonAction::Keystroke);

--- a/tests/test_device_reconnect.cpp
+++ b/tests/test_device_reconnect.cpp
@@ -29,7 +29,7 @@ TEST_F(AppControllerFixture, ReconnectPreservesHwProfile) {
 // This mirrors the state of AppController before device setup completes.
 TEST(DeviceReconnect, HwProfileEmptyOnFirstConnect) {
     ProfileEngine engine;
-    EXPECT_TRUE(engine.hardwareProfile().isEmpty());
+    EXPECT_TRUE(engine.hardwareProfile(QStringLiteral("mock-serial")).isEmpty());
 }
 
 TEST_F(AppControllerFixture, ProfileDataIntactAcrossReconnect) {

--- a/tests/test_profile_apply_behavior.cpp
+++ b/tests/test_profile_apply_behavior.cpp
@@ -32,7 +32,7 @@ TEST_F(ProfileApplyBehaviorTest, NonConfigurableButtonsAreSkippedDuringProfileAp
     focusApp("firefox");
 
     // Verify profile was applied (DPI changed = hardware profile switched)
-    EXPECT_EQ(profileEngine().hardwareProfile(), "Firefox");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "Firefox");
 }
 
 TEST_F(ProfileApplyBehaviorTest, ConfigurableButtonsStillDivertedWhenNonConfigExist) {
@@ -44,11 +44,11 @@ TEST_F(ProfileApplyBehaviorTest, ConfigurableButtonsStillDivertedWhenNonConfigEx
     setProfileButton("VSCode", 2, {ButtonAction::Keystroke, "Ctrl+Z"});
 
     focusApp("code");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "VSCode");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "VSCode");
 
     // Switching back to default should also work
     focusApp("some-other-app");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "default");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "default");
 }
 
 // ---------------------------------------------------------------------------
@@ -94,17 +94,17 @@ TEST_F(ProfileApplyBehaviorTest, ProfileSwitchDoesNotAccumulateStaleState) {
 
     // Rapidly switch between profiles
     focusApp("firefox");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "Firefox");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "Firefox");
 
     focusApp("code");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "VSCode");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "VSCode");
 
     focusApp("firefox");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "Firefox");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "Firefox");
 
     // Final state should be clean — no stale profile lingering
     focusApp("some-other-app");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "default");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "default");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test_profile_engine.cpp
+++ b/tests/test_profile_engine.cpp
@@ -259,3 +259,53 @@ TEST(ProfileEngine, DeltaNoDiff) {
     EXPECT_FALSE(delta.buttonsChanged);
     EXPECT_FALSE(delta.gesturesChanged);
 }
+
+// --- Per-device contexts ---
+
+TEST(ProfileEngine, MultipleDevicesKeepSeparateCaches) {
+    QTemporaryDir tmpA, tmpB;
+    ASSERT_TRUE(tmpA.isValid());
+    ASSERT_TRUE(tmpB.isValid());
+
+    logitune::ProfileEngine eng;
+    eng.registerDevice(QStringLiteral("A"), tmpA.path());
+    eng.registerDevice(QStringLiteral("B"), tmpB.path());
+
+    auto &pa = eng.cachedProfile(QStringLiteral("A"), QStringLiteral("default"));
+    auto &pb = eng.cachedProfile(QStringLiteral("B"), QStringLiteral("default"));
+
+    pa.dpi = 1234;
+    pb.dpi = 5678;
+
+    EXPECT_EQ(eng.cachedProfile(QStringLiteral("A"),
+                                QStringLiteral("default")).dpi, 1234);
+    EXPECT_EQ(eng.cachedProfile(QStringLiteral("B"),
+                                QStringLiteral("default")).dpi, 5678);
+}
+
+TEST(ProfileEngine, UnknownDeviceLazyRegisters) {
+    logitune::ProfileEngine eng;
+    EXPECT_FALSE(eng.hasDevice(QStringLiteral("ghost")));
+
+    auto &p = eng.cachedProfile(QStringLiteral("ghost"),
+                                QStringLiteral("default"));
+    EXPECT_EQ(p.dpi, 1000);
+    EXPECT_EQ(p.name, QStringLiteral("default"));
+    EXPECT_TRUE(eng.hasDevice(QStringLiteral("ghost")));
+}
+
+TEST(ProfileEngine, SetDisplayProfileScopedToDevice) {
+    QTemporaryDir tmpA, tmpB;
+    ASSERT_TRUE(tmpA.isValid());
+    ASSERT_TRUE(tmpB.isValid());
+
+    logitune::ProfileEngine eng;
+    eng.registerDevice(QStringLiteral("A"), tmpA.path());
+    eng.registerDevice(QStringLiteral("B"), tmpB.path());
+
+    eng.setDisplayProfile(QStringLiteral("A"), QStringLiteral("chrome"));
+
+    EXPECT_EQ(eng.displayProfile(QStringLiteral("A")),
+              QStringLiteral("chrome"));
+    EXPECT_EQ(eng.displayProfile(QStringLiteral("B")), QString());
+}

--- a/tests/test_profile_engine.cpp
+++ b/tests/test_profile_engine.cpp
@@ -271,11 +271,8 @@ TEST(ProfileEngine, MultipleDevicesKeepSeparateCaches) {
     eng.registerDevice(QStringLiteral("A"), tmpA.path());
     eng.registerDevice(QStringLiteral("B"), tmpB.path());
 
-    auto &pa = eng.cachedProfile(QStringLiteral("A"), QStringLiteral("default"));
-    auto &pb = eng.cachedProfile(QStringLiteral("B"), QStringLiteral("default"));
-
-    pa.dpi = 1234;
-    pb.dpi = 5678;
+    eng.cachedProfile(QStringLiteral("A"), QStringLiteral("default")).dpi = 1234;
+    eng.cachedProfile(QStringLiteral("B"), QStringLiteral("default")).dpi = 5678;
 
     EXPECT_EQ(eng.cachedProfile(QStringLiteral("A"),
                                 QStringLiteral("default")).dpi, 1234);

--- a/tests/test_profile_persistence.cpp
+++ b/tests/test_profile_persistence.cpp
@@ -94,54 +94,58 @@ TEST_F(ProfilePersistenceTest, MissingFileReturnsDefaults) {
 }
 
 TEST_F(ProfilePersistenceTest, CreateProfileSavesToDisk) {
+    const QString kSerial = QStringLiteral("test-serial");
     ProfileEngine engine;
     Profile def = makeDefaultProfile();
     ProfileEngine::saveProfile(tmpPath() + "/default.conf", def);
-    engine.setDeviceConfigDir(tmpPath());
+    engine.registerDevice(kSerial, tmpPath());
 
-    engine.createProfileForApp("google-chrome", "Google Chrome");
+    engine.createProfileForApp(kSerial, "google-chrome", "Google Chrome");
 
     EXPECT_TRUE(QFile::exists(tmpPath() + "/Google Chrome.conf"));
 }
 
 TEST_F(ProfilePersistenceTest, RemoveProfileDeletesFile) {
+    const QString kSerial = QStringLiteral("test-serial");
     ProfileEngine engine;
     Profile def = makeDefaultProfile();
     ProfileEngine::saveProfile(tmpPath() + "/default.conf", def);
-    engine.setDeviceConfigDir(tmpPath());
+    engine.registerDevice(kSerial, tmpPath());
 
-    engine.createProfileForApp("google-chrome", "Google Chrome");
+    engine.createProfileForApp(kSerial, "google-chrome", "Google Chrome");
     EXPECT_TRUE(QFile::exists(tmpPath() + "/Google Chrome.conf"));
 
-    engine.removeAppProfile("google-chrome");
+    engine.removeAppProfile(kSerial, "google-chrome");
     EXPECT_FALSE(QFile::exists(tmpPath() + "/Google Chrome.conf"));
 }
 
 TEST_F(ProfilePersistenceTest, SaveProfileToDiskWritesCache) {
+    const QString kSerial = QStringLiteral("test-serial");
     ProfileEngine engine;
     Profile def = makeDefaultProfile();
     ProfileEngine::saveProfile(tmpPath() + "/default.conf", def);
-    engine.setDeviceConfigDir(tmpPath());
+    engine.registerDevice(kSerial, tmpPath());
 
-    auto &p = engine.cachedProfile("default");
+    auto &p = engine.cachedProfile(kSerial, "default");
     p.dpi = 3200;
-    engine.saveProfileToDisk("default");
+    engine.saveProfileToDisk(kSerial, "default");
 
     // Reload from disk and verify
     Profile reloaded = ProfileEngine::loadProfile(tmpPath() + "/default.conf");
     EXPECT_EQ(reloaded.dpi, 3200);
 }
 
-TEST_F(ProfilePersistenceTest, SetDeviceConfigDirLoadsAllProfiles) {
+TEST_F(ProfilePersistenceTest, RegisterDeviceLoadsAllProfiles) {
     // Create two profile files on disk
     Profile p1 = makeDefaultProfile(); p1.name = "default"; p1.dpi = 1000;
     Profile p2 = makeDefaultProfile(); p2.name = "Chrome"; p2.dpi = 2000;
     ProfileEngine::saveProfile(tmpPath() + "/default.conf", p1);
     ProfileEngine::saveProfile(tmpPath() + "/Chrome.conf", p2);
 
+    const QString kSerial = QStringLiteral("test-serial");
     ProfileEngine engine;
-    engine.setDeviceConfigDir(tmpPath());
+    engine.registerDevice(kSerial, tmpPath());
 
-    EXPECT_EQ(engine.cachedProfile("default").dpi, 1000);
-    EXPECT_EQ(engine.cachedProfile("Chrome").dpi, 2000);
+    EXPECT_EQ(engine.cachedProfile(kSerial, "default").dpi, 1000);
+    EXPECT_EQ(engine.cachedProfile(kSerial, "Chrome").dpi, 2000);
 }

--- a/tests/test_profile_switching.cpp
+++ b/tests/test_profile_switching.cpp
@@ -9,25 +9,25 @@ using namespace logitune::test;
 TEST_F(AppControllerFixture, CreateProfileDoesNotOverwriteExisting) {
     createAppProfile("google-chrome", "Google Chrome", 2000);
     // Modify the profile
-    profileEngine().cachedProfile("Google Chrome").dpi = 3000;
+    profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Google Chrome").dpi = 3000;
     // Re-create — should NOT overwrite
-    profileEngine().createProfileForApp("google-chrome", "Google Chrome");
-    EXPECT_EQ(profileEngine().cachedProfile("Google Chrome").dpi, 3000);
+    profileEngine().createProfileForApp(QStringLiteral("mock-serial"), "google-chrome", "Google Chrome");
+    EXPECT_EQ(profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Google Chrome").dpi, 3000);
 }
 
 TEST_F(AppControllerFixture, NewProfileCopiesFromDefault) {
-    profileEngine().cachedProfile("default").dpi = 1500;
-    profileEngine().createProfileForApp("firefox", "Firefox");
-    EXPECT_EQ(profileEngine().cachedProfile("Firefox").dpi, 1500);
+    profileEngine().cachedProfile(QStringLiteral("mock-serial"), "default").dpi = 1500;
+    profileEngine().createProfileForApp(QStringLiteral("mock-serial"), "firefox", "Firefox");
+    EXPECT_EQ(profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Firefox").dpi, 1500);
 }
 
 TEST_F(AppControllerFixture, RestoreProfileDoesNotTriggerCreate) {
     // Create Chrome profile, then manually set a custom DPI in the cache
     createAppProfile("google-chrome", "Google Chrome");
-    profileEngine().cachedProfile("Google Chrome").dpi = 2500;
+    profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Google Chrome").dpi = 2500;
     // Simulate startup restore — should NOT overwrite the cache
     profileModel().restoreProfile("google-chrome", "Google Chrome");
-    EXPECT_EQ(profileEngine().cachedProfile("Google Chrome").dpi, 2500);
+    EXPECT_EQ(profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Google Chrome").dpi, 2500);
 }
 
 // --- Profile isolation ---
@@ -37,17 +37,17 @@ TEST_F(AppControllerFixture, ProfilesAreIndependent) {
     createAppProfile("org.kde.dolphin", "Dolphin", 1000);
 
     // Change Chrome's DPI
-    profileEngine().cachedProfile("Google Chrome").dpi = 2000;
+    profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Google Chrome").dpi = 2000;
     // Dolphin should be unaffected
-    EXPECT_EQ(profileEngine().cachedProfile("Dolphin").dpi, 1000);
+    EXPECT_EQ(profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Dolphin").dpi, 1000);
 }
 
 TEST_F(AppControllerFixture, DisplayAndHardwareCanDiffer) {
     createAppProfile("google-chrome", "Google Chrome", 2000);
     focusApp("google-chrome"); // hw = Chrome
     profileModel().selectTab(0); // display = default
-    EXPECT_EQ(profileEngine().displayProfile(), "default");
-    EXPECT_EQ(profileEngine().hardwareProfile(), "Google Chrome");
+    EXPECT_EQ(profileEngine().displayProfile(QStringLiteral("mock-serial")), "default");
+    EXPECT_EQ(profileEngine().hardwareProfile(QStringLiteral("mock-serial")), "Google Chrome");
     EXPECT_EQ(deviceModel().currentDPI(), 1000); // display shows default's DPI
 }
 
@@ -55,16 +55,16 @@ TEST_F(AppControllerFixture, DpiChangeSavesToDisplayedProfile) {
     createAppProfile("google-chrome", "Google Chrome");
     profileModel().selectTab(1); // display Chrome
     deviceModel().setDPI(2400);
-    EXPECT_EQ(profileEngine().cachedProfile("Google Chrome").dpi, 2400);
-    EXPECT_EQ(profileEngine().cachedProfile("default").dpi, 1000); // unchanged
+    EXPECT_EQ(profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Google Chrome").dpi, 2400);
+    EXPECT_EQ(profileEngine().cachedProfile(QStringLiteral("mock-serial"), "default").dpi, 1000); // unchanged
 }
 
 TEST_F(AppControllerFixture, ThumbWheelModeSavesToDisplayedProfile) {
     createAppProfile("google-chrome", "Google Chrome");
     profileModel().selectTab(1);
     deviceModel().setThumbWheelMode("zoom");
-    EXPECT_EQ(profileEngine().cachedProfile("Google Chrome").thumbWheelMode, "zoom");
-    EXPECT_EQ(profileEngine().cachedProfile("default").thumbWheelMode, "scroll");
+    EXPECT_EQ(profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Google Chrome").thumbWheelMode, "zoom");
+    EXPECT_EQ(profileEngine().cachedProfile(QStringLiteral("mock-serial"), "default").thumbWheelMode, "scroll");
 }
 
 // --- Profile removal ---
@@ -78,8 +78,8 @@ TEST_F(AppControllerFixture, RemoveProfileFallsToDefault) {
 
 TEST_F(AppControllerFixture, RemovedProfileWmClassResolvesToDefault) {
     createAppProfile("google-chrome", "Google Chrome");
-    profileEngine().removeAppProfile("google-chrome");
-    EXPECT_EQ(profileEngine().profileForApp("google-chrome"), "default");
+    profileEngine().removeAppProfile(QStringLiteral("mock-serial"), "google-chrome");
+    EXPECT_EQ(profileEngine().profileForApp(QStringLiteral("mock-serial"), "google-chrome"), "default");
 }
 
 // --- Focus + profile interaction ---
@@ -96,5 +96,5 @@ TEST_F(AppControllerFixture, FocusAfterProfileChangeAppliesNewSettings) {
     focusApp("kitty");
     focusApp("google-chrome");
 
-    EXPECT_EQ(profileEngine().cachedProfile("Google Chrome").thumbWheelMode, "zoom");
+    EXPECT_EQ(profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Google Chrome").thumbWheelMode, "zoom");
 }

--- a/tests/test_settings_change_behavior.cpp
+++ b/tests/test_settings_change_behavior.cpp
@@ -12,17 +12,17 @@ TEST_F(AppControllerFixture, DpiChangeSavesToDisplayedProfileOnly) {
 
     deviceModel().setDPI(2000);
 
-    Profile &chrome = profileEngine().cachedProfile("Chrome");
+    Profile &chrome = profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Chrome");
     EXPECT_EQ(chrome.dpi, 2000);
 
-    Profile &def = profileEngine().cachedProfile("default");
+    Profile &def = profileEngine().cachedProfile(QStringLiteral("mock-serial"), "default");
     EXPECT_EQ(def.dpi, 1000);  // unchanged
 }
 
 TEST_F(AppControllerFixture, SmartShiftToggleSavesAndUpdatesDisplay) {
     deviceModel().setSmartShift(false, 50);
 
-    Profile &def = profileEngine().cachedProfile("default");
+    Profile &def = profileEngine().cachedProfile(QStringLiteral("mock-serial"), "default");
     EXPECT_FALSE(def.smartShiftEnabled);
     EXPECT_EQ(def.smartShiftThreshold, 50);
 
@@ -33,7 +33,7 @@ TEST_F(AppControllerFixture, SmartShiftToggleSavesAndUpdatesDisplay) {
 TEST_F(AppControllerFixture, ScrollDirectionChangeSaves) {
     deviceModel().setScrollConfig(true, true);  // hiRes=true, invert=true (natural)
 
-    Profile &def = profileEngine().cachedProfile("default");
+    Profile &def = profileEngine().cachedProfile(QStringLiteral("mock-serial"), "default");
     EXPECT_EQ(def.scrollDirection, "natural");
     EXPECT_TRUE(def.hiResScroll);
 }
@@ -41,7 +41,7 @@ TEST_F(AppControllerFixture, ScrollDirectionChangeSaves) {
 TEST_F(AppControllerFixture, ThumbWheelInvertChangeSaves) {
     deviceModel().setThumbWheelInvert(true);
 
-    Profile &def = profileEngine().cachedProfile("default");
+    Profile &def = profileEngine().cachedProfile(QStringLiteral("mock-serial"), "default");
     EXPECT_TRUE(def.thumbWheelInvert);
     EXPECT_TRUE(deviceModel().thumbWheelInvert());
 }
@@ -51,6 +51,6 @@ TEST_F(AppControllerFixture, ThumbWheelInvertDoesNotAffectOtherProfile) {
 
     deviceModel().setThumbWheelInvert(true);
 
-    Profile &chrome = profileEngine().cachedProfile("Chrome");
+    Profile &chrome = profileEngine().cachedProfile(QStringLiteral("mock-serial"), "Chrome");
     EXPECT_FALSE(chrome.thumbWheelInvert);
 }

--- a/tests/test_wmclass_resolution.cpp
+++ b/tests/test_wmclass_resolution.cpp
@@ -15,80 +15,81 @@ protected:
         ProfileFixture::SetUp();
         m_profilesDir = tmpPath();
 
-        // Write default profile to disk so setDeviceConfigDir picks it up
+        // Write default profile to disk so registerDevice picks it up
         Profile def = makeDefaultProfile();
         ProfileEngine::saveProfile(m_profilesDir + "/default.conf", def);
 
-        m_engine.setDeviceConfigDir(m_profilesDir);
+        m_engine.registerDevice(kSerial, m_profilesDir);
 
         // Set up two app bindings for most tests
-        m_engine.createProfileForApp("google-chrome", "Google Chrome");
-        m_engine.createProfileForApp("dolphin", "Dolphin");
+        m_engine.createProfileForApp(kSerial, "google-chrome", "Google Chrome");
+        m_engine.createProfileForApp(kSerial, "dolphin", "Dolphin");
     }
 
     ProfileEngine m_engine;
     QString m_profilesDir;
+    const QString kSerial = QStringLiteral("test-serial");
 };
 
 // ExactMatch — binding stored under exact key resolves correctly
 TEST_F(WmClassTest, ExactMatch) {
-    EXPECT_EQ(m_engine.profileForApp("google-chrome"), "Google Chrome");
+    EXPECT_EQ(m_engine.profileForApp(kSerial, "google-chrome"), "Google Chrome");
 }
 
 // CaseInsensitive — lookup is case-insensitive on the wmClass key
 TEST_F(WmClassTest, CaseInsensitive) {
-    EXPECT_EQ(m_engine.profileForApp("Google-Chrome"), "Google Chrome");
+    EXPECT_EQ(m_engine.profileForApp(kSerial, "Google-Chrome"), "Google Chrome");
 }
 
 // No fallback — "org.kde.dolphin" does NOT match binding "dolphin".
 // Identity resolution (short-class matching) is handled by KDeDesktop, not ProfileEngine.
 TEST_F(WmClassTest, NoShortClassFallbackInProfileEngine) {
-    EXPECT_EQ(m_engine.profileForApp("org.kde.dolphin"), "default");
+    EXPECT_EQ(m_engine.profileForApp(kSerial, "org.kde.dolphin"), "default");
 }
 
 // NoMatchReturnsDefault — unknown wmClass returns "default"
 TEST_F(WmClassTest, NoMatchReturnsDefault) {
-    EXPECT_EQ(m_engine.profileForApp("firefox"), "default");
+    EXPECT_EQ(m_engine.profileForApp(kSerial, "firefox"), "default");
 }
 
 // EmptyReturnsDefault — empty wmClass returns "default"
 TEST_F(WmClassTest, EmptyReturnsDefault) {
-    EXPECT_EQ(m_engine.profileForApp(""), "default");
+    EXPECT_EQ(m_engine.profileForApp(kSerial, ""), "default");
 }
 
 // ShortClassNoFalseMatch — "org.kde.something" does not match "dolphin" binding
 TEST_F(WmClassTest, ShortClassNoFalseMatch) {
-    EXPECT_EQ(m_engine.profileForApp("org.kde.something"), "default");
+    EXPECT_EQ(m_engine.profileForApp(kSerial, "org.kde.something"), "default");
 }
 
 // MultipleBindingsCorrectOne — both chrome and dolphin resolve to their own profiles
 TEST_F(WmClassTest, MultipleBindingsCorrectOne) {
-    EXPECT_EQ(m_engine.profileForApp("google-chrome"), "Google Chrome");
-    EXPECT_EQ(m_engine.profileForApp("dolphin"), "Dolphin");
+    EXPECT_EQ(m_engine.profileForApp(kSerial, "google-chrome"), "Google Chrome");
+    EXPECT_EQ(m_engine.profileForApp(kSerial, "dolphin"), "Dolphin");
 }
 
 // No short-class fallback — identity resolution moved to KDeDesktop
 TEST_F(WmClassTest, NoShortClassCaseInsensitiveFallback) {
-    EXPECT_EQ(m_engine.profileForApp("org.KDE.Dolphin"), "default");
+    EXPECT_EQ(m_engine.profileForApp(kSerial, "org.KDE.Dolphin"), "default");
 }
 
 // CreateProfileForAppGuard — modifying a cached profile's DPI and re-calling
 // createProfileForApp must NOT reset the cached profile (guard prevents overwrite)
 TEST_F(WmClassTest, CreateProfileForAppGuard) {
     // Mutate the cached "Google Chrome" profile
-    m_engine.cachedProfile("Google Chrome").dpi = 4000;
+    m_engine.cachedProfile(kSerial, "Google Chrome").dpi = 4000;
 
     // Call createProfileForApp again — should be a no-op for the profile itself
-    m_engine.createProfileForApp("google-chrome", "Google Chrome");
+    m_engine.createProfileForApp(kSerial, "google-chrome", "Google Chrome");
 
-    EXPECT_EQ(m_engine.cachedProfile("Google Chrome").dpi, 4000);
+    EXPECT_EQ(m_engine.cachedProfile(kSerial, "Google Chrome").dpi, 4000);
 }
 
 // DisplayHardwareProfileSeparation — display and hardware profiles track independently
 TEST_F(WmClassTest, DisplayHardwareProfileSeparation) {
-    m_engine.setDisplayProfile("Google Chrome");
-    m_engine.setHardwareProfile("Dolphin");
+    m_engine.setDisplayProfile(kSerial, "Google Chrome");
+    m_engine.setHardwareProfile(kSerial, "Dolphin");
 
-    EXPECT_EQ(m_engine.displayProfile(), "Google Chrome");
-    EXPECT_EQ(m_engine.hardwareProfile(), "Dolphin");
+    EXPECT_EQ(m_engine.displayProfile(kSerial), "Google Chrome");
+    EXPECT_EQ(m_engine.hardwareProfile(kSerial), "Dolphin");
 }


### PR DESCRIPTION
Closes #77.

## Summary

Replaces ProfileEngine's hidden global context with a map keyed by
deviceSerial. Wires DeviceModel::selectedChanged to refresh the UI
from the newly-selected device's cached profile.

Fixes the case where switching the carousel to a different device left
ButtonModel and DeviceModel display values stuck on the first-seeded
device's profile. On real single-device hardware the bug was
invisible; it surfaced in --simulate-all and on multi-device setups.

## Change breakdown

1. refactor(profile) commits: introduce DeviceProfileContext,
   per-device API, serial-bearing signals. Legacy API stays during
   the migration then is deleted.
2. refactor(app) commits: migrate all AppController call sites to
   pass selectedSerial(). Rework AppControllerFixture to go through
   onPhysicalDeviceAdded.
3. feat(app) + test(app) commits: new onSelectedDeviceChanged
   slot plus three integration tests covering the bug.

## Test plan

- [x] logitune-tests: 571/571 pass (568 baseline + 3 integration)
- [x] logitune-qml-tests: 72/72 pass
- [x] --simulate-all manual verification: MX Vertical's Buttons page
      shows "DPI cycle" as the secondary on the DPI card even when
      MX Anywhere 3 is seeded first; carousel switches update action
      labels and DPI values correctly.