### PR TITLE
Derive app version from latest git tag at configure time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,31 @@
 # SPDX-License-Identifier: GPL-3.0-only
 cmake_minimum_required(VERSION 3.22)
-project(logitune VERSION 0.2.3 LANGUAGES CXX)
+
+# Derive version from the latest v*-prefixed git tag so local/dev builds
+# report the same version users see on the last release. project()'s
+# VERSION field only accepts numeric major.minor.patch, so pre-release
+# suffixes (-beta.N) are stripped into LOGITUNE_DISPLAY_VERSION for the
+# About page label; the numeric core stays the authoritative Qt version.
+find_package(Git QUIET)
+set(LOGITUNE_VERSION "0.2.3")
+set(LOGITUNE_DISPLAY_VERSION "${LOGITUNE_VERSION}")
+
+if(Git_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 --match "v[0-9]*"
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE _git_tag
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE _git_rc
+    )
+    if(_git_rc EQUAL 0 AND _git_tag MATCHES "^v([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)$")
+        set(LOGITUNE_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
+        string(REGEX REPLACE "^v" "" LOGITUNE_DISPLAY_VERSION "${_git_tag}")
+    endif()
+endif()
+
+project(logitune VERSION ${LOGITUNE_VERSION} LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/scripts/package-arch.sh
+++ b/scripts/package-arch.sh
@@ -2,13 +2,14 @@
 set -e
 
 # Derive version from the tag when the workflow is triggered by a tag push,
-# otherwise fall back to the version in CMakeLists.txt. pkgver forbids
-# hyphens and tildes, so pre-release identifiers use dots: v0.3.0-beta.1
-# becomes 0.3.0.beta.1.
+# otherwise fall back to the latest v*-prefixed git tag (same logic
+# CMakeLists.txt uses). pkgver forbids hyphens and tildes, so pre-release
+# identifiers use dots: v0.3.0-beta.1 becomes 0.3.0.beta.1.
 if [ -n "$GITHUB_REF_NAME" ] && [[ "$GITHUB_REF_NAME" =~ ^v[0-9] ]]; then
     TAG="${GITHUB_REF_NAME#v}"
 else
-    TAG=$(grep -oP 'project\(logitune VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
+    TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null | sed 's/^v//')
+    : "${TAG:=0.2.3}"
 fi
 VERSION="${TAG//-/.}"
 SRCDIR="$(cd "$(dirname "$0")/.." && pwd)"

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -2,12 +2,14 @@
 set -e
 
 # Derive version from the tag when the workflow is triggered by a tag push,
-# otherwise fall back to the version in CMakeLists.txt. Pre-release tags
-# like v0.3.0-beta.1 encode as 0.3.0~beta.1 so dpkg sorts them before 0.3.0.
+# otherwise fall back to the latest v*-prefixed git tag (same logic
+# CMakeLists.txt uses). Pre-release tags like v0.3.0-beta.1 encode as
+# 0.3.0~beta.1 so dpkg sorts them before 0.3.0.
 if [ -n "$GITHUB_REF_NAME" ] && [[ "$GITHUB_REF_NAME" =~ ^v[0-9] ]]; then
     TAG="${GITHUB_REF_NAME#v}"
 else
-    TAG=$(grep -oP 'project\(logitune VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
+    TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null | sed 's/^v//')
+    : "${TAG:=0.2.3}"
 fi
 VERSION="${TAG//-/\~}"
 PKGDIR="/tmp/logitune-deb"

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -2,13 +2,14 @@
 set -e
 
 # Derive version from the tag when the workflow is triggered by a tag push,
-# otherwise fall back to the version in CMakeLists.txt. rpm 4.10+ treats
-# tilde as a pre-release separator that sorts before digits, so 0.3.0~beta.1
-# sorts before 0.3.0.
+# otherwise fall back to the latest v*-prefixed git tag (same logic
+# CMakeLists.txt uses). rpm 4.10+ treats tilde as a pre-release separator
+# that sorts before digits, so 0.3.0~beta.1 sorts before 0.3.0.
 if [ -n "$GITHUB_REF_NAME" ] && [[ "$GITHUB_REF_NAME" =~ ^v[0-9] ]]; then
     TAG="${GITHUB_REF_NAME#v}"
 else
-    TAG=$(grep -oP 'project\(logitune VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
+    TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' 2>/dev/null | sed 's/^v//')
+    : "${TAG:=0.2.3}"
 fi
 VERSION="${TAG//-/\~}"
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -18,7 +18,10 @@ target_include_directories(logitune-app-lib PUBLIC
 )
 
 target_link_libraries(logitune-app-lib PUBLIC logitune-core Qt6::Quick Qt6::Widgets)
-target_compile_definitions(logitune-app-lib PUBLIC PROJECT_VERSION="${PROJECT_VERSION}")
+target_compile_definitions(logitune-app-lib PUBLIC
+    PROJECT_VERSION="${PROJECT_VERSION}"
+    PROJECT_VERSION_FULL="${LOGITUNE_DISPLAY_VERSION}"
+)
 
 set_source_files_properties(qml/Theme.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
     QApplication app(argc, argv);
     app.setOrganizationName("Logitune");
     app.setApplicationName("Logitune");
-    app.setApplicationVersion(QStringLiteral(PROJECT_VERSION));
+    app.setApplicationVersion(QStringLiteral(PROJECT_VERSION_FULL));
     app.setQuitOnLastWindowClosed(false);  // tray icon keeps app alive
     app.setWindowIcon(QIcon(":/Logitune/qml/assets/logitune-icon.svg"));
 


### PR DESCRIPTION
Closes #80.

## Summary

`CMakeLists.txt:3` hardcoded `0.2.3`, which went stale across `v0.3.0-beta.1` and `v0.3.1-beta.1` releases. Every local/dev build and `--version` output reported the wrong version; CI release builds (tag-driven via `GITHUB_REF_NAME`) were unaffected.

## Change

`CMakeLists.txt` now runs `git describe --tags --abbrev=0 --match 'v[0-9]*'` at configure time. Two variables result:

- `LOGITUNE_VERSION` — numeric `major.minor.patch` for `project(VERSION …)` (CMake rejects pre-release suffixes).
- `LOGITUNE_DISPLAY_VERSION` — the full tag with any `-beta.N` suffix preserved.

`PROJECT_VERSION_FULL` compile definition wires the display version into `main.cpp`, which uses it for `setApplicationVersion`. Fallback to `0.2.3` if git is unavailable (e.g., source tarball builds).

## Verification

```
$ cmake -B build
$ cmake --build build
$ ./build/src/app/logitune --version
Logitune 0.3.1-beta.1
```

571/571 tests pass.

## Out of scope

- Changes to `scripts/package-*.sh` CI flow — already correct.
- Auto-bumping between releases.