### PR TITLE
Fetch tags in release workflow so git describe works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Cache apt archives
         uses: actions/cache@v4
@@ -61,6 +63,8 @@ jobs:
       image: fedora:41
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
         run: |
@@ -92,6 +96,8 @@ jobs:
       options: --user root
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Problem

`v0.3.2-beta.1` shipped with the wrong in-app version string (`0.2.3`). Root cause: `actions/checkout@v4` defaults to a shallow clone with no tags fetched. The git-describe-based version derivation added in PR #81 runs inside the CI build environment, can't see the tag, and falls back to the hardcoded `0.2.3` emergency value in both `CMakeLists.txt` and the three `scripts/package-*.sh` scripts.

The package filename encodes the correct version (`logitune-0.3.2.beta.1-...`) because the scripts read `GITHUB_REF_NAME` first, but the binary itself uses `PROJECT_VERSION_FULL` which is populated from CMake's git-describe path — hence the wrong About dialog.

## Fix

Add `fetch-depth: 0` to all three `actions/checkout@v4` steps in `.github/workflows/release.yml` (Debian, Fedora, Arch jobs). Full clone brings tags into the runner's working tree so `git describe --tags --abbrev=0 --match 'v[0-9]*'` returns the current release tag instead of failing.

## Recovery for v0.3.2-beta.1

Release + tag already deleted. Once this PR is merged, retag `v0.3.2-beta.1` on master HEAD; CI rebuilds with the correct version baked in.

## Verification

Can't locally reproduce the runner's shallow-clone behaviour, but the fix is the standard GitHub-Actions workaround for `git describe` under `actions/checkout@v4`. The retagged beta's About dialog will show `0.3.2-beta.1` to confirm.