### PR TITLE
Detect AppIndicator via StatusNotifierWatcher service

### DIFF
--- a/src/core/desktop/GnomeDesktop.cpp
+++ b/src/core/desktop/GnomeDesktop.cpp
@@ -1,6 +1,7 @@
 #include "desktop/GnomeDesktop.h"
 #include "logging/LogManager.h"
 #include <QDBusConnection>
+#include <QDBusConnectionInterface>
 #include <QDBusMessage>
 #include <QDBusReply>
 #include <QDBusVariant>
@@ -69,41 +70,62 @@ void GnomeDesktop::start()
 
 void GnomeDesktop::detectAppIndicatorStatus()
 {
-    static const QString kAppIndicatorUuid =
-        QStringLiteral("appindicatorsupport@rgcjonas.gmail.com");
+    // Primary signal: any AppIndicator implementation (rgcjonas'
+    // appindicatorsupport, Ubuntu's ubuntu-appindicators, etc.) registers
+    // org.kde.StatusNotifierWatcher on the session bus. If present, the
+    // tray icon will render regardless of which extension backs it.
+    //
+    // Previous implementation checked a specific uuid via GetExtensionInfo
+    // and incorrectly reported "not installed" on Ubuntu GNOME, which ships
+    // ubuntu-appindicators@ubuntu.com preinstalled.
+    const bool watcherRegistered = QDBusConnection::sessionBus()
+        .interface()
+        ->isServiceRegistered(QStringLiteral("org.kde.StatusNotifierWatcher"));
 
-    QDBusMessage infoMsg = QDBusMessage::createMethodCall(
-        QStringLiteral("org.gnome.Shell.Extensions"),
-        QStringLiteral("/org/gnome/Shell/Extensions"),
-        QStringLiteral("org.gnome.Shell.Extensions"),
-        QStringLiteral("GetExtensionInfo"));
-    infoMsg << kAppIndicatorUuid;
-    QDBusMessage infoReply = QDBusConnection::sessionBus().call(infoMsg, QDBus::Block, 2000);
-
-    bool installed = false;
-    QVariantMap info;
-    if (infoReply.type() == QDBusMessage::ReplyMessage && !infoReply.arguments().isEmpty()) {
-        info = qdbus_cast<QVariantMap>(infoReply.arguments().first());
-        installed = !info.isEmpty();
-    }
-
-    if (!installed) {
-        m_appIndicatorStatus = AppIndicatorNotInstalled;
-        qCWarning(lcFocus) << "AppIndicator extension not installed -- tray icon will not be visible."
-                           << "Install: gnome-shell-extension-appindicator";
+    if (watcherRegistered) {
+        m_appIndicatorStatus = AppIndicatorActive;
+        qCInfo(lcFocus) << "StatusNotifier watcher active; tray icons supported";
         return;
     }
 
-    // GNOME Shell extension states: 1=ENABLED, 2=DISABLED, 3=ERROR, 4=OUT_OF_DATE, 5=DOWNLOADING, 6=INITIALIZED
-    int state = info.value(QStringLiteral("state")).toInt();
-    if (state == 1) {
-        m_appIndicatorStatus = AppIndicatorActive;
-        qCInfo(lcFocus) << "AppIndicator extension active";
-    } else {
+    // Watcher is absent. Distinguish "installed but disabled" from
+    // "not installed at all" so the banner shows the right remediation
+    // (enable vs install). Probe the two known community uuids.
+    static const QStringList kKnownUuids = {
+        QStringLiteral("appindicatorsupport@rgcjonas.gmail.com"),
+        QStringLiteral("ubuntu-appindicators@ubuntu.com"),
+    };
+
+    for (const QString &uuid : kKnownUuids) {
+        QDBusMessage infoMsg = QDBusMessage::createMethodCall(
+            QStringLiteral("org.gnome.Shell.Extensions"),
+            QStringLiteral("/org/gnome/Shell/Extensions"),
+            QStringLiteral("org.gnome.Shell.Extensions"),
+            QStringLiteral("GetExtensionInfo"));
+        infoMsg << uuid;
+        QDBusMessage infoReply = QDBusConnection::sessionBus()
+            .call(infoMsg, QDBus::Block, 2000);
+
+        if (infoReply.type() != QDBusMessage::ReplyMessage
+            || infoReply.arguments().isEmpty())
+            continue;
+
+        const QVariantMap info = qdbus_cast<QVariantMap>(
+            infoReply.arguments().first());
+        if (info.isEmpty())
+            continue;
+
         m_appIndicatorStatus = AppIndicatorDisabled;
-        qCWarning(lcFocus) << "AppIndicator extension installed but not enabled (state:" << state << ")"
-                           << "-- run: gnome-extensions enable" << kAppIndicatorUuid;
+        qCWarning(lcFocus) << "AppIndicator extension" << uuid
+                           << "installed but not enabled -- run: "
+                              "gnome-extensions enable" << uuid;
+        return;
     }
+
+    m_appIndicatorStatus = AppIndicatorNotInstalled;
+    qCWarning(lcFocus) << "No StatusNotifier watcher and no known AppIndicator "
+                          "extension installed -- tray icon will not be visible."
+                       << "Install: gnome-shell-extension-appindicator";
 }
 
 bool GnomeDesktop::ensureExtensionInstalled()


### PR DESCRIPTION
Reported in testing `v0.3.2-beta.1` on Ubuntu: the "AppIndicator extension not installed" banner fires even though Ubuntu GNOME ships `ubuntu-appindicators@ubuntu.com` preinstalled and the tray icon renders correctly.

## Root cause

`GnomeDesktop::detectAppIndicatorStatus` hard-coded the rgcjonas fork's uuid (`appindicatorsupport@rgcjonas.gmail.com`) and called `GetExtensionInfo` on it. On Ubuntu GNOME that uuid isn't installed — Ubuntu ships their own fork under a different uuid. Both forks register the same DBus watcher service, so Qt's tray works either way, but our detection returns "not installed".

## Fix

Switch to a capability-based check. Any AppIndicator-compatible extension that actually provides tray support registers `org.kde.StatusNotifierWatcher` on the session bus. If that service is registered, `AppIndicatorActive` — done.

If the watcher isn't registered, the fallback path probes the two known extension uuids (rgcjonas + ubuntu) via `GetExtensionInfo` to distinguish "installed but disabled" from "not installed at all" so the banner still shows the right remediation (enable vs install).

## Covered cases

| Scenario                                       | Detection result         |
|------------------------------------------------|--------------------------|
| Ubuntu GNOME default                           | Active (was: NotInstalled) |
| Fedora/Arch with rgcjonas fork enabled         | Active (unchanged)       |
| rgcjonas installed but disabled                | Disabled (unchanged)     |
| ubuntu-appindicators installed but disabled    | Disabled (was: NotInstalled) |
| No watcher, no known uuid                      | NotInstalled (unchanged) |

## Test plan

- [x] 575/575 core tests pass
- [x] 72/72 QML tests pass
- [ ] Install on Ubuntu VM, confirm banner no longer fires
- [ ] Install on Arch with extension disabled, confirm "Disabled" banner