### PR TITLE
Use isSystemTrayAvailable() for --minimized autostart gate

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -259,7 +259,13 @@ int main(int argc, char *argv[])
     QObject::connect(tray.quitAction(), &QAction::triggered, &app, &QApplication::quit);
     tray.show();
 
-    const bool trayVisible = tray.trayIcon()->isVisible();
+    // QSystemTrayIcon::isVisible() returns true as soon as show() is called,
+    // even when no StatusNotifier host exists to actually render the icon.
+    // isSystemTrayAvailable() is the real capability check: it returns false
+    // on GNOME Wayland without an AppIndicator extension. Using the wrong
+    // check stranded users with no way to reach the app after --minimized
+    // autostart on a session without a tray.
+    const bool trayVisible = QSystemTrayIcon::isSystemTrayAvailable();
     if (!trayVisible) {
         // Without a tray icon (e.g. GNOME with no AppIndicator extension)
         // there is no way to re-open the window or quit from a tray menu, so


### PR DESCRIPTION
Reported in testing: on Arch + GNOME without an AppIndicator extension enabled, `logitune --minimized` (the autostart launcher) hides its window but there's no tray icon — users get stranded with an invisible running process and have to `pkill logitune` to recover.

## Root cause

`src/app/main.cpp:262` checked `tray.trayIcon()->isVisible()` to decide whether to hide the window in `--minimized` mode. `QSystemTrayIcon::isVisible()` returns true immediately after `show()` is called regardless of whether a StatusNotifier watcher actually exists to display the icon. So on a session with no tray support, `trayVisible` was `true`, the window hid, and no tray icon appeared.

PR #72 introduced this gate to solve the no-tray case, but picked the wrong check. #86 fixed the same bug class in `GnomeDesktop::detectAppIndicatorStatus`. This PR finishes the job on the startup path.

## Fix

Swap `isVisible()` for `QSystemTrayIcon::isSystemTrayAvailable()` — Qt's documented capability probe that returns `false` on Linux sessions without a `org.kde.StatusNotifierWatcher` registered on the bus. Consistent with the approach #86 took for the AppIndicator banner.

## Behaviour after this PR

| Scenario | Startup action |
|----------|---------------|
| Tray available + `--minimized` | Hide window (unchanged) |
| Tray available, no `--minimized` | Show window (unchanged) |
| No tray + `--minimized` | **Show window** (was: stranded) |
| No tray, no `--minimized` | Show window (unchanged) |

## Test plan

- [x] 575/575 core tests pass
- [x] 72/72 QML tests pass
- [ ] Manual: Arch + GNOME session with the AppIndicator extension disabled, launch `logitune --minimized`, confirm window appears instead of hiding.