### PR TITLE
Fix OBS Fedora build: autostart path in spec file

### DIFF
--- a/pkg/obs/logitune.spec
+++ b/pkg/obs/logitune.spec
@@ -55,7 +55,7 @@ DPI, SmartShift, scroll, gesture, and thumb wheel settings.
 %{_bindir}/logitune
 %{_prefix}/lib/udev/rules.d/71-logitune.rules
 %{_datadir}/applications/logitune.desktop
-%{_prefix}/etc/xdg/autostart/logitune.desktop
+/etc/xdg/autostart/logitune.desktop
 %{_datadir}/icons/hicolor/scalable/apps/com.logitune.Logitune.svg
 %dir %{_datadir}/gnome-shell
 %dir %{_datadir}/gnome-shell/extensions


### PR DESCRIPTION
## Summary
OBS Fedora_42 builds have been failing with:
```
error: File not found: /home/abuild/rpmbuild/BUILD/logitune-0.3.2-build/BUILDROOT/usr/etc/xdg/autostart/logitune.desktop
```

`pkg/obs/logitune.spec` listed the autostart file under `%{_prefix}/etc/xdg/autostart/` (which expands to `/usr/etc/xdg/autostart/`), but `CMakeLists.txt:53-55` installs it to `/etc/xdg/autostart/` with an absolute DESTINATION. `scripts/package-rpm.sh:49` already uses the correct `/etc/xdg/autostart/` — this aligns the OBS spec with it.

## Test plan
- [ ] After merge, `osc service remoterun home:mmaher88:logitune logitune` to pull the fixed spec.
- [ ] Fedora_42 x86_64 target transitions to `succeeded`.