### PR TITLE
Auto-publish PKGBUILD to AUR on stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,3 +149,69 @@ jobs:
           # are published as GitHub pre-releases so they do not appear as the
           # latest stable download.
           prerelease: ${{ contains(github.ref_name, '-') }}
+
+  # --------------------------------------------------------------------------
+  # Publish the updated PKGBUILD to the AUR. Runs only for stable tags
+  # (no '-' in the ref name); pre-release channels stay off the AUR.
+  # --------------------------------------------------------------------------
+  push-aur:
+    needs: [release]
+    runs-on: ubuntu-24.04
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    container:
+      image: archlinux:latest
+      options: --user root
+    steps:
+      - name: Install dependencies
+        run: |
+          pacman -Syu --noconfirm --needed base-devel git openssh sudo
+
+      - uses: actions/checkout@v4
+
+      - name: Set up AUR SSH access
+        env:
+          AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$AUR_SSH_KEY" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          ssh-keyscan -t ed25519,rsa aur.archlinux.org >> ~/.ssh/known_hosts
+          cat > ~/.ssh/config <<'EOF'
+          Host aur.archlinux.org
+              IdentityFile ~/.ssh/aur
+              User aur
+              StrictHostKeyChecking yes
+          EOF
+
+      - name: Clone AUR repo
+        run: git clone ssh://aur@aur.archlinux.org/logitune.git aur
+
+      - name: Stage updated PKGBUILD + install hook
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          TARBALL_URL="https://github.com/mmaher88/logitune/archive/v${VERSION}.tar.gz"
+          SHA=$(curl -fsSL --retry 3 "$TARBALL_URL" | sha256sum | awk '{print $1}')
+          cp packaging/PKGBUILD aur/PKGBUILD
+          cp packaging/logitune.install aur/logitune.install
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" aur/PKGBUILD
+          sed -i "s/^sha256sums=.*/sha256sums=('${SHA}')/" aur/PKGBUILD
+
+      - name: Regenerate .SRCINFO (makepkg refuses root)
+        run: |
+          useradd -m builder
+          chown -R builder aur
+          sudo -u builder bash -c 'cd aur && makepkg --printsrcinfo > .SRCINFO'
+
+      - name: Commit and push
+        run: |
+          cd aur
+          git config user.email "mina.maher88@hotmail.com"
+          git config user.name "mmaher88"
+          git add PKGBUILD .SRCINFO logitune.install
+          if git diff --cached --quiet; then
+            echo "No AUR changes to push."
+          else
+            git commit -m "Update to ${GITHUB_REF_NAME#v}"
+            git push
+          fi

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Mina Maher <mina.maher88@hotmail.com>
 pkgname=logitune
-pkgver=0.1.2
+pkgver=0.3.2
 pkgrel=1
 pkgdesc="Logitech device configurator for Linux — per-app profiles, button remapping, DPI, gestures"
 arch=('x86_64')
@@ -9,7 +9,8 @@ license=('GPL-3.0-or-later')
 install=logitune.install
 depends=('qt6-base' 'qt6-declarative' 'qt6-svg' 'qt6-5compat' 'systemd-libs')
 makedepends=('cmake' 'ninja' 'qt6-tools')
-optdepends=('gnome-shell: per-app profile switching on GNOME')
+optdepends=('gnome-shell: per-app profile switching on GNOME'
+             'gnome-shell-extension-appindicator: tray icon on GNOME')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
 sha256sums=('SKIP')
 

--- a/packaging/logitune.install
+++ b/packaging/logitune.install
@@ -1,0 +1,33 @@
+post_install() {
+    echo ""
+    echo "==> Logitune installed!"
+    echo ""
+
+    # Reload udev rules so hidraw/uinput permissions take effect
+    udevadm control --reload-rules 2>/dev/null
+    udevadm trigger 2>/dev/null
+
+    echo "    1. Unplug and replug your Logitech device (or reboot)"
+    echo "    2. Run: logitune"
+    echo ""
+
+    # Detect GNOME and give specific instructions
+    _de=$(printenv XDG_CURRENT_DESKTOP 2>/dev/null | tr '[:upper:]' '[:lower:]')
+    case "$_de" in
+        *gnome*)
+            echo "    GNOME users:"
+            echo ""
+            echo "    For tray icon support, install and enable AppIndicator:"
+            echo "      sudo pacman -S gnome-shell-extension-appindicator"
+            echo "      gnome-extensions enable appindicatorsupport@rgcjonas.gmail.com"
+            echo ""
+            echo "    Log out and back in after first launch for per-app"
+            echo "    profile switching and tray icon to take effect."
+            echo ""
+            ;;
+    esac
+}
+
+post_upgrade() {
+    post_install
+}


### PR DESCRIPTION
## Summary
- New `push-aur` job in `release.yml` mirrors `packaging/PKGBUILD` to the AUR `logitune` package after the GitHub release is published. Runs only on stable tags (skips `v*-beta.N`).
- `packaging/PKGBUILD` synced to current AUR state (pkgver 0.3.2, qt6 deps, gnome optdepends).
- `packaging/logitune.install` checked in so the post-install hook (udev reload + GNOME AppIndicator hint) lives alongside the PKGBUILD.

## What the job does
1. Clones `ssh://aur@aur.archlinux.org/logitune.git`.
2. Copies in-repo `PKGBUILD` + `logitune.install`; bumps `pkgver` from the tag, sets `pkgrel=1`, rewrites `sha256sums` from the GitHub tarball.
3. Regenerates `.SRCINFO` via `makepkg --printsrcinfo` as an unprivileged user.
4. Commits and pushes (no-op if no diff).

## Prereqs before this lands
- [ ] Add `AUR_SSH_KEY` repo secret at `Settings -> Secrets and variables -> Actions` — private half of an ed25519 keypair whose public side is registered on the `mmaher88` AUR account.

## Test plan
- [ ] First real run on the next stable tag (v0.3.3 or later); confirm AUR `pkgver` flips and `yay -Syu` picks it up.