### PR TITLE
Install git in container jobs so CMake's describe reads the real tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,14 @@ jobs:
     container:
       image: fedora:41
     steps:
+      # actions/checkout falls back to a REST API tarball download when git
+      # is missing, which skips .git entirely. That breaks the git-describe
+      # version lookup in CMakeLists.txt and the binary ends up reporting
+      # the hardcoded 0.2.3 fallback. Install git first so checkout does a
+      # real clone.
+      - name: Install git (required by actions/checkout for .git history)
+        run: dnf install -y git
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -95,6 +103,12 @@ jobs:
       image: archlinux:latest
       options: --user root
     steps:
+      # Same reason as package-rpm: without git, actions/checkout uses the
+      # REST API tarball path and there is no .git, so CMake's
+      # git describe lookup falls back to the hardcoded version.
+      - name: Install git (required by actions/checkout for .git history)
+        run: pacman -Sy --noconfirm --needed git
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary
About dialog was reporting the hardcoded `0.2.3` fallback on Fedora and Arch installs even though the outer package filenames were correct (0.3.2). Ubuntu installs showed the right version.

## Root cause
`actions/checkout@v4` only runs a real `git clone` when a `git` binary is available in the environment. Otherwise it silently falls back to a GitHub REST API tarball download — which gives us the tree but **no `.git` directory**.

Neither `archlinux:latest` nor `fedora:41` ship git in the base image. So:

- `package-deb` runs on the `ubuntu-24.04` host (git preinstalled) → real clone → CMake's `git describe` works → binary shows `0.3.2`. ✓
- `package-rpm` / `package-arch` run in containers without git → REST fallback → no `.git` → `git describe` fails in CMake (`CMakeLists.txt:13-26`) → binary reports hardcoded `0.2.3`. ✗

The package-level version string (`pkgver`, filename) was always correct because `scripts/package-*.sh` reads `$GITHUB_REF_NAME` directly and doesn't depend on `.git`.

## Fix
Add an `Install git` step *before* `actions/checkout` in both container jobs (`dnf install -y git` for Fedora, `pacman -Sy --noconfirm --needed git` for Arch).

## Test plan
- [ ] Next stable tag (v0.3.3) — install the Arch + Fedora artifacts and confirm About dialog reports matching version.
- [ ] Optional: `workflow_dispatch` dry-run on this branch, inspect the arch/rpm artifacts' embedded version before tagging.