### PR TITLE
Fix OBS Fedora build: ship device + extension subtrees as directories

### DIFF
--- a/pkg/obs/logitune.spec
+++ b/pkg/obs/logitune.spec
@@ -57,12 +57,8 @@ DPI, SmartShift, scroll, gesture, and thumb wheel settings.
 %{_datadir}/applications/logitune.desktop
 /etc/xdg/autostart/logitune.desktop
 %{_datadir}/icons/hicolor/scalable/apps/com.logitune.Logitune.svg
-%dir %{_datadir}/gnome-shell
-%dir %{_datadir}/gnome-shell/extensions
-%dir %{_datadir}/gnome-shell/extensions/logitune-focus@logitune.com
-%{_datadir}/gnome-shell/extensions/logitune-focus@logitune.com/metadata.json
-%{_datadir}/gnome-shell/extensions/logitune-focus@logitune.com/extension.js
-%dir %{_datadir}/gnome-shell/extensions/logitune-focus@logitune.com/v42
-%{_datadir}/gnome-shell/extensions/logitune-focus@logitune.com/v42/extension.js
-%dir %{_datadir}/gnome-shell/extensions/logitune-focus@logitune.com/v45
-%{_datadir}/gnome-shell/extensions/logitune-focus@logitune.com/v45/extension.js
+# Device descriptors (JSON + images) and the GNOME shell extension live in
+# their own subtrees. Ship the directories so new devices and any
+# additional extension resources land automatically.
+%{_datadir}/logitune
+%{_datadir}/gnome-shell/extensions/logitune-focus@logitune.com


### PR DESCRIPTION
## Summary
After #88 fixed the autostart path, Fedora_42 OBS builds advanced to the next failure mode:
```
error: Installed (but unpackaged) file(s) found:
   /usr/share/logitune/devices/mx-*/...
```

Every device descriptor under `/usr/share/logitune/devices/` was installed by CMake but not listed in `pkg/obs/logitune.spec`'s `%files` section — and the GNOME extension was enumerated file-by-file. `scripts/package-rpm.sh:51-55` already uses directory globs. This PR aligns the OBS spec with that pattern.

## Change
In `pkg/obs/logitune.spec`, replace the hand-listed extension files and add `/usr/share/logitune`.

## Test plan
- [x] Spec uploaded directly to OBS as rev 20 for verification; Fedora_42 and xUbuntu_24.04 both `succeeded`.
- [x] This PR keeps the in-repo copy in sync so OBS and git don't diverge again.