### PR TITLE
Tooltip on device verified/beta badge

### DIFF
--- a/src/app/qml/components/DeviceCard.qml
+++ b/src/app/qml/components/DeviceCard.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Controls
 import Logitune
 
 Item {
@@ -31,6 +32,7 @@ Item {
     }
 
     Rectangle {
+        id: statusBadge
         anchors { top: parent.top; right: parent.right; margins: -4 }
         width: 22; height: 22; radius: 11
         z: 2
@@ -54,6 +56,14 @@ Item {
                 }
             }
         }
+
+        HoverHandler { id: badgeHover }
+
+        ToolTip.visible: badgeHover.hovered
+        ToolTip.delay: 500
+        ToolTip.text: root.status === "verified"
+            ? qsTr("Verified on real hardware by the Logitune team. Full feature support.")
+            : qsTr("Beta descriptor — added but not yet verified on physical hardware. Core features should work; some may be untested.")
     }
 
     Text {


### PR DESCRIPTION
## Summary
Hover the green ✓ or orange β badge on any device card and a tooltip explains what the status means. Previously there was no way to know what the glyph meant without reading the README.

## Copy
- **Verified:** *"Verified on real hardware by the Logitune team. Full feature support."*
- **Beta:** *"Beta descriptor — added but not yet verified on physical hardware. Core features should work; some may be untested."*

## Implementation
Uses the same `HoverHandler` + attached `ToolTip` pattern already established in `EditorToolbar.qml:40-48`. One-file change adding `QtQuick.Controls` import, an id on the badge, and ~6 lines for the tooltip.

## Test plan
- [x] Built; 575/575 core + 72/72 QML tests pass.
- [x] Smoke-tested in `--simulate-all`: hover both verified and beta badges; tooltip appears after ~500ms with correct text.