### PR TITLE
Fix AUR push: use accept-new host key policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,12 +189,14 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "$AUR_SSH_KEY" > ~/.ssh/aur
           chmod 600 ~/.ssh/aur
-          ssh-keyscan -t ed25519,rsa aur.archlinux.org >> ~/.ssh/known_hosts
+          # Trust the AUR host key on first connect and persist it; subsequent
+          # connects still fail on mismatch. Avoids brittle ssh-keyscan calls
+          # inside a freshly-started container where DNS may not be settled.
           cat > ~/.ssh/config <<'EOF'
           Host aur.archlinux.org
               IdentityFile ~/.ssh/aur
               User aur
-              StrictHostKeyChecking yes
+              StrictHostKeyChecking accept-new
           EOF
 
       - name: Clone AUR repo


### PR DESCRIPTION
## Summary
`push-aur` on the v0.3.3 release failed at "Clone AUR repo":
```
Cloning into 'aur'...
Host key verification failed.
fatal: Could not read from remote repository.
```

The `ssh-keyscan -t ed25519,rsa aur.archlinux.org` step produced no output inside the freshly-started `archlinux:latest` container (likely DNS hadn't settled, or the pacman keyring init warning disrupted something — hard to say for certain, the log shows the command ran but nothing was written). `known_hosts` ended up empty and `StrictHostKeyChecking=yes` did its job.

## Fix
Switch to `StrictHostKeyChecking=accept-new`. Trusts the key on first connect, persists it for the rest of the job, and still fails on later mismatches. Safer than `no`, not brittle against container startup timing.

## Next step after merge
Re-tag `v0.3.3` via `git tag -d v0.3.3 && git push origin :v0.3.3 && git tag v0.3.3 <new-sha> && git push`.
