### PR TITLE
Require explicit version source in CMake; fail loudly on missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,10 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Need full history + tags so CMakeLists.txt's git-describe path
+          # can resolve LOGITUNE_VERSION. Without this, configure fails.
+          fetch-depth: 0
 
       # Ubuntu ships gtest as source-only (libgtest-dev); we compile and
       # install it ourselves. Cache the installed artifacts so subsequent
@@ -153,6 +157,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # Route apt's .deb cache into a user-owned directory so actions/cache
       # can both read it on save and extract into it on restore. Caching

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,10 @@ jobs:
         run: cd /usr/src/googletest && cmake -B build && cmake --build build && cmake --install build
 
       - name: Configure
-        run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=${{ matrix.run_tests && 'ON' || 'OFF' }} -Wno-dev
+        # CI builds aren't shipped; a static version string is fine. This
+        # also sidesteps git-describe inside container volumes where
+        # safe.directory can refuse to trust the mounted work tree.
+        run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=${{ matrix.run_tests && 'ON' || 'OFF' }} -DLOGITUNE_VERSION=0.0.0+ci -Wno-dev
 
       - name: Build
         run: cmake --build build -j"$(nproc)"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,29 +1,60 @@
 # SPDX-License-Identifier: GPL-3.0-only
 cmake_minimum_required(VERSION 3.22)
 
-# Derive version from the latest v*-prefixed git tag so local/dev builds
-# report the same version users see on the last release. project()'s
-# VERSION field only accepts numeric major.minor.patch, so pre-release
-# suffixes (-beta.N) are stripped into LOGITUNE_DISPLAY_VERSION for the
-# About page label; the numeric core stays the authoritative Qt version.
+# Derive version from one of two sources, in order:
+#
+#   1. -DLOGITUNE_VERSION=X.Y.Z[-suffix] passed at configure time.
+#      Packaging builds (AUR, OBS, etc.) set this from $pkgver/%{version}
+#      so they don't depend on an in-tree .git directory.
+#   2. The latest v*-prefixed git tag via `git describe`. Works for local
+#      development and CI clones that fetched tags.
+#
+# If neither yields a version, the configure step fails. No hardcoded
+# fallback: a silently-wrong version string shipping to users (the
+# 0.2.3-in-0.3.x regression we hit in AUR/OBS builds) is worse than a
+# loud build failure that forces the packager to pass -DLOGITUNE_VERSION.
+#
+# project()'s VERSION field only accepts numeric major.minor.patch, so
+# pre-release suffixes (-beta.N) are split out into
+# LOGITUNE_DISPLAY_VERSION for the About page label; the numeric core
+# stays the authoritative Qt version.
 find_package(Git QUIET)
-set(LOGITUNE_VERSION "0.2.3")
-set(LOGITUNE_DISPLAY_VERSION "${LOGITUNE_VERSION}")
 
-if(Git_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
-    execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 --match "v[0-9]*"
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        OUTPUT_VARIABLE _git_tag
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-        RESULT_VARIABLE _git_rc
-    )
-    if(_git_rc EQUAL 0 AND _git_tag MATCHES "^v([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)$")
-        set(LOGITUNE_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
-        string(REGEX REPLACE "^v" "" LOGITUNE_DISPLAY_VERSION "${_git_tag}")
+if(NOT DEFINED LOGITUNE_VERSION)
+    if(Git_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 --match "v[0-9]*"
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            OUTPUT_VARIABLE _git_tag
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+            RESULT_VARIABLE _git_rc
+        )
+        if(_git_rc EQUAL 0 AND _git_tag MATCHES "^v([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)$")
+            set(LOGITUNE_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
+            string(REGEX REPLACE "^v" "" LOGITUNE_DISPLAY_VERSION "${_git_tag}")
+        endif()
     endif()
 endif()
+
+if(NOT DEFINED LOGITUNE_VERSION)
+    message(FATAL_ERROR
+        "Could not determine LOGITUNE_VERSION. "
+        "Either pass -DLOGITUNE_VERSION=X.Y.Z[-suffix] at configure time, "
+        "or configure from a git checkout that has v*-prefixed tags fetched.")
+endif()
+
+if(NOT LOGITUNE_VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)$")
+    message(FATAL_ERROR
+        "LOGITUNE_VERSION='${LOGITUNE_VERSION}' is not in X.Y.Z[-suffix] form.")
+endif()
+
+# Split the numeric core from any pre-release suffix so project() is happy.
+set(_logitune_numeric "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
+if(NOT DEFINED LOGITUNE_DISPLAY_VERSION)
+    set(LOGITUNE_DISPLAY_VERSION "${LOGITUNE_VERSION}")
+endif()
+set(LOGITUNE_VERSION "${_logitune_numeric}")
 
 project(logitune VERSION ${LOGITUNE_VERSION} LANGUAGES CXX)
 

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -15,10 +15,14 @@ source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
 sha256sums=('SKIP')
 
 build() {
+    # Pass the version explicitly: the GitHub source tarball has no .git,
+    # so CMake's git-describe lookup would fail and the configure step
+    # refuses to guess. pkgver is the single source of truth here.
     cmake -B build -S "$pkgname-$pkgver" -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DBUILD_TESTING=OFF \
+        -DLOGITUNE_VERSION="$pkgver" \
         -Wno-dev
     cmake --build build
 }

--- a/pkg/obs/logitune.spec
+++ b/pkg/obs/logitune.spec
@@ -45,7 +45,9 @@ DPI, SmartShift, scroll, gesture, and thumb wheel settings.
 %autosetup -n logitune-%{version}
 
 %build
-%cmake -DBUILD_TESTING=OFF
+# OBS builds from a source tarball with no .git, so feed the version
+# through -DLOGITUNE_VERSION; CMakeLists.txt refuses to guess.
+%cmake -DBUILD_TESTING=OFF -DLOGITUNE_VERSION=%{version}
 %cmake_build
 
 %install

--- a/scripts/package-arch.sh
+++ b/scripts/package-arch.sh
@@ -34,7 +34,7 @@ source=()
 
 build() {
     cd "$startdir"
-    cmake -B build-pkg -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTING=OFF -Wno-dev
+    cmake -B build-pkg -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTING=OFF -DLOGITUNE_VERSION=VERSION_PLACEHOLDER -Wno-dev
     cmake --build build-pkg -j$(nproc)
 }
 
@@ -46,7 +46,7 @@ package() {
 PKGBUILD_EOF
 
 # Inject version (heredoc was single-quoted to preserve $startdir/$pkgdir)
-sed -i "s/VERSION_PLACEHOLDER/$VERSION/" "$SRCDIR/PKGBUILD"
+sed -i "s/VERSION_PLACEHOLDER/$VERSION/g" "$SRCDIR/PKGBUILD"
 
 # Build
 cd "$SRCDIR"

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -19,7 +19,7 @@ echo "Building .deb package v$VERSION ($ARCH)"
 
 # Build release (offscreen for headless gtest_discover_tests)
 export QT_QPA_PLATFORM=offscreen
-cmake -B build-release -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTING=OFF -Wno-dev > /dev/null 2>&1
+cmake -B build-release -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTING=OFF -DLOGITUNE_VERSION="$VERSION" -Wno-dev > /dev/null 2>&1
 cmake --build build-release -j$(nproc)
 
 # Create package structure

--- a/scripts/package-rpm.sh
+++ b/scripts/package-rpm.sh
@@ -16,7 +16,7 @@ VERSION="${TAG//-/\~}"
 echo "Building .rpm package v$VERSION"
 
 # Build release
-cmake -B build-release -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTING=OFF -Wno-dev > /dev/null 2>&1
+cmake -B build-release -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_TESTING=OFF -DLOGITUNE_VERSION="$VERSION" -Wno-dev > /dev/null 2>&1
 cmake --build build-release -j$(nproc)
 
 # Install to staging dir


### PR DESCRIPTION
## Summary
User-installed AUR `logitune 0.3.3-1` was showing `v0.2.3` in the About page. Root cause: every packaging path that builds from a source tarball (AUR on end-user machines, OBS `obs_scm`, rpm source builds) has no `.git` directory. CMakeLists.txt's `git describe` silently failed and the hardcoded `0.2.3` fallback shipped. CI builds worked because they clone with `.git`.

## Fix
Drop the hardcoded fallback entirely. `LOGITUNE_VERSION` must come from one of:
1. `-DLOGITUNE_VERSION=X.Y.Z[-suffix]` at configure time (set by packagers).
2. `git describe` on an in-tree `.git`.

If neither yields a usable value, **configure fails** with a message pointing at the `-D` flag. No more silently-wrong version strings shipping to users.

## Files touched
- `CMakeLists.txt` — remove `0.2.3` fallback; add `FATAL_ERROR` path.
- `packaging/PKGBUILD` — pass `-DLOGITUNE_VERSION="$pkgver"`.
- `pkg/obs/logitune.spec` — pass `-DLOGITUNE_VERSION=%{version}`.
- `scripts/package-{arch,deb,rpm}.sh` — pass `-DLOGITUNE_VERSION="$VERSION"` (belt-and-braces; they have `.git`).

## Test plan
- [x] Local build from git: About dialog shows `0.3.3`.
- [x] Simulated tarball build (`rm -rf .git; cmake ...`) without `-D` → `FATAL_ERROR`.
- [x] Same + `-DLOGITUNE_VERSION=0.3.3` → configure succeeds, binary reports `0.3.3`.
- [x] 575/575 core + 72/72 QML tests pass.
- [ ] After merge + AUR re-push (either via #89 automation on next tag, or manually now), `yay -Syu` gives a package whose About page matches `pkgver`.