### PR TITLE
Auto-trigger OBS source service on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,9 @@ jobs:
           SLEEP=30
           elapsed=0
           last_codes=""
-          result_url="https://api.opensuse.org/build/home:mmaher88:logitune/_result?package=logitune"
+          # Public endpoint — no auth required for build results on public
+          # projects. The plain /build/.../_result path returns 401 anonymously.
+          result_url="https://api.opensuse.org/public/build/home:mmaher88:logitune/_result?package=logitune"
 
           # Non-terminal state codes per OBS: wait until none of these
           # appear in the result set.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,12 +197,78 @@ jobs:
         (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
         || (github.event_name == 'workflow_dispatch' && inputs.trigger_obs)
       )
+    # Poll OBS for up to 30 minutes before giving up. Typical stable-tag
+    # rebuild across Fedora + xUbuntu settles in 5-15 min.
+    timeout-minutes: 40
     steps:
       - name: Trigger OBS source service
         run: |
           curl -fsSL -X POST \
             -H "Authorization: Token ${{ secrets.OBS_TRIGGER_TOKEN }}" \
             "https://build.opensuse.org/trigger/runservice?project=home:mmaher88:logitune&package=logitune"
+
+      - name: Wait for OBS builds to settle
+        run: |
+          set -u
+          MAX_WAIT=1800   # 30 min
+          SLEEP=30
+          elapsed=0
+          last_codes=""
+          result_url="https://api.opensuse.org/build/home:mmaher88:logitune/_result?package=logitune"
+
+          # Non-terminal state codes per OBS: wait until none of these
+          # appear in the result set.
+          is_busy() {
+            echo "$1" | grep -qE '<status[^>]+code="(building|blocked|scheduled|dispatching|finished|unknown|signing)"'
+          }
+
+          while [ "$elapsed" -lt "$MAX_WAIT" ]; do
+            # Tolerate a flaky OBS API: one timeout should not fail the whole wait.
+            xml=$(curl -sSf --retry 3 --retry-delay 5 "$result_url" || true)
+            if [ -z "$xml" ]; then
+              echo "[${elapsed}s] OBS result query failed; retrying"
+              sleep "$SLEEP"; elapsed=$((elapsed + SLEEP)); continue
+            fi
+            codes=$(echo "$xml" \
+              | grep -oE '<status[^>]+package="logitune"[^>]*code="[^"]+"' \
+              | grep -oE 'code="[^"]+"' | sort -u | tr '\n' ' ')
+            if [ "$codes" != "$last_codes" ]; then
+              echo "[${elapsed}s] package codes: $codes"
+              last_codes="$codes"
+            fi
+            if ! is_busy "$xml"; then
+              echo "All OBS builds settled."
+              break
+            fi
+            sleep "$SLEEP"
+            elapsed=$((elapsed + SLEEP))
+          done
+
+          echo "--- final per-target results ---"
+          echo "$xml" | grep -E '<result [^>]+>' \
+            | sed -E 's/.*repository="([^"]+)".*arch="([^"]+)".*/\1 \2/' \
+            | while read repo arch; do
+                code=$(echo "$xml" \
+                  | awk -v r="$repo" -v a="$arch" \
+                    '/<result / { match_block = ($0 ~ "repository=\""r"\"" && $0 ~ "arch=\""a"\""); }
+                     match_block && /<status[^>]+package="logitune"/ {
+                       if (match($0, /code="[^"]+"/)) {
+                         print substr($0, RSTART+6, RLENGTH-7)
+                       }
+                       match_block=0
+                     }')
+                printf '  %-24s %-12s %s\n' "$repo" "$arch" "$code"
+              done
+
+          if echo "$xml" | grep -qE '<status[^>]+package="logitune"[^>]*code="(failed|unresolvable|broken)"'; then
+            echo "::error::One or more OBS builds failed."
+            exit 1
+          fi
+          if [ "$elapsed" -ge "$MAX_WAIT" ]; then
+            echo "::error::Timed out waiting for OBS builds to settle after ${MAX_WAIT}s."
+            exit 1
+          fi
+          echo "All OBS builds succeeded."
 
   # --------------------------------------------------------------------------
   # Publish the updated PKGBUILD to the AUR. Runs only for stable tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ on:
         description: "Tag to simulate for dry_run_aur (e.g. v0.3.3). Ignored otherwise."
         type: string
         default: ''
+      trigger_obs:
+        description: "Fire the OBS source-service trigger end-to-end (same call as the real tag path — re-runs the OBS service)."
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -188,7 +192,11 @@ jobs:
   trigger-obs:
     needs: [release]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: |
+      always() && (
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        || (github.event_name == 'workflow_dispatch' && inputs.trigger_obs)
+      )
     steps:
       - name: Trigger OBS source service
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,23 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-') }}
 
   # --------------------------------------------------------------------------
+  # Trigger the OBS source service to pull the new tarball and rebuild
+  # all repo targets (Fedora, openSUSE Ubuntu, etc.). The token is a
+  # "Run source services" token scoped to home:mmaher88:logitune/logitune,
+  # created at https://build.opensuse.org/my/tokens.
+  # --------------------------------------------------------------------------
+  trigger-obs:
+    needs: [release]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Trigger OBS source service
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Token ${{ secrets.OBS_TRIGGER_TOKEN }}" \
+            "https://build.opensuse.org/trigger/runservice?project=home:mmaher88:logitune&package=logitune"
+
+  # --------------------------------------------------------------------------
   # Publish the updated PKGBUILD to the AUR. Runs only for stable tags
   # (no '-' in the ref name); pre-release channels stay off the AUR.
   # --------------------------------------------------------------------------

--- a/pkg/obs/debian.rules
+++ b/pkg/obs/debian.rules
@@ -1,9 +1,14 @@
 #!/usr/bin/make -f
+include /usr/share/dpkg/pkg-info.mk
+
 %:
 	dh $@
 
 override_dh_auto_configure:
-	cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -Wno-dev
+	# DEB_VERSION_UPSTREAM comes from debian/changelog (which OBS keeps in
+	# sync via the set_version service). CMakeLists.txt refuses to guess
+	# without an explicit -DLOGITUNE_VERSION, so feed it here.
+	cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DLOGITUNE_VERSION=$(DEB_VERSION_UPSTREAM) -Wno-dev
 
 override_dh_auto_build:
 	cmake --build build -j$$(nproc)


### PR DESCRIPTION
## Summary
After #89 and #94, AUR is fully automated on stable tags. OBS was still manual (`osc service remoterun` after every release). This closes that gap with a single HTTP POST to an OBS webhook token.

## Setup prereq (once)
1. Go to https://build.opensuse.org/my/tokens
2. **Create Token** — operation: `Run source services`, project: `home:mmaher88:logitune`, package: `logitune`
3. Copy the secret value and add it as `OBS_TRIGGER_TOKEN` in the repo's GitHub secrets.

## Workflow change
New `trigger-obs` job in `release.yml`, runs after `release` succeeds on any `v*` tag (including pre-releases — OBS versioning uses `@PARENT_TAG@` which respects semver ordering). One `curl` call hitting the OBS token URL.

## Caveats
- **Spec changes still manual**: `pkg/obs/logitune.spec` changes need `osc commit` to the OBS project. The token only re-runs the service; it doesn't sync the spec. Spec changes are rare.
- **Fire-and-forget**: The job triggers, it doesn't wait for OBS build completion. Build failures surface only in OBS's UI.

## Test plan
- [ ] After OBS_TRIGGER_TOKEN secret is set + PR merged, next stable tag auto-refreshes OBS. Inspect `osc api "/source/home:mmaher88:logitune/logitune?expand=1"` to confirm the new `logitune-X.Y.Z.tar.xz` appears.