### PR TITLE
Enforce every descriptor has a DeviceSpec entry

### DIFF
--- a/tests/test_device_registry.cpp
+++ b/tests/test_device_registry.cpp
@@ -316,3 +316,61 @@ TEST(DeviceRegistry, MxMaster3sHasNoDpiCycleRing) {
     ASSERT_NE(dev, nullptr);
     EXPECT_TRUE(dev->dpiCycleRing().empty());
 }
+
+// Every devices/*/descriptor.json must have a matching entry in kDevices[]
+// above so the parameterized suite actually validates the new descriptor.
+// Without this check, a new descriptor can be added (hardware PID, controls,
+// hotspots, gestures...) with zero test coverage — issues only surface at
+// runtime for an end user. Inverse check catches kDevices entries that no
+// longer correspond to a descriptor on disk (e.g. after a rename).
+TEST(DeviceRegistry, EveryDescriptorHasSpecCoverage) {
+    // Descriptors that share a PID with another entry can't be parameterized
+    // via kDevices because DeviceRegistry::findByPid returns the first-loaded
+    // match, so the FindsByPid assertion on the shared-PID variant would flap.
+    // They're covered by dedicated tests instead
+    // (MxVerticalDpiButtonIsNotConfigurable iterates both MX Vertical variants).
+    static const QSet<QString> kPidCollisionExemptions = {
+        QStringLiteral("MX Vertical for Business"),
+    };
+
+    QSet<QString> specNames;
+    for (const auto &s : kDevices) {
+        specNames.insert(QString::fromUtf8(s.name));
+    }
+    specNames.unite(kPidCollisionExemptions);
+
+    QSet<QString> descriptorNames;
+    const QDir devicesDir(QStringLiteral(SOURCE_ROOT "/devices"));
+    ASSERT_TRUE(devicesDir.exists()) << "devices/ dir not found at " << devicesDir.path().toStdString();
+    const auto slugs = devicesDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name);
+    for (const QString &slug : slugs) {
+        const QString descPath = devicesDir.filePath(slug) + QStringLiteral("/descriptor.json");
+        if (!QFile::exists(descPath))
+            continue;
+        auto dev = logitune::JsonDevice::load(devicesDir.filePath(slug));
+        ASSERT_NE(dev, nullptr) << slug.toStdString();
+        descriptorNames.insert(dev->deviceName());
+    }
+
+    // Descriptors on disk with no DeviceSpec entry.
+    const QSet<QString> uncovered = descriptorNames - specNames;
+    if (!uncovered.isEmpty()) {
+        QStringList sorted = uncovered.values();
+        std::sort(sorted.begin(), sorted.end());
+        ADD_FAILURE() << "Descriptors missing a DeviceSpec entry in kDevices[]:\n"
+                      << "  " << sorted.join(QStringLiteral(", ")).toStdString() << "\n"
+                      << "  Add matching entries to tests/test_device_registry.cpp "
+                         "(kDevices[] near the top of the file).";
+    }
+
+    // DeviceSpec entries with no descriptor on disk (stale test data).
+    const QSet<QString> orphaned = specNames - descriptorNames;
+    if (!orphaned.isEmpty()) {
+        QStringList sorted = orphaned.values();
+        std::sort(sorted.begin(), sorted.end());
+        ADD_FAILURE() << "kDevices[] has entries with no descriptor on disk:\n"
+                      << "  " << sorted.join(QStringLiteral(", ")).toStdString() << "\n"
+                      << "  Remove them from tests/test_device_registry.cpp or "
+                         "restore the missing devices/<slug>/descriptor.json.";
+    }
+}


### PR DESCRIPTION
## Summary
Pairs with #97: #97 keeps the README in sync with descriptors; this keeps `tests/test_device_registry.cpp`'s parameterized suite in sync. Adds one gtest that fails if a `devices/*/descriptor.json` has no matching entry in `kDevices[]` (or the other way — orphaned spec entries that no longer have a descriptor).

## Why
The parameterized `DeviceRegistryTest` validates PID lookup, control IDs, default gestures, feature flags, DPI range, hotspot counts per device — but it's driven by `kDevices[]`. Before this, a new descriptor could ship with zero coverage: no compile error, no test failure, the parameterized suite just skipped it silently. A real case showed up immediately when I added the test: **MX Vertical for Business** has had a descriptor on disk with no `DeviceSpec` entry for an unknown amount of time.

## Side note caught while implementing
`MX Vertical` and `MX Vertical for Business` share PID `0xb020`. `DeviceRegistry::findByPid` returns the first-loaded match, so the parameterized `FindsByPid` on the `for Business` variant would flap. The test allowlists it explicitly (see the `kPidCollisionExemptions` comment) since the variant is already covered by a dedicated non-parameterized test (`MxVerticalDpiButtonIsNotConfigurable`). Fixing the PID overlap is out of scope; this PR just surfaces the gap and keeps the enforcement non-flaky.

## Test plan
- [x] Local `logitune-tests --gtest_filter='DeviceRegistry.*'` — 7/7 pass.
- [x] Full suite — 576/576 pass (was 575, plus this new test).
- [x] Removed a device from `kDevices[]` locally to confirm it fires → error message lists the orphan and points at the array to edit.