### PR TITLE
packaging(obs): trigger udev on install so button remapping works

### DIFF
--- a/pkg/obs/logitune.spec
+++ b/pkg/obs/logitune.spec
@@ -53,6 +53,19 @@ DPI, SmartShift, scroll, gesture, and thumb wheel settings.
 %install
 %cmake_install
 
+%post
+# Reload udev rules and retag /dev/uinput + hidraw nodes so keystroke
+# injection and device access work on first install without a reboot.
+# /dev/uinput exists before the package is installed, so uaccess won't
+# be applied retroactively unless we trigger a change event.
+udevadm control --reload-rules >/dev/null 2>&1 || :
+udevadm trigger --subsystem-match=misc --subsystem-match=hidraw --action=change >/dev/null 2>&1 || :
+
+%postun
+if [ $1 -eq 0 ] ; then
+    udevadm control --reload-rules >/dev/null 2>&1 || :
+fi
+
 %files
 %{_bindir}/logitune
 %{_prefix}/lib/udev/rules.d/71-logitune.rules


### PR DESCRIPTION
## Summary

Fixes a bug where button remapping and thumb wheel actions silently do nothing on Fedora (and likely openSUSE) after a fresh install, until the user reboots.

## Root cause

`data/71-logitune.rules` grants the logged-in user access to `/dev/uinput` and Logitech hidraw devices via the `uaccess` tag. But udev **does not apply new rules retroactively to existing device nodes**. `/dev/uinput` is created when the `uinput` kernel module loads at boot — well before logitune is installed — so the node stays `crw------- root:root 0600` even after the package is installed.

When the app boots, `UinputInjector::init()` tries to open `/dev/uinput`, fails, and logs:

```
[WARN] UinputInjector: uinput init failed (no /dev/uinput access?). Keystrokes will not be injected.
```

Every remapped button is still *captured* correctly by the core pipeline (`button event: CID 56 pressed`, `thumbWheel action: "VolumeUp"`), but the injection step is a no-op. From the user's perspective, button remapping is completely broken.

The AUR package doesn't have this problem because `packaging/logitune.install`'s `post_install` already runs `udevadm control --reload-rules && udevadm trigger`. The OBS spec has no scriptlets at all.

## Fix

Add `%post` and `%postun` scriptlets to `pkg/obs/logitune.spec`:
- `%post` reloads udev rules and triggers a change event on `misc` (for `/dev/uinput`) and `hidraw` subsystems so the existing nodes pick up the `uaccess` tag.
- `%postun` reloads rules on uninstall so stale entries don't linger.
- `|| :` suffix keeps the install succeeding if `udevadm` is missing from the build chroot's PATH.

This mirrors what the AUR install hook does.

## Verification

Reproduced on Fedora 42 / GNOME 49 / logitune-0.3.4-15.1 with an MX Master 3S:

1. Before fix: `/dev/uinput` is `crw------- root:root`, `getfacl` shows no ACL, button remap silently drops.
2. Run `sudo udevadm control --reload && sudo udevadm trigger --subsystem-match=misc --action=change` manually.
3. `getfacl /dev/uinput` now shows `user:mina:rw-`.
4. Restart logitune — button remap fires, volume wheel works.

After this PR ships, existing users will get the fix automatically on their next `dnf upgrade` without any manual steps or reboot.

## Test plan

- [ ] OBS builds the new RPM successfully
- [ ] Install RPM on clean Fedora VM → `/dev/uinput` gets ACL without reboot
- [ ] Upgrade RPM from 0.3.4-15.1 → `%post` runs, ACL appears, remap starts working
- [ ] Uninstall → `%postun` reloads rules
- [ ] Arch AUR unaffected (this PR doesn't touch `packaging/logitune.install`)