### PR TITLE
ci: sync pkg/obs/ to OBS package VCS on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,13 +184,81 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-') }}
 
   # --------------------------------------------------------------------------
+  # Sync pkg/obs/* into the OBS package's own VCS. OBS stores the spec,
+  # _service, and debian packaging files in its own checkout separate from
+  # git; tar_scm only pulls source code, not these. Without this sync,
+  # changes to pkg/obs/ in git never reach the builds.
+  #
+  # Runs before trigger-obs so the rebuild that follows picks up any new
+  # spec/packaging changes. If pkg/obs/ is unchanged, osc commit is a no-op.
+  # --------------------------------------------------------------------------
+  sync-obs-spec:
+    needs: [release]
+    runs-on: ubuntu-latest
+    if: |
+      always() && (
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        || (github.event_name == 'workflow_dispatch' && inputs.trigger_obs)
+      )
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install osc
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y osc
+
+      - name: Configure osc credentials
+        env:
+          OSC_USERNAME: ${{ secrets.OSC_USERNAME }}
+          OSC_PASSWORD: ${{ secrets.OSC_PASSWORD }}
+        run: |
+          mkdir -p ~/.config/osc
+          umask 077
+          cat > ~/.config/osc/oscrc <<EOF
+          [general]
+          apiurl = https://api.opensuse.org
+
+          [https://api.opensuse.org]
+          user = ${OSC_USERNAME}
+          pass = ${OSC_PASSWORD}
+          EOF
+
+      - name: Checkout OBS package
+        run: osc checkout home:mmaher88:logitune logitune /tmp/obs-pkg
+
+      - name: Sync pkg/obs/ into OBS checkout
+        run: |
+          # Mirror pkg/obs/ into the OBS checkout, keeping osc's .osc/
+          # metadata. --delete removes files deleted from git. osc addremove
+          # then stages additions + deletions for commit.
+          rsync -av --delete --exclude '.osc' pkg/obs/ /tmp/obs-pkg/
+
+      - name: Commit to OBS (triggers service + rebuild if files changed)
+        run: |
+          cd /tmp/obs-pkg
+          osc addremove
+          echo "--- osc status ---"
+          osc status || true
+          echo "--- osc diff ---"
+          osc diff || true
+          if [ -n "$(osc status)" ]; then
+            osc commit -m "sync packaging from git ${GITHUB_SHA}"
+          else
+            echo "OBS package already in sync with git; nothing to commit."
+          fi
+
+  # --------------------------------------------------------------------------
   # Trigger the OBS source service to pull the new tarball and rebuild
   # all repo targets (Fedora, openSUSE Ubuntu, etc.). The token is a
   # "Run source services" token scoped to home:mmaher88:logitune/logitune,
   # created at https://build.opensuse.org/my/tokens.
+  #
+  # Runs after sync-obs-spec so any spec changes committed by that job
+  # are already live before this rebuild fires.
   # --------------------------------------------------------------------------
   trigger-obs:
-    needs: [release]
+    needs: [release, sync-obs-spec]
     runs-on: ubuntu-latest
     if: |
       always() && (


### PR DESCRIPTION
## Summary

Fixes the hidden bug that made PR #102 a no-op at runtime: OBS builds from its **own** VCS copy of the spec/_service/debian files, not from `pkg/obs/` in this repo. Until now, changes to `pkg/obs/` never reached OBS.

## Why this matters

When you tag a release today, the flow is:

1. `trigger-obs` hits OBS's `runservice` endpoint.
2. OBS runs `_service` → `tar_scm` pulls fresh master as a source tarball.
3. OBS builds **with its own stale spec** + fresh tarball.

That's why the uinput-ACL fix from PR #102 shipped as `0.3.4-17.1` without the `%post` scriptlet — the commit updated git's `pkg/obs/logitune.spec` but OBS's own copy still had the pre-PR version.

## How this PR fixes it

Adds a new `sync-obs-spec` job that runs **before** `trigger-obs` on the same triggers (tag push or `workflow_dispatch` with `trigger_obs=true`):

1. `osc checkout home:mmaher88:logitune/logitune` — pull OBS's VCS copy.
2. `rsync pkg/obs/ → OBS checkout` with `--delete` so removals propagate.
3. `osc addremove` + `osc commit` — pushes the updated spec/packaging files to OBS.
4. The `osc commit` causes OBS to re-run `_service` and rebuild. `trigger-obs` still runs after for belt-and-suspenders, and to re-trigger when only source changed.

After this lands, `pkg/obs/*` in git becomes the source of truth.

## Required repo secrets (ADD BEFORE TRIGGERING)

Two new secrets needed at https://github.com/mmaher88/logitune/settings/secrets/actions :

- `OSC_USERNAME` — your OBS account username (same one used to create `OBS_TRIGGER_TOKEN`).
- `OSC_PASSWORD` — your OBS account password, or an osc-compatible application password/token.

Without these, the `sync-obs-spec` job fails on `osc checkout`.

## Test plan

- [ ] Add `OSC_USERNAME` and `OSC_PASSWORD` secrets to the repo.
- [ ] Merge.
- [ ] Manually trigger: `gh workflow run release.yml -f trigger_obs=true`.
- [ ] Verify `sync-obs-spec` step logs show `osc commit` with a real changeset (the %post scriptlets finally landing on OBS).
- [ ] Verify OBS rebuilds (Fedora_42, xUbuntu_24.04 → `published`).
- [ ] On test VM: `sudo dnf upgrade logitune` → `rpm -q --scripts logitune` shows `%post` scriptlet → `/dev/uinput` gets ACL automatically after clean `setfacl -b` → install cycle.

## Future work

- Consider replacing `OSC_PASSWORD` with an OBS API token if/when `osc` adds token-auth support for commits (currently trigger-only tokens can't commit).
- Optionally run `sync-obs-spec` on every push to master that touches `pkg/obs/**` so out-of-band tag releases aren't required.