### PR TITLE
ci: fix osc checkout path in sync-obs-spec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,18 +225,27 @@ jobs:
           EOF
 
       - name: Checkout OBS package
-        run: osc checkout home:mmaher88:logitune logitune /tmp/obs-pkg
+        # osc checkout always nests <project>/<package>/ under PWD,
+        # regardless of any trailing positional arg. Work inside a known
+        # parent dir and reference the nested path explicitly.
+        run: |
+          mkdir -p /tmp/obs-workdir
+          cd /tmp/obs-workdir
+          osc checkout home:mmaher88:logitune logitune
+          test -d "/tmp/obs-workdir/home:mmaher88:logitune/logitune/.osc" \
+            || { echo "::error::osc checkout produced no working copy"; exit 1; }
 
       - name: Sync pkg/obs/ into OBS checkout
         run: |
           # Mirror pkg/obs/ into the OBS checkout, keeping osc's .osc/
           # metadata. --delete removes files deleted from git. osc addremove
           # then stages additions + deletions for commit.
-          rsync -av --delete --exclude '.osc' pkg/obs/ /tmp/obs-pkg/
+          rsync -av --delete --exclude '.osc' \
+            pkg/obs/ "/tmp/obs-workdir/home:mmaher88:logitune/logitune/"
 
       - name: Commit to OBS (triggers service + rebuild if files changed)
         run: |
-          cd /tmp/obs-pkg
+          cd "/tmp/obs-workdir/home:mmaher88:logitune/logitune"
           osc addremove
           echo "--- osc status ---"
           osc status || true


### PR DESCRIPTION
Follow-up to #103.

## What went wrong

On the first real run (https://github.com/mmaher88/logitune/actions/runs/24814060887), the `sync-obs-spec` job's commit step failed with:

```
Error: "/tmp/obs-pkg" is not an osc package working copy.
```

## Root cause

`osc checkout <project> <package> <target>` **always nests** `<project>/<package>/` under PWD. The trailing positional arg is a cwd-like hint, not a flat output target. So:

- Expected: `/tmp/obs-pkg/{_service,logitune.spec,...}`
- Actual: `/tmp/obs-pkg/home:mmaher88:logitune/logitune/{_service,logitune.spec,...}`

Then `rsync pkg/obs/ /tmp/obs-pkg/` wrote files into the empty wrapper dir — no `.osc/` metadata — and `osc commit` rightly refused.

## Fix

Checkout from a dedicated parent dir, then reference the nested working copy path explicitly in the rsync target and the commit `cd`. Added an early `.osc/` existence check so future regressions fail loudly instead of silently.

## Test plan

- [ ] Merge.
- [ ] Trigger `gh workflow run release.yml -f trigger_obs=true`.
- [ ] `sync-obs-spec` → commit step shows a real changeset (the `%post` scriptlets landing on OBS).
- [ ] OBS rebuilds → `rpm -q --scripts logitune` on the VM shows the new scriptlets.