### PR TITLE
ci(wiki-sync): rewrite diagrams/ image refs to raw URLs

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -37,16 +37,26 @@ jobs:
           set -euo pipefail
 
           # Absolute URL base for image references. GitHub wiki pages cannot
-          # reach into the main repo via relative paths, so rewrite every
-          # ../images/X.png to the canonical raw URL instead.
-          RAW_BASE="${GITHUB_SERVER_URL/github.com/raw.githubusercontent.com}/${GITHUB_REPOSITORY}/master/docs/images"
+          # reach into the main repo via relative paths, so rewrite image
+          # refs to canonical raw URLs. Two roots:
+          #   ../images/X.png       -> docs/images/ (app screenshots)
+          #   diagrams/X.png|svg    -> docs/wiki/diagrams/ (wiki diagrams)
+          RAW_IMAGES="${GITHUB_SERVER_URL/github.com/raw.githubusercontent.com}/${GITHUB_REPOSITORY}/master/docs/images"
+          RAW_DIAGRAMS="${GITHUB_SERVER_URL/github.com/raw.githubusercontent.com}/${GITHUB_REPOSITORY}/master/docs/wiki/diagrams"
 
           # Copy each wiki page, rewriting image paths. The wiki repo is flat:
           # every .md lives at the root, Home.md is the landing page.
+          # Only rewrite diagrams/ when it is the start of a URL (src="..."
+          # or ](...)) so references inside code spans like `docs/wiki/diagrams/...`
+          # are left alone.
           shopt -s nullglob
           for src in docs/wiki/*.md; do
             name=$(basename "$src")
-            sed "s|\.\./images/|${RAW_BASE//|/\\|}/|g" "$src" > "wiki/$name"
+            sed \
+              -e "s|\.\./images/|${RAW_IMAGES//|/\\|}/|g" \
+              -e "s|src=\"diagrams/|src=\"${RAW_DIAGRAMS//|/\\|}/|g" \
+              -e "s|](diagrams/|](${RAW_DIAGRAMS//|/\\|}/|g" \
+              "$src" > "wiki/$name"
           done
 
       - name: Commit and push


### PR DESCRIPTION
## Problem

On the rendered wiki, the **System Overview** image on the Architecture page fails to load — the alt text is shown instead.

Root cause: `wiki-sync.yml` copies only `docs/wiki/*.md` to the wiki repo (flat layout). The `docs/wiki/diagrams/` folder never ships there, so `<img src="diagrams/system-overview.png">` has nothing to resolve against on the wiki.

## Fix

Extend the existing sed rewrite (which already converts `../images/X.png` to canonical raw URLs under `docs/images/`) to also handle `diagrams/` refs, rewriting them to raw URLs under `docs/wiki/diagrams/` in the main repo.

The pattern is anchored to `src="diagrams/` and `](diagrams/` so plain text references inside code spans (e.g. the `Source: \`docs/wiki/diagrams/system-overview.svg\`` note) are left untouched.

## Verification

After this merges, `Sync Wiki` runs and the Architecture page should load the system overview image from:

`raw.githubusercontent.com/.../master/docs/wiki/diagrams/system-overview.png`