### PR TITLE
fix(approot): make onSelectionChanged idempotent on the active device

### DIFF
--- a/src/app/AppRoot.cpp
+++ b/src/app/AppRoot.cpp
@@ -297,6 +297,17 @@ void AppRoot::onSelectionChanged()
     auto *device = m_deviceResolver.activeDevice();
     if (!device) return;
 
+    // DeviceModel::selectedChanged also fires from refreshRow whenever any
+    // observable property of the selected device ticks (battery, SmartShift,
+    // DPI, etc.). For those, the active device pointer hasn't actually
+    // moved, so the orchestrator-replay below would re-prime the displayed-
+    // values cache from the profile and clobber the live hardware value the
+    // per-property NOTIFY chain just published. Bail out unless the active
+    // device actually changed.
+    if (device == m_lastSelectionTarget)
+        return;
+    m_lastSelectionTarget = device;
+
     // Tell the orchestrator about the new IDevice; it in turn emits
     // currentDeviceChanged which is wired to the dispatcher in wireSignals().
     m_profileOrchestrator.onCurrentDeviceChanged(device->descriptor());

--- a/src/app/AppRoot.h
+++ b/src/app/AppRoot.h
@@ -77,6 +77,14 @@ private:
     void wireSignals();
     void onSelectionChanged();
 
+    // Tracks the last active device handed to onSelectionChanged so the
+    // slot stays idempotent. DeviceModel::selectedChanged also fires from
+    // refreshRow on every per-property hardware tick, so without this
+    // guard a SmartShift / DPI / scroll change would immediately re-prime
+    // the displayed-values cache from the stored profile and overwrite the
+    // live hardware value the QML bindings should reflect.
+    PhysicalDevice *m_lastSelectionTarget = nullptr;
+
     static std::unique_ptr<IDesktopIntegration> makeOwnedDesktop(IDesktopIntegration *provided);
     static std::unique_ptr<IInputInjector>      makeOwnedInjector(IInputInjector *provided);
 

--- a/tests/test_app_root.cpp
+++ b/tests/test_app_root.cpp
@@ -438,9 +438,16 @@ TEST_F(AppRootFixture, MediaActionPerProfileSwitching) {
 
 TEST_F(AppRootFixture, CarouselSwitchSwapsButtonModel) {
     // Fixture's primary device "mock-serial" is selected (index 0). Set
-    // its button 3 to a distinctive action.
+    // its button 3 to a distinctive action and bounce the display profile
+    // so ButtonModel re-loads from the mutated cache. (Mutating the cache
+    // alone doesn't refresh the ButtonModel; that requires going through
+    // onDisplayProfileChanged.)
     setProfileButton("default", 3,
                      {ButtonAction::Keystroke, QStringLiteral("Alt+Left")});
+    profileEngine().setDisplayProfile(
+        QStringLiteral("mock-serial"), QString());
+    profileEngine().setDisplayProfile(
+        QStringLiteral("mock-serial"), QStringLiteral("default"));
     deviceModel().setSelectedIndex(0);
 
     auto *secondary = addMockDevice(QStringLiteral("B"));
@@ -453,8 +460,7 @@ TEST_F(AppRootFixture, CarouselSwitchSwapsButtonModel) {
             serialB, QStringLiteral("default"));
     }
 
-    // Select device A explicitly and confirm ButtonModel reflects A.
-    deviceModel().setSelectedIndex(0);
+    // ButtonModel reflects A's profile.
     EXPECT_EQ(buttonModel().actionTypeForButton(3),
               QStringLiteral("keystroke"));
 
@@ -489,17 +495,25 @@ TEST_F(AppRootFixture, DisplayProfileChangedIgnoredForNonSelectedDevice) {
     deviceModel().setSelectedIndex(0);
     EXPECT_EQ(deviceModel().currentDPI(), 1000);
 
-    // Add a second device without switching to it. Primary stays selected.
-    addMockDevice(QStringLiteral("B"), /*seedDpi=*/2500);
-    EXPECT_EQ(deviceModel().selectedIndex(), 0);
-
-    // Modify device B's cached profile and fire its displayProfile signal.
-    // setDisplayProfile short-circuits on unchanged name, so bounce through
-    // an intermediate value to force emission.
+    // Register a second device's profile dir with the engine WITHOUT
+    // adding it to the carousel. addMockDevice would also drive
+    // setupProfileForDevice + applyProfileToHardware, which routes
+    // through the active session (i.e. A's) and clobbers A's hardware
+    // values. We're testing the engine-level filter here, not transport
+    // routing, so we sidestep that path.
     const QString serialB = QStringLiteral("mock-serial-B");
-    Profile &pB = profileEngine().cachedProfile(
+    const QString dirB = m_tmpDir.path() + "/" + serialB + "/profiles";
+    QDir().mkpath(dirB);
+    Profile pB;
+    pB.name = QStringLiteral("Default");
+    pB.dpi  = 9999;
+    ProfileEngine::saveProfile(dirB + "/default.conf", pB);
+    profileEngine().registerDevice(serialB, dirB);
+
+    // Bounce setDisplayProfile to force deviceDisplayProfileChanged emission
+    // (setDisplayProfile short-circuits on unchanged name).
+    profileEngine().setDisplayProfile(
         serialB, QStringLiteral("default"));
-    pB.dpi = 9999;
     profileEngine().setDisplayProfile(
         serialB, QStringLiteral("other"));
     profileEngine().setDisplayProfile(
@@ -508,4 +522,28 @@ TEST_F(AppRootFixture, DisplayProfileChangedIgnoredForNonSelectedDevice) {
     // DeviceModel should still reflect device A's 1000 DPI — the
     // onDisplayProfileChanged filter rejected device B's signal.
     EXPECT_EQ(deviceModel().currentDPI(), 1000);
+}
+
+// Regression test for the stale-cache-on-state-tick bug. The per-property
+// NOTIFY chain (DeviceSession -> PhysicalDevice -> DeviceModel) clears
+// m_hasDisplayValues so QML re-reads the live session value. A separate
+// path also fires DeviceModel::selectedChanged from refreshRow on the
+// same state tick; AppRoot::onSelectionChanged must not treat that as a
+// real selection change and replay onDisplayProfileChanged, which would
+// re-prime the cache from the stored profile and clobber the live value.
+TEST_F(AppRootFixture, HardwareDpiTickDoesNotRepriDisplayCache) {
+    deviceModel().setSelectedIndex(0);
+    EXPECT_EQ(deviceModel().currentDPI(), 1000);  // primed from profile
+
+    // Simulate a hardware-side DPI change on the selected device (e.g. the
+    // user pressed the DPI cycle button on the mouse). Going through
+    // DeviceSession::setDPI exercises the same per-property emit + stateChanged
+    // co-fire that the live HID++ path produces.
+    m_session->setDPI(2400);
+
+    // Without the fix: AppRoot::onSelectionChanged is re-driven by
+    // refreshRow's selectedChanged emit, replays onDisplayProfileChanged,
+    // and setDisplayValues re-arms m_displayDpi back to the profile's 1000.
+    // With the fix: same active device, so onSelectionChanged bails.
+    EXPECT_EQ(deviceModel().currentDPI(), 2400);
 }


### PR DESCRIPTION
## Summary

Restores the per-property NOTIFY chain from #68 that #108 silently regressed. Pressing the DPI cycle / SmartShift button on the mouse now correctly updates the on-page values.

Closes #114.

## Mechanism

`AppRoot::onSelectionChanged` was driven by `DeviceModel::selectedChanged`, which fires both on real selection changes and on every state tick of the selected device (via `refreshRow`). The slot was replaying `ProfileOrchestrator::onDisplayProfileChanged(serial, profile)` and re-arming the displayed-values cache from the stored profile, clobbering the live hardware value the per-property NOTIFY chain just published.

## Fix

Track the last active `PhysicalDevice*` and bail when it has not changed. Real carousel switches still flow through; state ticks for the same active device do not.

## Tests

Two existing `AppRootFixture` tests (`CarouselSwitchSwapsButtonModel`, `DisplayProfileChangedIgnoredForNonSelectedDevice`) were passing only because of the bug being fixed. Updated:

- `CarouselSwitchSwapsButtonModel` now bounces `setDisplayProfile` after the profile mutation to refresh `ButtonModel`. Mutating the cache alone never refreshed it; the previous behavior was a side effect of the cache-reprime loop.
- `DisplayProfileChangedIgnoredForNonSelectedDevice` now registers the second device's profile dir directly with the engine instead of going through `addMockDevice`. This sidesteps an orthogonal session-routing bug in `ProfileOrchestrator::applyProfileToHardware` (uses `m_selection->activeSession()` instead of the per-device session, so `setupProfileForDevice(B)` writes B's profile values to A's session). The test now exercises only the engine-level filter it claims to test.

Added regression test `HardwareDpiTickDoesNotRepriDisplayCache`: simulates a hardware-side `setDPI` on the selected device and asserts `DeviceModel::currentDPI()` returns the live value, not the stored profile's. Verified to fail without the fix.

Tangentially confirmed the orthogonal `applyProfileToHardware` session-routing bug while writing the test fix; out of scope here, will file a follow-up.

## Test plan

- [x] All 647 unit + integration tests pass.
- [x] Regression test fails without the fix.
- [x] Manually verified on MX Master 3S: DPI cycle and SmartShift buttons now update the on-page values.