### PR TITLE
feat(desktop): add Hyprland support

### DIFF
--- a/docs/wiki/Adding-a-Desktop-Environment.md
+++ b/docs/wiki/Adding-a-Desktop-Environment.md
@@ -32,7 +32,7 @@ signals:
 | `available()` | Return true if this DE is detected and usable | Checked before relying on DE features |
 | `desktopName()` | Human-readable name (e.g., "KDE", "GNOME") | Logging and UI |
 | `detectedCompositors()` | List of detected compositor names | Diagnostics |
-| `variantKey()` | Short string key matching a top-level key under `variants` in `actions.json` (e.g. `"kde"`, `"gnome"`, `"generic"`). | Read by `ActionFilterModel` per row, by `ActionPresetRegistry::supportedBy` queries. |
+| `variantKey()` | Short string key matching a top-level key under `variants` in `actions.json` (e.g. `"kde"`, `"gnome"`, `"hyprland"`, `"generic"`). | Read by `ActionFilterModel` per row, by `ActionPresetRegistry::supportedBy` queries. |
 | `resolveNamedAction(id)` | Turn a semantic preset id into a concrete `ButtonAction`, or `nullopt` if this DE cannot resolve it. | Called by `ButtonActionDispatcher` on every button press with a `PresetRef` action, and by `ActionFilterModel` at filter time to grey out presets whose live binding is empty. |
 | `blockGlobalShortcuts(bool)` | Temporarily disable global shortcuts during keystroke capture | During KeystrokeCapture QML component |
 | `runningApplications()` | Return list of installed GUI applications | App profile picker dialog |
@@ -346,7 +346,7 @@ GNOME has no binding-independent invoker for most actions, so the GNOME impl rea
 
 ### Example: Hyprland / Sway / i3
 
-The tiling WMs have IPC-dispatchable actions by name. A `hyprctl` / `swaymsg` / `i3-msg` hint kind could produce `ButtonAction{AppLaunch, "hyprctl dispatch exec ..."}` or similar. Binding-independent like KDE.
+Hyprland support uses IPC for focus tracking and live bind inspection for presets. The C++ integration listens to Hyprland's event socket for `activewindow` events and queries `j/binds` from the command socket when resolving supported semantic presets. A preset only appears when a matching keyboard bind exists in the default submap; unsupported or unbound presets return `nullopt`.
 
 ### If your DE does not support some presets
 
@@ -370,10 +370,11 @@ These could live in a `DesktopUtils` static class or be moved to the `GenericDes
 
 Hyprland is a wlroots-based compositor with a powerful IPC system. Here is a brief outline:
 
-1. **Class**: `HyprlandDesktop` extending `IDesktopIntegration`
+1. **Class**: `HyprlandDesktop` extending `LinuxDesktopBase`
 2. **Focus tracking**: Subscribe to Hyprland IPC socket (`$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock`) for `activewindow>>` events
 3. **Window identity**: Hyprland reports the `class` property, equivalent to X11 `WM_CLASS`. Run through `resolveDesktopFile()`.
-4. **blockGlobalShortcuts**: Use `hyprctl keyword bind` to temporarily unbind all shortcuts, or use `hyprctl dispatch submap` to switch to an empty submap
-5. **Detection**: Check for `HYPRLAND_INSTANCE_SIGNATURE` environment variable
+4. **Preset resolution**: Query `j/binds` from the Hyprland command socket and map matching keyboard binds to Logitune `Keystroke` payloads.
+5. **blockGlobalShortcuts**: Leave as a no-op unless Hyprland gains a stable compositor-wide shortcut-block API.
+6. **Detection**: Check `XDG_CURRENT_DESKTOP` for `Hyprland` or `HYPRLAND_INSTANCE_SIGNATURE`.
 
-The Hyprland IPC approach would be event-driven (no polling), making it more efficient than the GNOME polling fallback.
+The Hyprland IPC approach is event-driven (no polling), making focus tracking efficient and low latency.

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -786,7 +786,9 @@ After the extension is in place, `GnomeDesktop` registers the service `com.logit
 
 ### Generic Desktop Fallback
 
-`GenericDesktop` (`src/core/desktop/GenericDesktop.{h,cpp}`) is the no-op fallback for desktop environments that are neither KDE nor GNOME (XFCE, MATE, Cinnamon, sway, Hyprland, etc.). `start()` does nothing, `available()` returns true unconditionally, `desktopName()` returns `"Generic"`, `detectedCompositors()` returns an empty list, and `blockGlobalShortcuts(bool)` is a no-op. The practical consequence: per-app profile switching is disabled on these environments because there is no focus-tracking signal; the user can still switch profiles manually through the profile tab bar, and every other feature (HID++, button remapping, uinput injection) continues to work.
+`HyprlandDesktop` (`src/core/desktop/HyprlandDesktop.{h,cpp}`) is the Hyprland implementation. It connects to Hyprland's event socket at `$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock`, listens for `activewindow` events, resolves the reported window class through the shared `.desktop` lookup, and emits `activeWindowChanged` for automatic per-app profile switching. Its semantic presets are resolved from the user's live Hyprland binds by querying the command socket with `j/binds`; unsupported or unbound presets are hidden. `blockGlobalShortcuts(bool)` is intentionally a no-op because Hyprland does not expose a stable compositor-wide shortcut-block API.
+
+`GenericDesktop` (`src/core/desktop/GenericDesktop.{h,cpp}`) is the no-op fallback for desktop environments that are neither KDE, GNOME, nor Hyprland (XFCE, MATE, Cinnamon, sway, etc.). `start()` does nothing, `available()` returns true unconditionally, `desktopName()` returns `"Generic"`, `detectedCompositors()` returns an empty list, and `blockGlobalShortcuts(bool)` is a no-op. The practical consequence: per-app profile switching is disabled on these environments because there is no focus-tracking signal; the user can still switch profiles manually through the profile tab bar, and every other feature (HID++, button remapping, uinput injection) continues to work.
 
 ### Input Injection
 
@@ -1278,12 +1280,14 @@ Semantic action presets let the action catalog contain DE-independent entries li
 
 Each `IDesktopIntegration` impl overrides two virtuals:
 
-- `variantKey()` returns the short string key used in `actions.json` (`"kde"`, `"gnome"`, `"generic"`).
+- `variantKey()` returns the short string key used in `actions.json` (`"kde"`, `"gnome"`, `"hyprland"`, `"generic"`).
 - `resolveNamedAction(id)` returns `std::optional<ButtonAction>` - the concrete action the executor can fire, or nullopt if this DE cannot resolve the preset.
 
 **KDE** (`KDeDesktop::resolveNamedAction`) reads the `kde` variant from the registry. For a `kglobalaccel` hint (`{"component": "...", "name": "..."}`), it emits a DBus `ButtonAction` with a 5-field payload: `org.kde.kglobalaccel,/component/<component>,org.kde.kglobalaccel.Component,invokeShortcut,<name>`. kglobalaccel then invokes the action by name, independent of what keystroke the user has bound to it. For `app-launch` hints, it returns an `AppLaunch` ButtonAction directly.
 
 **GNOME** (`GnomeDesktop::resolveNamedAction`) reads the `gnome` variant. For a `gsettings` hint (`{"schema": "...", "key": "..."}`), it shells out to `gsettings get <schema> <key>` via QProcess, parses the GLib variant output (e.g. `['<Super>d']`), and rewrites the modifier tokens into Logitune keystroke format (`<Primary>` -> `Ctrl`, `<Super>`/`<Meta>`/`<Hyper>` -> `Super`, `<AltGr>`/`<ISO_Level3_Shift>` dropped). Returns a `Keystroke` ButtonAction with the resolved combo. Empty binding (user cleared the shortcut) returns nullopt so the picker can grey out the preset. For `app-launch` hints, direct passthrough.
+
+**Hyprland** (`HyprlandDesktop::resolveNamedAction`) reads the `hyprland` variant. For a `hyprland-bind` hint (`{"dispatcher": "...", "arg": "..."}`), it queries Hyprland's live bind list through `j/binds`, finds a matching default-submap keyboard bind, converts supported modifiers (`Ctrl`, `Shift`, `Alt`, `Super`) and keys into Logitune keystroke format, and returns a `Keystroke` ButtonAction. Missing binds, mouse binds, unsupported modifier masks, or unsupported key names return nullopt. For `app-launch` hints, direct passthrough.
 
 **Generic** returns nullopt for every id. No preset has a `"generic"` variant in the shipped catalog.
 

--- a/docs/wiki/Testing.md
+++ b/docs/wiki/Testing.md
@@ -436,6 +436,7 @@ All tests run with `QT_QPA_PLATFORM=offscreen` (no display server required).
 | `test_action_model.cpp` | ActionModel catalog, indexForName, payloadForName |
 | `test_device_model.cpp` | DeviceModel display values, settings relay |
 | `test_wmclass_resolution.cpp` | Desktop file resolution logic |
+| `core/desktop/test_hyprland_desktop_resolve.cpp` | Hyprland focus events and live-bind preset resolution |
 | `test_app_controller.cpp` | AppRoot init, wireSignals, device setup |
 | `test_profile_switching.cpp` | Focus change triggers profile switch |
 | `test_profile_persistence.cpp` | Profile save/load round-trip |

--- a/src/app/AppRoot.cpp
+++ b/src/app/AppRoot.cpp
@@ -3,6 +3,7 @@
 #include "models/EditorModel.h"
 #include "desktop/KDeDesktop.h"
 #include "desktop/GnomeDesktop.h"
+#include "desktop/HyprlandDesktop.h"
 #include "desktop/GenericDesktop.h"
 #include "input/UinputInjector.h"
 #include "logging/LogManager.h"
@@ -15,8 +16,12 @@ namespace logitune {
 std::unique_ptr<IDesktopIntegration> AppRoot::makeOwnedDesktop(IDesktopIntegration *provided)
 {
     if (provided) return {};
-    const QString xdgDesktop = QProcessEnvironment::systemEnvironment()
-                                   .value(QStringLiteral("XDG_CURRENT_DESKTOP"));
+    const QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    const QString xdgDesktop = env.value(QStringLiteral("XDG_CURRENT_DESKTOP"));
+    if (xdgDesktop.contains(QStringLiteral("Hyprland"), Qt::CaseInsensitive)
+        || !env.value(QStringLiteral("HYPRLAND_INSTANCE_SIGNATURE")).isEmpty()) {
+        return std::make_unique<HyprlandDesktop>();
+    }
     if (xdgDesktop.contains(QStringLiteral("KDE"), Qt::CaseInsensitive))
         return std::make_unique<KDeDesktop>();
     if (xdgDesktop.contains(QStringLiteral("GNOME"), Qt::CaseInsensitive))
@@ -67,6 +72,8 @@ AppRoot::AppRoot(IDesktopIntegration *desktop, IInputInjector *injector, QObject
         kde->setPresetRegistry(&m_presetRegistry);
     if (auto *gnome = dynamic_cast<GnomeDesktop *>(m_desktop))
         gnome->setPresetRegistry(&m_presetRegistry);
+    if (auto *hyprland = dynamic_cast<HyprlandDesktop *>(m_desktop))
+        hyprland->setPresetRegistry(&m_presetRegistry);
 }
 
 AppRoot::~AppRoot() = default;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(logitune-core PRIVATE
     interfaces/ITransport.cpp
     desktop/LinuxDesktopBase.cpp
     desktop/GnomeDesktop.cpp
+    desktop/HyprlandDesktop.cpp
     desktop/KDeDesktop.cpp
     desktop/GenericDesktop.cpp
     input/UinputInjector.cpp

--- a/src/core/actions/actions.json
+++ b/src/core/actions/actions.json
@@ -26,7 +26,8 @@
     "category": "workspace",
     "variants": {
       "kde":   { "kglobalaccel": { "component": "kwin", "name": "Switch to Previous Desktop" } },
-      "gnome": { "gsettings":    { "schema": "org.gnome.desktop.wm.keybindings", "key": "switch-to-workspace-left" } }
+      "gnome": { "gsettings":    { "schema": "org.gnome.desktop.wm.keybindings", "key": "switch-to-workspace-left" } },
+      "hyprland": { "hyprland-bind": { "dispatcher": "workspace", "arg": "r-1" } }
     }
   },
   {
@@ -36,7 +37,8 @@
     "category": "workspace",
     "variants": {
       "kde":   { "kglobalaccel": { "component": "kwin", "name": "Switch to Next Desktop" } },
-      "gnome": { "gsettings":    { "schema": "org.gnome.desktop.wm.keybindings", "key": "switch-to-workspace-right" } }
+      "gnome": { "gsettings":    { "schema": "org.gnome.desktop.wm.keybindings", "key": "switch-to-workspace-right" } },
+      "hyprland": { "hyprland-bind": { "dispatcher": "workspace", "arg": "r+1" } }
     }
   },
   {
@@ -56,7 +58,8 @@
     "category": "window",
     "variants": {
       "kde":   { "kglobalaccel": { "component": "kwin", "name": "Window Close" } },
-      "gnome": { "gsettings":    { "schema": "org.gnome.desktop.wm.keybindings", "key": "close" } }
+      "gnome": { "gsettings":    { "schema": "org.gnome.desktop.wm.keybindings", "key": "close" } },
+      "hyprland": { "hyprland-bind": { "dispatcher": "killactive" } }
     }
   },
   {

--- a/src/core/desktop/HyprlandDesktop.cpp
+++ b/src/core/desktop/HyprlandDesktop.cpp
@@ -1,0 +1,339 @@
+#include "desktop/HyprlandDesktop.h"
+#include "actions/ActionPresetRegistry.h"
+#include "logging/LogManager.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLocalSocket>
+#include <QProcessEnvironment>
+#include <QTimer>
+
+namespace logitune {
+
+namespace {
+constexpr int kSocketTimeoutMs = 1000;
+constexpr int kReconnectIntervalMs = 1000;
+
+bool hasUnsupportedModifiers(int modmask)
+{
+    constexpr int supported =
+        0x01 |  // Shift
+        0x04 |  // Ctrl
+        0x08 |  // Alt
+        0x40;   // Super
+    return (modmask & ~supported) != 0;
+}
+} // namespace
+
+HyprlandDesktop::HyprlandDesktop(QObject *parent)
+    : LinuxDesktopBase(parent)
+{
+}
+
+void HyprlandDesktop::start()
+{
+    if (!m_reconnectTimer) {
+        m_reconnectTimer = new QTimer(this);
+        m_reconnectTimer->setSingleShot(true);
+        m_reconnectTimer->setInterval(kReconnectIntervalMs);
+        connect(m_reconnectTimer, &QTimer::timeout,
+                this, &HyprlandDesktop::connectEventSocket);
+    }
+
+    if (eventSocketPath().isEmpty()) {
+        qCWarning(lcFocus) << "Hyprland: missing IPC socket path; focus tracking disabled";
+        m_available = false;
+        return;
+    }
+
+    connectEventSocket();
+}
+
+bool HyprlandDesktop::available() const
+{
+    return m_available;
+}
+
+QString HyprlandDesktop::desktopName() const
+{
+    return QStringLiteral("Hyprland");
+}
+
+QStringList HyprlandDesktop::detectedCompositors() const
+{
+    QStringList compositors;
+    const QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    const QString desktop = env.value(QStringLiteral("XDG_CURRENT_DESKTOP"));
+    if (desktop.contains(QStringLiteral("Hyprland"), Qt::CaseInsensitive)
+        || !env.value(QStringLiteral("HYPRLAND_INSTANCE_SIGNATURE")).isEmpty()) {
+        compositors << QStringLiteral("Hyprland");
+    }
+    return compositors;
+}
+
+void HyprlandDesktop::blockGlobalShortcuts(bool)
+{
+    // Hyprland does not provide a stable compositor-wide shortcut-block API.
+    // Keystroke capture remains functional; global bindings may still fire.
+}
+
+QString HyprlandDesktop::variantKey() const
+{
+    return QStringLiteral("hyprland");
+}
+
+std::optional<ButtonAction> HyprlandDesktop::resolveNamedAction(const QString &id) const
+{
+    if (!m_registry)
+        return std::nullopt;
+
+    const QJsonObject variant = m_registry->variantData(id, QStringLiteral("hyprland"));
+    if (variant.isEmpty())
+        return std::nullopt;
+
+    if (variant.contains(QStringLiteral("hyprland-bind")))
+        return resolveHyprlandBind(variant.value(QStringLiteral("hyprland-bind")).toObject());
+
+    if (variant.contains(QStringLiteral("app-launch"))) {
+        const QJsonObject spec = variant.value(QStringLiteral("app-launch")).toObject();
+        const QString binary = spec.value(QStringLiteral("binary")).toString();
+        if (binary.isEmpty())
+            return std::nullopt;
+        return ButtonAction{ButtonAction::AppLaunch, binary};
+    }
+
+    return std::nullopt;
+}
+
+void HyprlandDesktop::connectEventSocket()
+{
+    const QString path = eventSocketPath();
+    if (path.isEmpty()) {
+        m_available = false;
+        return;
+    }
+
+    if (!m_eventSocket) {
+        m_eventSocket = new QLocalSocket(this);
+        connect(m_eventSocket, &QLocalSocket::readyRead,
+                this, &HyprlandDesktop::onEventReadyRead);
+        connect(m_eventSocket, &QLocalSocket::connected, this, [this]() {
+            m_available = true;
+            qCInfo(lcFocus) << "Hyprland desktop integration started";
+        });
+        connect(m_eventSocket, &QLocalSocket::disconnected,
+                this, &HyprlandDesktop::scheduleReconnect);
+        connect(m_eventSocket, &QLocalSocket::errorOccurred, this,
+                [this](QLocalSocket::LocalSocketError) {
+                    m_available = false;
+                    scheduleReconnect();
+                });
+    }
+
+    if (m_eventSocket->state() != QLocalSocket::UnconnectedState)
+        m_eventSocket->abort();
+
+    m_eventBuffer.clear();
+    m_eventSocket->connectToServer(path);
+}
+
+void HyprlandDesktop::scheduleReconnect()
+{
+    m_available = false;
+    if (m_reconnectTimer && !m_reconnectTimer->isActive())
+        m_reconnectTimer->start();
+}
+
+void HyprlandDesktop::onEventReadyRead()
+{
+    if (!m_eventSocket)
+        return;
+
+    m_eventBuffer += m_eventSocket->readAll();
+
+    int newline = -1;
+    while ((newline = m_eventBuffer.indexOf('\n')) >= 0) {
+        const QByteArray line = m_eventBuffer.left(newline).trimmed();
+        m_eventBuffer.remove(0, newline + 1);
+        handleEventLine(line);
+    }
+}
+
+void HyprlandDesktop::handleEventLine(const QByteArray &line)
+{
+    static const QByteArray prefix = "activewindow>>";
+    if (!line.startsWith(prefix))
+        return;
+
+    const QByteArray payload = line.mid(prefix.size());
+    const int comma = payload.indexOf(',');
+    const QString resourceClass = QString::fromUtf8(
+        comma >= 0 ? payload.left(comma) : payload).trimmed();
+    const QString title = comma >= 0
+        ? QString::fromUtf8(payload.mid(comma + 1)).trimmed()
+        : QString();
+
+    if (resourceClass.isEmpty())
+        return;
+
+    const QString appId = resolveDesktopFile(resourceClass);
+    if (appId == m_lastAppId)
+        return;
+
+    m_lastAppId = appId;
+    emit activeWindowChanged(appId, title);
+}
+
+QString HyprlandDesktop::socketDir() const
+{
+    if (!m_socketDirOverride.isEmpty())
+        return m_socketDirOverride;
+
+    const QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    const QString runtimeDir = env.value(QStringLiteral("XDG_RUNTIME_DIR"));
+    const QString signature = env.value(QStringLiteral("HYPRLAND_INSTANCE_SIGNATURE"));
+    if (runtimeDir.isEmpty() || signature.isEmpty())
+        return {};
+
+    return runtimeDir + QStringLiteral("/hypr/") + signature;
+}
+
+QString HyprlandDesktop::eventSocketPath() const
+{
+    const QString dir = socketDir();
+    return dir.isEmpty() ? QString() : dir + QStringLiteral("/.socket2.sock");
+}
+
+QString HyprlandDesktop::commandSocketPath() const
+{
+    const QString dir = socketDir();
+    return dir.isEmpty() ? QString() : dir + QStringLiteral("/.socket.sock");
+}
+
+QByteArray HyprlandDesktop::readHyprlandCommand(const QByteArray &command) const
+{
+    const QString path = commandSocketPath();
+    if (path.isEmpty() || !QFileInfo::exists(path))
+        return {};
+
+    QLocalSocket socket;
+    socket.connectToServer(path);
+    if (!socket.waitForConnected(kSocketTimeoutMs))
+        return {};
+
+    socket.write(command);
+    if (!socket.waitForBytesWritten(kSocketTimeoutMs))
+        return {};
+
+    QByteArray out;
+    if (socket.waitForReadyRead(kSocketTimeoutMs))
+        out += socket.readAll();
+    while (socket.waitForReadyRead(25))
+        out += socket.readAll();
+
+    socket.disconnectFromServer();
+    return out;
+}
+
+QByteArray HyprlandDesktop::readBindsJson() const
+{
+    if (m_bindReader)
+        return m_bindReader();
+    return readHyprlandCommand(QByteArrayLiteral("j/binds"));
+}
+
+std::optional<ButtonAction> HyprlandDesktop::resolveHyprlandBind(
+    const QJsonObject &spec) const
+{
+    const QString dispatcher = spec.value(QStringLiteral("dispatcher")).toString();
+    const bool requiresArg = spec.contains(QStringLiteral("arg"));
+    const QString arg = spec.value(QStringLiteral("arg")).toString();
+    if (dispatcher.isEmpty())
+        return std::nullopt;
+
+    QJsonParseError error{};
+    const QJsonDocument doc = QJsonDocument::fromJson(readBindsJson(), &error);
+    if (error.error != QJsonParseError::NoError || !doc.isArray())
+        return std::nullopt;
+
+    const QJsonArray binds = doc.array();
+    for (const QJsonValue &value : binds) {
+        const QJsonObject bind = value.toObject();
+        if (bind.value(QStringLiteral("mouse")).toBool())
+            continue;
+        if (!bind.value(QStringLiteral("submap")).toString().isEmpty())
+            continue;
+        if (bind.value(QStringLiteral("dispatcher")).toString()
+                .compare(dispatcher, Qt::CaseInsensitive) != 0) {
+            continue;
+        }
+        if (requiresArg && bind.value(QStringLiteral("arg")).toString() != arg)
+            continue;
+
+        const QString combo = bindingToKeystroke(
+            bind.value(QStringLiteral("modmask")).toInt(),
+            bind.value(QStringLiteral("key")).toString());
+        if (!combo.isEmpty())
+            return ButtonAction{ButtonAction::Keystroke, combo};
+    }
+
+    return std::nullopt;
+}
+
+QString HyprlandDesktop::bindingToKeystroke(int modmask, const QString &key)
+{
+    if (key.isEmpty() || key.startsWith(QStringLiteral("mouse:"), Qt::CaseInsensitive)
+        || hasUnsupportedModifiers(modmask)) {
+        return {};
+    }
+
+    QStringList parts;
+    if (modmask & 0x04) parts << QStringLiteral("Ctrl");
+    if (modmask & 0x01) parts << QStringLiteral("Shift");
+    if (modmask & 0x08) parts << QStringLiteral("Alt");
+    if (modmask & 0x40) parts << QStringLiteral("Super");
+
+    const QString normalized = normalizeKeyName(key);
+    if (normalized.isEmpty())
+        return {};
+
+    parts << normalized;
+    return parts.join(QLatin1Char('+'));
+}
+
+QString HyprlandDesktop::normalizeKeyName(const QString &key)
+{
+    const QString trimmed = key.trimmed();
+    if (trimmed.isEmpty())
+        return {};
+    if (trimmed.length() == 1)
+        return trimmed;
+
+    const QString lower = trimmed.toLower();
+    if (lower == QStringLiteral("return")) return QStringLiteral("Enter");
+    if (lower == QStringLiteral("enter")) return QStringLiteral("Enter");
+    if (lower == QStringLiteral("escape")) return QStringLiteral("Escape");
+    if (lower == QStringLiteral("esc")) return QStringLiteral("Escape");
+    if (lower == QStringLiteral("delete")) return QStringLiteral("Delete");
+    if (lower == QStringLiteral("space")) return QStringLiteral("Space");
+    if (lower == QStringLiteral("tab")) return QStringLiteral("Tab");
+    if (lower == QStringLiteral("left")) return QStringLiteral("Left");
+    if (lower == QStringLiteral("right")) return QStringLiteral("Right");
+    if (lower == QStringLiteral("up")) return QStringLiteral("Up");
+    if (lower == QStringLiteral("down")) return QStringLiteral("Down");
+    if (lower == QStringLiteral("print") || lower == QStringLiteral("printscreen"))
+        return QStringLiteral("Print");
+    if (lower.startsWith(QLatin1Char('f'))) {
+        bool ok = false;
+        const int n = lower.mid(1).toInt(&ok);
+        if (ok && n >= 1 && n <= 12)
+            return QStringLiteral("F%1").arg(n);
+    }
+
+    return {};
+}
+
+} // namespace logitune

--- a/src/core/desktop/HyprlandDesktop.h
+++ b/src/core/desktop/HyprlandDesktop.h
@@ -1,0 +1,66 @@
+#pragma once
+#include "desktop/LinuxDesktopBase.h"
+#include <QByteArray>
+#include <functional>
+#include <optional>
+
+class QLocalSocket;
+class QJsonObject;
+class QTimer;
+
+namespace logitune {
+
+class ActionPresetRegistry;
+
+class HyprlandDesktop : public LinuxDesktopBase {
+    Q_OBJECT
+public:
+    using BindReader = std::function<QByteArray()>;
+
+    explicit HyprlandDesktop(QObject *parent = nullptr);
+
+    void start() override;
+    bool available() const override;
+    QString desktopName() const override;
+    QStringList detectedCompositors() const override;
+    void blockGlobalShortcuts(bool block) override;
+    QString variantKey() const override;
+    std::optional<ButtonAction> resolveNamedAction(const QString &id) const override;
+
+    /// Test seam: point to a registry the resolver should query.
+    /// Takes non-owning pointer; the registry must outlive this object.
+    void setPresetRegistry(const ActionPresetRegistry *registry) { m_registry = registry; }
+
+    /// Test seam: replace the default Hyprland command-socket bind reader.
+    void setBindReader(BindReader reader) { m_bindReader = std::move(reader); }
+
+    /// Test seam: override $XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE.
+    void setSocketDirForTest(const QString &socketDir) { m_socketDirOverride = socketDir; }
+
+private:
+    void connectEventSocket();
+    void scheduleReconnect();
+    void onEventReadyRead();
+    void handleEventLine(const QByteArray &line);
+
+    QString socketDir() const;
+    QString eventSocketPath() const;
+    QString commandSocketPath() const;
+    QByteArray readHyprlandCommand(const QByteArray &command) const;
+    QByteArray readBindsJson() const;
+    std::optional<ButtonAction> resolveHyprlandBind(const QJsonObject &spec) const;
+
+    static QString bindingToKeystroke(int modmask, const QString &key);
+    static QString normalizeKeyName(const QString &key);
+
+    QLocalSocket *m_eventSocket = nullptr;
+    QTimer *m_reconnectTimer = nullptr;
+    QByteArray m_eventBuffer;
+    QString m_lastAppId;
+    QString m_socketDirOverride;
+    bool m_available = false;
+    const ActionPresetRegistry *m_registry = nullptr;
+    BindReader m_bindReader;
+};
+
+} // namespace logitune

--- a/src/core/interfaces/IDesktopIntegration.h
+++ b/src/core/interfaces/IDesktopIntegration.h
@@ -20,7 +20,7 @@ public:
     virtual QStringList detectedCompositors() const = 0;
 
     /// Short key identifying this DE in the action preset variants map
-    /// (e.g. "kde", "gnome", "generic"). Matches a top-level key under
+    /// (e.g. "kde", "gnome", "hyprland", "generic"). Matches a top-level key under
     /// "variants" in actions.json.
     virtual QString variantKey() const = 0;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(logitune-tests
     core/actions/test_action_preset.cpp
     core/actions/test_action_preset_registry.cpp
     core/desktop/test_generic_desktop_resolve.cpp
+    core/desktop/test_hyprland_desktop_resolve.cpp
     core/desktop/test_kde_desktop_resolve.cpp
     core/desktop/test_gnome_desktop_resolve.cpp
     services/test_active_device_resolver.cpp

--- a/tests/core/actions/test_action_preset_registry.cpp
+++ b/tests/core/actions/test_action_preset_registry.cpp
@@ -141,6 +141,27 @@ TEST(ActionPresetRegistry, ShippedShowDesktopHasKdeAndGnomeVariants) {
     r.loadFromResource();
     EXPECT_TRUE(r.supportedBy("show-desktop", "kde"));
     EXPECT_TRUE(r.supportedBy("show-desktop", "gnome"));
+    EXPECT_FALSE(r.supportedBy("show-desktop", "hyprland"));
+}
+
+TEST(ActionPresetRegistry, ShippedHyprlandVariantsUseLiveBinds) {
+    ActionPresetRegistry r;
+    r.loadFromResource();
+
+    EXPECT_TRUE(r.supportedBy("close-window", "hyprland"));
+    EXPECT_TRUE(r.supportedBy("switch-desktop-left", "hyprland"));
+    EXPECT_TRUE(r.supportedBy("switch-desktop-right", "hyprland"));
+    EXPECT_FALSE(r.supportedBy("task-switcher", "hyprland"));
+    EXPECT_FALSE(r.supportedBy("screenshot", "hyprland"));
+
+    QJsonObject close = r.variantData("close-window", "hyprland")
+                            .value("hyprland-bind").toObject();
+    EXPECT_EQ(close.value("dispatcher").toString(), "killactive");
+
+    QJsonObject left = r.variantData("switch-desktop-left", "hyprland")
+                           .value("hyprland-bind").toObject();
+    EXPECT_EQ(left.value("dispatcher").toString(), "workspace");
+    EXPECT_EQ(left.value("arg").toString(), "r-1");
 }
 
 TEST(ActionPresetRegistry, ShippedCalculatorUsesAppLaunch) {

--- a/tests/core/desktop/test_hyprland_desktop_resolve.cpp
+++ b/tests/core/desktop/test_hyprland_desktop_resolve.cpp
@@ -1,0 +1,236 @@
+#include <gtest/gtest.h>
+
+#include "desktop/HyprlandDesktop.h"
+#include "actions/ActionPresetRegistry.h"
+#include "interfaces/IDesktopIntegration.h"
+
+#include <QDir>
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QTest>
+
+using logitune::ActionPresetRegistry;
+using logitune::ButtonAction;
+using logitune::HyprlandDesktop;
+using logitune::IDesktopIntegration;
+
+namespace {
+const QByteArray kCatalog = R"([
+    {
+        "id": "close-window",
+        "label": "Close Window",
+        "variants": {
+            "hyprland": { "hyprland-bind": { "dispatcher": "killactive" } }
+        }
+    },
+    {
+        "id": "switch-desktop-left",
+        "label": "Switch Desktop Left",
+        "variants": {
+            "hyprland": { "hyprland-bind": { "dispatcher": "workspace", "arg": "r-1" } }
+        }
+    },
+    {
+        "id": "switch-desktop-right",
+        "label": "Switch Desktop Right",
+        "variants": {
+            "hyprland": { "hyprland-bind": { "dispatcher": "workspace", "arg": "r+1" } }
+        }
+    },
+    {
+        "id": "calculator",
+        "label": "Calculator",
+        "variants": {
+            "hyprland": { "app-launch": { "binary": "qalculate-gtk" } }
+        }
+    },
+    {
+        "id": "kde-only",
+        "label": "Kde Only",
+        "variants": {
+            "kde": { "kglobalaccel": { "component": "kwin", "name": "Something" } }
+        }
+    }
+])";
+
+void attachRegistry(HyprlandDesktop &desktop, ActionPresetRegistry &registry)
+{
+    registry.loadFromJson(kCatalog);
+    desktop.setPresetRegistry(&registry);
+}
+
+QByteArray oneBind(int modmask, const char *key, const char *dispatcher,
+                   const char *arg = "")
+{
+    return QByteArray("[{\"mouse\":false,\"submap\":\"\",\"modmask\":")
+        + QByteArray::number(modmask)
+        + ",\"key\":\"" + key
+        + "\",\"dispatcher\":\"" + dispatcher
+        + "\",\"arg\":\"" + arg + "\"}]";
+}
+} // namespace
+
+TEST(HyprlandDesktopResolve, VariantKeyIsHyprland) {
+    HyprlandDesktop d;
+    EXPECT_EQ(d.variantKey(), "hyprland");
+}
+
+TEST(HyprlandDesktopResolve, DesktopNameIsHyprland) {
+    HyprlandDesktop d;
+    EXPECT_EQ(d.desktopName(), "Hyprland");
+}
+
+TEST(HyprlandDesktopResolve, ResolveReturnsNulloptWithoutRegistry) {
+    HyprlandDesktop d;
+    EXPECT_FALSE(d.resolveNamedAction("close-window").has_value());
+}
+
+TEST(HyprlandDesktopResolve, ResolveKillactiveBindReturnsKeystroke) {
+    HyprlandDesktop d;
+    ActionPresetRegistry reg;
+    attachRegistry(d, reg);
+    d.setBindReader([] { return oneBind(64, "Q", "killactive"); });
+
+    auto result = d.resolveNamedAction("close-window");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->type, ButtonAction::Keystroke);
+    EXPECT_EQ(result->payload, "Super+Q");
+}
+
+TEST(HyprlandDesktopResolve, ResolveWorkspaceBindMatchesArg) {
+    HyprlandDesktop d;
+    ActionPresetRegistry reg;
+    attachRegistry(d, reg);
+    d.setBindReader([] {
+        return QByteArray(R"([
+            {"mouse":false,"submap":"","modmask":64,"key":"Right","dispatcher":"workspace","arg":"r+1"},
+            {"mouse":false,"submap":"","modmask":68,"key":"Left","dispatcher":"workspace","arg":"r-1"}
+        ])");
+    });
+
+    auto result = d.resolveNamedAction("switch-desktop-left");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->type, ButtonAction::Keystroke);
+    EXPECT_EQ(result->payload, "Ctrl+Super+Left");
+}
+
+TEST(HyprlandDesktopResolve, ResolveReturnsNulloptForAbsentBind) {
+    HyprlandDesktop d;
+    ActionPresetRegistry reg;
+    attachRegistry(d, reg);
+    d.setBindReader([] { return oneBind(64, "Q", "killactive"); });
+
+    EXPECT_FALSE(d.resolveNamedAction("switch-desktop-left").has_value());
+}
+
+TEST(HyprlandDesktopResolve, ResolveIgnoresMouseBinds) {
+    HyprlandDesktop d;
+    ActionPresetRegistry reg;
+    attachRegistry(d, reg);
+    d.setBindReader([] {
+        return QByteArray(R"([
+            {"mouse":true,"submap":"","modmask":64,"key":"mouse:272","dispatcher":"killactive","arg":""}
+        ])");
+    });
+
+    EXPECT_FALSE(d.resolveNamedAction("close-window").has_value());
+}
+
+TEST(HyprlandDesktopResolve, ResolveReturnsNulloptForUnsupportedModifierMask) {
+    HyprlandDesktop d;
+    ActionPresetRegistry reg;
+    attachRegistry(d, reg);
+    d.setBindReader([] { return oneBind(66, "Q", "killactive"); });
+
+    EXPECT_FALSE(d.resolveNamedAction("close-window").has_value());
+}
+
+TEST(HyprlandDesktopResolve, ResolveReturnsNulloptForInvalidJson) {
+    HyprlandDesktop d;
+    ActionPresetRegistry reg;
+    attachRegistry(d, reg);
+    d.setBindReader([] { return QByteArray("not json"); });
+
+    EXPECT_FALSE(d.resolveNamedAction("close-window").has_value());
+}
+
+TEST(HyprlandDesktopResolve, ResolveAppLaunchReturnsPayload) {
+    HyprlandDesktop d;
+    ActionPresetRegistry reg;
+    attachRegistry(d, reg);
+
+    auto result = d.resolveNamedAction("calculator");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->type, ButtonAction::AppLaunch);
+    EXPECT_EQ(result->payload, "qalculate-gtk");
+}
+
+TEST(HyprlandDesktopResolve, ResolveReturnsNulloptForOtherDesktopVariant) {
+    HyprlandDesktop d;
+    ActionPresetRegistry reg;
+    attachRegistry(d, reg);
+
+    EXPECT_FALSE(d.resolveNamedAction("kde-only").has_value());
+}
+
+TEST(HyprlandDesktopFocus, ActiveWindowEventEmitsFocusSignal) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString socketDir = tmp.path() + QStringLiteral("/hypr/testsig");
+    ASSERT_TRUE(QDir().mkpath(socketDir));
+    const QString socketPath = socketDir + QStringLiteral("/.socket2.sock");
+    QLocalServer::removeServer(socketPath);
+
+    QLocalServer server;
+    ASSERT_TRUE(server.listen(socketPath));
+
+    HyprlandDesktop d;
+    d.setSocketDirForTest(socketDir);
+    QSignalSpy spy(&d, &IDesktopIntegration::activeWindowChanged);
+    d.start();
+
+    ASSERT_TRUE(server.waitForNewConnection(1000));
+    QLocalSocket *client = server.nextPendingConnection();
+    ASSERT_NE(client, nullptr);
+
+    client->write("activewindow>>firefox,Mozilla Firefox\n");
+    ASSERT_TRUE(client->waitForBytesWritten(1000));
+    ASSERT_TRUE(spy.wait(1000));
+
+    ASSERT_EQ(spy.size(), 1);
+    EXPECT_EQ(spy.at(0).at(0).toString(), "firefox");
+    EXPECT_EQ(spy.at(0).at(1).toString(), "Mozilla Firefox");
+}
+
+TEST(HyprlandDesktopFocus, DuplicateActiveWindowClassIsSuppressed) {
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    const QString socketDir = tmp.path() + QStringLiteral("/hypr/testsig");
+    ASSERT_TRUE(QDir().mkpath(socketDir));
+    const QString socketPath = socketDir + QStringLiteral("/.socket2.sock");
+    QLocalServer::removeServer(socketPath);
+
+    QLocalServer server;
+    ASSERT_TRUE(server.listen(socketPath));
+
+    HyprlandDesktop d;
+    d.setSocketDirForTest(socketDir);
+    QSignalSpy spy(&d, &IDesktopIntegration::activeWindowChanged);
+    d.start();
+
+    ASSERT_TRUE(server.waitForNewConnection(1000));
+    QLocalSocket *client = server.nextPendingConnection();
+    ASSERT_NE(client, nullptr);
+
+    client->write("activewindow>>firefox,One\n");
+    ASSERT_TRUE(client->waitForBytesWritten(1000));
+    ASSERT_TRUE(spy.wait(1000));
+
+    client->write("activewindow>>firefox,Two\n");
+    ASSERT_TRUE(client->waitForBytesWritten(1000));
+    QTest::qWait(50);
+
+    EXPECT_EQ(spy.size(), 1);
+}

--- a/tests/test_desktop_factory.cpp
+++ b/tests/test_desktop_factory.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "desktop/KDeDesktop.h"
 #include "desktop/GnomeDesktop.h"
+#include "desktop/HyprlandDesktop.h"
 #include "desktop/GenericDesktop.h"
 
 using namespace logitune;
@@ -13,6 +14,11 @@ TEST(DesktopFactory, KDeDesktopReportsKDE) {
 TEST(DesktopFactory, GnomeDesktopReportsGNOME) {
     GnomeDesktop gnome;
     EXPECT_EQ(gnome.desktopName(), "GNOME");
+}
+
+TEST(DesktopFactory, HyprlandDesktopReportsHyprland) {
+    HyprlandDesktop hyprland;
+    EXPECT_EQ(hyprland.desktopName(), "Hyprland");
 }
 
 TEST(DesktopFactory, GenericDesktopReportsGeneric) {
@@ -44,6 +50,11 @@ TEST(DesktopFactory, KDeVariantKeyIsKde) {
 TEST(DesktopFactory, GnomeVariantKeyIsGnome) {
     GnomeDesktop d;
     EXPECT_EQ(d.variantKey(), "gnome");
+}
+
+TEST(DesktopFactory, HyprlandVariantKeyIsHyprland) {
+    HyprlandDesktop d;
+    EXPECT_EQ(d.variantKey(), "hyprland");
 }
 
 TEST(DesktopFactory, GenericVariantKeyIsGeneric) {


### PR DESCRIPTION
Previously Hyprland fell back to `GenericDesktop` which meant no active-window tracking and not per-app profile switching, this should fix that. It detects hyprland via `XDG_CURRENT_DESKTOP` or `HYPRLAND_INSTANCE_SIGNATURE`, connects to hyprland's event socket, and listens for activewindow events, then routes them through the existing desktop-file resolution and the `activeWindowChanged` signal so the rest of the logic is untouched. For now, there's only 3 preset: close window, switch desktop left, and switch desktop right, and they only appear when a matching live Hyrpland keybind exists.