### PR TITLE
[codex] Add MX Mechanical descriptor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img src="data/com.logitune.Logitune.svg" width="80">
   <h1 align="center">Logitune</h1>
-  <p align="center">A Linux configurator for Logitech peripherals — per-application profiles, gesture mapping, thumb wheel modes, and a dark-themed Qt Quick UI matching Logitech Options+.</p>
+  <p align="center">A Linux configurator for Logitech peripherals — per-application profiles, gesture mapping, thumb wheel modes, and a dark-themed Qt Quick UI inspired by Logitech Options+.</p>
 </p>
 
 <p align="center">
@@ -120,6 +120,7 @@ logitune
 | MX Anywhere 3 for Business | 🧪 Beta | ✅ | ✅ | ✅ | — | ✅ | — | ✅ | ✅ |
 | MX Anywhere 3S | 🧪 Beta | ✅ | ✅ | ✅ | — | ✅ | — | ✅ | ✅ |
 | MX Anywhere 3S for Business | 🧪 Beta | ✅ | ✅ | ✅ | — | ✅ | — | ✅ | ✅ |
+| MX Mechanical | 🧪 Beta | ✅ | — | — | — | ✅ | — | — | ✅ |
 | MX Vertical | 🧪 Beta | ✅ | ✅ | — | — | ✅ | — | ✅ | ✅ |
 | MX Vertical for Business | 🧪 Beta | ✅ | ✅ | — | — | ✅ | — | ✅ | ✅ |
 <!-- END DEVICES TABLE -->
@@ -129,6 +130,24 @@ logitune
 The four MX Anywhere family descriptors ship as 🧪 **Beta** pending hardware confirmation. Issue [#46](https://github.com/mmaher88/logitune/issues/46) tracks the verification.
 
 Other Logitech HID++ 2.0 devices can be added by contributing a [device descriptor](https://github.com/mmaher88/logitune/wiki/Adding-a-Device). See [Device Support Status](https://github.com/mmaher88/logitune/wiki/Getting-Started#device-support-status) for what the badges mean.
+
+For local descriptor-feed testing from a fork or branch, override the generated manifest and raw device file base at launch:
+
+```bash
+LOGITUNE_DEVICE_MANIFEST_URL="https://raw.githubusercontent.com/<owner>/<repo>/<branch>/devices/manifest.json" \
+LOGITUNE_DEVICE_RAW_BASE_URL="https://raw.githubusercontent.com/<owner>/<repo>/<branch>/devices/" \
+logitune
+```
+
+Unset either variable, or set it to an empty value, to use the upstream defaults.
+
+### Options+ parity scope
+
+Logitune implements feasible Linux HID++ functionality; it is not a proprietary Logitech Options+ clone. Feasible scope includes battery state, Easy-Switch state, mouse DPI/scroll/SmartShift/thumb wheel/gestures, key or button remapping where HID++ controls are exposed, and per-app profile switching on supported desktop environments.
+
+Logitech account/cloud features, Flow internals, firmware update services, Marketplace, AI Prompt Builder, Smart Actions cloud features, and macOS-only APIs or services are not currently reproducible in Logitune.
+
+MX Mechanical beta support covers recognition by name/WPID, battery, Easy-Switch display, and beta key remapping CIDs. Backlight, fn-inversion, disable-keys, and multiplatform UI are future HID++ feature work.
 
 ## 🖥️ Desktop Environment Support
 

--- a/devices/manifest.json
+++ b/devices/manifest.json
@@ -1,0 +1,135 @@
+{
+  "devices": {
+    "mx-anywhere-3": {
+      "version": 1,
+      "pids": [
+        "0xb025",
+        "0x4090"
+      ],
+      "files": [
+        "descriptor.json",
+        "back.png",
+        "front.png",
+        "side.png"
+      ]
+    },
+    "mx-anywhere-3-for-business": {
+      "version": 1,
+      "pids": [
+        "0xb02d"
+      ],
+      "files": [
+        "descriptor.json",
+        "back.png",
+        "front.png",
+        "side.png"
+      ]
+    },
+    "mx-anywhere-3s": {
+      "version": 1,
+      "pids": [
+        "0xb037"
+      ],
+      "files": [
+        "descriptor.json",
+        "back.png",
+        "front.png",
+        "side.png"
+      ]
+    },
+    "mx-anywhere-3s-for-business": {
+      "version": 1,
+      "pids": [
+        "0xb038"
+      ],
+      "files": [
+        "descriptor.json",
+        "back.png",
+        "front.png",
+        "side.png"
+      ]
+    },
+    "mx-master-2s": {
+      "version": 1,
+      "pids": [
+        "0xb019"
+      ],
+      "files": [
+        "descriptor.json",
+        "back.png",
+        "front.png",
+        "side.png"
+      ]
+    },
+    "mx-master-3": {
+      "version": 1,
+      "pids": [
+        "0xc52b"
+      ],
+      "files": [
+        "descriptor.json",
+        "back.png",
+        "front.png",
+        "side.png"
+      ]
+    },
+    "mx-master-3s": {
+      "version": 1,
+      "pids": [
+        "0xb034"
+      ],
+      "files": [
+        "descriptor.json",
+        "back.png",
+        "front.png",
+        "side.png"
+      ]
+    },
+    "mx-master-4": {
+      "version": 1,
+      "pids": [
+        "0xb042"
+      ],
+      "files": [
+        "descriptor.json",
+        "back.png",
+        "front.png",
+        "side.png"
+      ]
+    },
+    "mx-mechanical": {
+      "version": 1,
+      "pids": [
+        "0xb366"
+      ],
+      "files": [
+        "descriptor.json"
+      ]
+    },
+    "mx-vertical": {
+      "version": 1,
+      "pids": [
+        "0xb020",
+        "0x407b"
+      ],
+      "files": [
+        "descriptor.json",
+        "back.png",
+        "front.png",
+        "side.png"
+      ]
+    },
+    "mx-vertical-for-business": {
+      "version": 1,
+      "pids": [
+        "0xb020"
+      ],
+      "files": [
+        "descriptor.json",
+        "back.png",
+        "front.png",
+        "side.png"
+      ]
+    }
+  }
+}

--- a/devices/mx-anywhere-3-for-business/descriptor.json
+++ b/devices/mx-anywhere-3-for-business/descriptor.json
@@ -1,5 +1,7 @@
 {
     "$schema": "../schema.json",
+    "deviceKind": "mouse",
+    "version": 1,
     "controls": [
         {
             "buttonIndex": 0,

--- a/devices/mx-anywhere-3/descriptor.json
+++ b/devices/mx-anywhere-3/descriptor.json
@@ -1,5 +1,7 @@
 {
     "$schema": "../schema.json",
+    "deviceKind": "mouse",
+    "version": 1,
     "controls": [
         {
             "buttonIndex": 0,

--- a/devices/mx-anywhere-3s-for-business/descriptor.json
+++ b/devices/mx-anywhere-3s-for-business/descriptor.json
@@ -1,5 +1,7 @@
 {
     "$schema": "../schema.json",
+    "deviceKind": "mouse",
+    "version": 1,
     "controls": [
         {
             "buttonIndex": 0,

--- a/devices/mx-anywhere-3s/descriptor.json
+++ b/devices/mx-anywhere-3s/descriptor.json
@@ -1,5 +1,7 @@
 {
     "$schema": "../schema.json",
+    "deviceKind": "mouse",
+    "version": 1,
     "controls": [
         {
             "buttonIndex": 0,

--- a/devices/mx-master-2s/descriptor.json
+++ b/devices/mx-master-2s/descriptor.json
@@ -1,8 +1,10 @@
 {
   "$schema": "../schema.json",
   "name": "MX Master 2S",
+  "deviceKind": "mouse",
   "status": "verified",
   "productIds": ["0xb019"],
+  "version": 1,
   "features": {
     "battery": true,
     "adjustableDpi": true,

--- a/devices/mx-master-3/descriptor.json
+++ b/devices/mx-master-3/descriptor.json
@@ -1,8 +1,10 @@
 {
   "$schema": "../schema.json",
   "name": "MX Master 3",
+  "deviceKind": "mouse",
   "status": "verified",
   "productIds": ["0xc52b"],
+  "version": 1,
   "features": {
     "battery": true,
     "adjustableDpi": true,

--- a/devices/mx-master-3s/descriptor.json
+++ b/devices/mx-master-3s/descriptor.json
@@ -1,8 +1,10 @@
 {
   "$schema": "../schema.json",
   "name": "MX Master 3S",
+  "deviceKind": "mouse",
   "status": "verified",
   "productIds": ["0xb034"],
+  "version": 1,
   "features": {
     "battery": true,
     "adjustableDpi": true,

--- a/devices/mx-master-4/descriptor.json
+++ b/devices/mx-master-4/descriptor.json
@@ -1,8 +1,10 @@
 {
   "$schema": "../schema.json",
   "name": "MX Master 4",
+  "deviceKind": "mouse",
   "status": "verified",
   "productIds": ["0xb042"],
+  "version": 1,
   "features": {
     "battery": true,
     "adjustableDpi": true,

--- a/devices/mx-mechanical/descriptor.json
+++ b/devices/mx-mechanical/descriptor.json
@@ -1,0 +1,315 @@
+{
+  "name": "MX Mechanical",
+  "deviceKind": "keyboard",
+  "status": "beta",
+  "productIds": [
+    "0xb366"
+  ],
+  "version": 1,
+  "features": {
+    "battery": true,
+    "adjustableDpi": false,
+    "extendedDpi": false,
+    "smartShift": false,
+    "hiResWheel": false,
+    "hiResScrolling": false,
+    "lowResWheel": false,
+    "smoothScroll": false,
+    "thumbWheel": false,
+    "reprogControls": true,
+    "gestureV2": false,
+    "mouseGesture": false,
+    "hapticFeedback": false,
+    "forceSensingButton": false,
+    "crown": false,
+    "reportRate": false,
+    "extendedReportRate": false,
+    "pointerSpeed": false,
+    "leftRightSwap": false,
+    "surfaceTuning": false,
+    "angleSnapping": false,
+    "colorLedEffects": false,
+    "rgbEffects": false,
+    "onboardProfiles": false,
+    "gkey": false,
+    "mkeys": false,
+    "persistentRemappableAction": false
+  },
+  "controls": [
+    {
+      "controlId": "0x000A",
+      "buttonIndex": 0,
+      "defaultName": "Calculator",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x006E",
+      "buttonIndex": 1,
+      "defaultName": "Show Desktop",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x006F",
+      "buttonIndex": 2,
+      "defaultName": "Lock PC",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x00C7",
+      "buttonIndex": 3,
+      "defaultName": "Brightness Down",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x00C8",
+      "buttonIndex": 4,
+      "defaultName": "Brightness Up",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x00D4",
+      "buttonIndex": 5,
+      "defaultName": "MultiPlatform Search",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x00E2",
+      "buttonIndex": 6,
+      "defaultName": "Backlight Down",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x00E3",
+      "buttonIndex": 7,
+      "defaultName": "Backlight Up",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x00E4",
+      "buttonIndex": 8,
+      "defaultName": "Previous Fn",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x00E5",
+      "buttonIndex": 9,
+      "defaultName": "Play/Pause Fn",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x00E6",
+      "buttonIndex": 10,
+      "defaultName": "Next Fn",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x00E7",
+      "buttonIndex": 11,
+      "defaultName": "Mute Fn",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x00E8",
+      "buttonIndex": 12,
+      "defaultName": "Volume Down Fn",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x00E9",
+      "buttonIndex": 13,
+      "defaultName": "Volume Up Fn",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x0103",
+      "buttonIndex": 14,
+      "defaultName": "Voice Dictation",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x0108",
+      "buttonIndex": 15,
+      "defaultName": "Open Emoji Panel",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x010A",
+      "buttonIndex": 16,
+      "defaultName": "Snipping Tool",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x010B",
+      "buttonIndex": 17,
+      "defaultName": "Grave Accent",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x010C",
+      "buttonIndex": 18,
+      "defaultName": "Tab Key",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x010D",
+      "buttonIndex": 19,
+      "defaultName": "Caps Lock",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x010E",
+      "buttonIndex": 20,
+      "defaultName": "Left Shift",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x010F",
+      "buttonIndex": 21,
+      "defaultName": "Left Control",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x0110",
+      "buttonIndex": 22,
+      "defaultName": "Left Option/Start",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x0111",
+      "buttonIndex": 23,
+      "defaultName": "Left Command/Alt",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x0112",
+      "buttonIndex": 24,
+      "defaultName": "Right Command/Alt",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x0113",
+      "buttonIndex": 25,
+      "defaultName": "Right Option/Start",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x0114",
+      "buttonIndex": 26,
+      "defaultName": "Right Control",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x0115",
+      "buttonIndex": 27,
+      "defaultName": "Right Shift",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x0116",
+      "buttonIndex": 28,
+      "defaultName": "Insert",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x0117",
+      "buttonIndex": 29,
+      "defaultName": "Delete",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x0118",
+      "buttonIndex": 30,
+      "defaultName": "Home",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x0119",
+      "buttonIndex": 31,
+      "defaultName": "End",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x011A",
+      "buttonIndex": 32,
+      "defaultName": "Page Up",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x011B",
+      "buttonIndex": 33,
+      "defaultName": "Page Down",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x011C",
+      "buttonIndex": 34,
+      "defaultName": "Mute Microphone",
+      "defaultActionType": "default",
+      "configurable": true
+    },
+    {
+      "controlId": "0x011E",
+      "buttonIndex": 35,
+      "defaultName": "Backslash",
+      "defaultActionType": "default",
+      "configurable": true
+    }
+  ],
+  "hotspots": {
+    "buttons": [],
+    "scroll": []
+  },
+  "images": {},
+  "easySwitchSlots": [
+    {
+      "xPct": 0.4,
+      "yPct": 0.5,
+      "label": "1"
+    },
+    {
+      "xPct": 0.5,
+      "yPct": 0.5,
+      "label": "2"
+    },
+    {
+      "xPct": 0.6,
+      "yPct": 0.5,
+      "label": "3"
+    }
+  ],
+  "defaultGestures": {}
+}

--- a/devices/mx-vertical-for-business/descriptor.json
+++ b/devices/mx-vertical-for-business/descriptor.json
@@ -1,5 +1,7 @@
 {
     "$schema": "../schema.json",
+    "deviceKind": "mouse",
+    "version": 1,
     "controls": [
         {
             "buttonIndex": 0,

--- a/devices/mx-vertical/descriptor.json
+++ b/devices/mx-vertical/descriptor.json
@@ -1,5 +1,7 @@
 {
     "$schema": "../schema.json",
+    "deviceKind": "mouse",
+    "version": 1,
     "controls": [
         {
             "buttonIndex": 0,

--- a/devices/schema.json
+++ b/devices/schema.json
@@ -4,7 +4,7 @@
   "title": "Logitune device descriptor",
   "description": "Schema for a Logitune device descriptor. Matches the fields parsed by JsonDevice::parseFromObject in src/core/devices/JsonDevice.cpp.",
   "type": "object",
-  "required": ["name", "status", "productIds"],
+  "required": ["name", "deviceKind", "status", "productIds"],
   "additionalProperties": true,
   "properties": {
     "$schema": {
@@ -15,10 +15,15 @@
       "type": "string",
       "description": "Display name, e.g. \"MX Master 3S\"."
     },
+    "deviceKind": {
+      "type": "string",
+      "enum": ["mouse", "keyboard"],
+      "description": "Canonical physical device family. Mouse descriptors may expose pointer, wheel, DPI, and mouse-button capabilities; keyboard descriptors expose keyboard controls and Easy-Switch state."
+    },
     "status": {
       "type": "string",
-      "enum": ["verified", "beta", "implemented"],
-      "description": "Support status. \"verified\" = maintainer hardware-tested. \"beta\" = community-submitted or not yet hardware-verified. \"implemented\" is a legacy alias for \"verified\"."
+      "enum": ["verified", "beta"],
+      "description": "Support status. \"verified\" = maintainer hardware-tested. \"beta\" = community-submitted or not yet hardware-verified."
     },
     "productIds": {
       "type": "array",

--- a/docs/wiki/Adding-a-Device.md
+++ b/docs/wiki/Adding-a-Device.md
@@ -10,6 +10,7 @@ The MX Master 3S descriptor (`devices/mx-master-3s/`) is used as the worked exam
 
 Gather the following before you start:
 
+- **Device kind:** decide whether the descriptor is `"mouse"` or `"keyboard"`. This is the required `deviceKind` field and controls which coverage rules apply to the descriptor.
 - **Product ID (PID):** run `lsusb | grep Logitech` and note the hex ID after `ID 046d:`, or read it from Solaar (`solaar show`). Bolt-receiver connections and Bluetooth connections often report different PIDs; include both. Use the **device WPID** (e.g. `0xb034`), not the Unifying receiver's USB PID (`0xc52b`).
 - **Control IDs (CIDs):** logging is enabled by default (toggle it in **Settings → Debug logging** if you disabled it). Launch Logitune, connect the device, then press each physical button one at a time. The log records a line per press:
   ```
@@ -63,6 +64,7 @@ A machine-readable [JSON Schema](https://json-schema.org) for this format lives 
 | Field | Type | Required | Meaning |
 |-------|------|----------|---------|
 | `name` | string | yes | Display name shown in the UI, e.g. `"MX Master 3S"` |
+| `deviceKind` | string | yes | Canonical device family: `"mouse"` or `"keyboard"` |
 | `status` | string | yes | `"verified"` or `"beta"`. See [Device Support Status](Getting-Started#device-support-status) |
 | `productIds` | array of string | yes | Hex PIDs as strings, e.g. `["0xb034"]`. Include all known PIDs (Bolt, Bluetooth, USB) |
 | `features` | object | yes | Map of HID++ feature flags. All keys default to `false`; set to `true` if the device supports the feature |
@@ -132,11 +134,14 @@ A machine-readable [JSON Schema](https://json-schema.org) for this format lives 
 
 > **Tip on feature flags:** you do not need to know which HID++ sub-variant a feature uses. Set `"battery": true` regardless of whether the device uses Battery Unified (0x1004) or Battery Status (0x1000). DeviceManager selects the right variant at runtime via capability dispatch tables in `src/core/hidpp/capabilities/`.
 
+For keyboard descriptors, omit the `dpi` block and leave mouse-specific feature flags false unless runtime code exists for that feature. Keyboard control entries still use ReprogControls CIDs and can be remappable when the firmware exposes divertable controls. Options+ dumps, Solaar output, and local Logitune logs are evidence inputs for names, WPIDs, features, and CIDs; they are not a guarantee that every proprietary Options+ behavior is reproducible on Linux.
+
 ### Minimal bootstrap example
 
 ```json
 {
   "name": "My Device",
+  "deviceKind": "mouse",
   "status": "beta",
   "productIds": ["0xb037"],
   "features": {
@@ -243,6 +248,8 @@ This loads all descriptors in simulate mode, bypassing the real HID++ device. Us
 - [ ] Easy-Switch page shows three slot circles
 - [ ] DPI range and step display correctly
 - [ ] No `JsonDevice` warnings in `~/.local/share/Logitune/Logitune/logs/logitune-*.log`
+
+For keyboard beta descriptors without images, the first pass is recognition, battery, Easy-Switch, and control-list validation. Mouse image, hotspot, Point & Scroll, and DPI checks apply only when the descriptor exposes those features.
 
 ### Descriptor fixture test
 

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -219,6 +219,12 @@ Each capability is a plain struct that stores the `FeatureId` it matches, the fu
 
 Protocol-level feature code (parsing one variant, building one request) lives in `src/core/hidpp/features/` (`AdjustableDPI`, `Battery`, `DeviceName`, `GestureV2`, `HiResWheel`, `ReprogControls`, `SmartShift`, `ThumbWheel`). Features without multiple variants (`AdjustableDPI`, `HiResWheel`, `ThumbWheel`, `DeviceName`, `GestureV2`) are called directly against their `FeatureId`; only Battery, SmartShift, and ReprogControls currently need the dispatch-table layer.
 
+### Descriptor device kinds and parity boundaries
+
+Every JSON descriptor declares a canonical `deviceKind` of `mouse` or `keyboard`. Mouse descriptors can expose pointer, DPI, wheel, thumb-wheel, SmartShift, gestures, and button hotspot metadata. Keyboard descriptors use the same registry and ReprogControls plumbing for HID++ key CIDs, but omit mouse-only DPI and hotspot expectations unless runtime support exists for a keyboard-specific feature.
+
+Options+ exports, Solaar reports, and local Logitune logs are evidence sources for descriptor data: names, WPIDs, HID++ feature IDs, divertable controls, and observed state such as battery or Easy-Switch host. They do not make Logitune an Options+ clone. Cloud services, Flow internals, firmware update services, Marketplace/AI Prompt Builder/Smart Actions features, and macOS-only APIs are outside the Linux HID++ architecture documented here.
+
 ### FeatureDispatcher
 
 `hidpp::FeatureDispatcher` (`src/core/hidpp/FeatureDispatcher.{h,cpp}`) owns the per-device feature index table. HID++ 2.0 assigns each feature a device-specific 8-bit index at runtime (Root is always `0x00`, the rest vary), so every feature call has to resolve `FeatureId -> index` before building a report. `callAsync` assigns a rotating `softwareId` (1 to 15) so responses can be routed back to the original caller even when multiple requests are in flight; `handleResponse` is invoked by `DeviceManager` whenever an incoming report has non-zero `softwareId` (that is, a response rather than an unsolicited notification).
@@ -1063,15 +1069,15 @@ For the contributor-facing workflow, see
 
 ## Device Descriptors
 
-A device in Logitune is data, not code. Every supported mouse is a directory under `devices/{slug}/` containing one `descriptor.json` plus `front.png`, `side.png`, and `back.png`. At startup `DeviceRegistry` enumerates these directories, wraps each one in a `JsonDevice`, and that `JsonDevice *` is what the rest of the app sees through the `IDevice` interface. Adding a new mouse requires no C++ changes.
+A device in Logitune is data, not code. Every supported peripheral is a directory under `devices/{slug}/` containing one `descriptor.json` plus any device images the descriptor references. Mouse descriptors usually ship `front.png`, `side.png`, and `back.png`; beta keyboard descriptors may omit images until keyboard-specific visual layout is implemented. At startup `DeviceRegistry` enumerates these directories, wraps each one in a `JsonDevice`, and that `JsonDevice *` is what the rest of the app sees through the `IDevice` interface. Adding a descriptor normally requires no C++ changes unless the device needs a HID++ feature variant that the runtime cannot drive yet.
 
 ### IDevice
 
-`IDevice` (`src/core/interfaces/IDevice.h`) is the pure-virtual interface every descriptor satisfies. It is intentionally read-only: getters for identity (`deviceName`, `productIds`, `matchesPid(pid)`), DPI range (`minDpi`, `maxDpi`, `dpiStep`, `dpiCycleRing`), buttons (`controls()` returning `QList<ControlDescriptor>`), hotspots (`buttonHotspots()`, `scrollHotspots()`), feature support flags (`features()` returning `FeatureSupport`), images (`frontImagePath`, `sideImagePath`, `backImagePath`), default gestures (`defaultGestures()` keyed by `"up" / "down" / "left" / "right" / "click"`), and Easy-Switch slot positions (`easySwitchSlotPositions()`).
+`IDevice` (`src/core/interfaces/IDevice.h`) is the pure-virtual interface every descriptor satisfies. It is intentionally read-only: getters for identity (`deviceName`, `deviceKind`, `productIds`, `matchesPid(pid)`), DPI range (`minDpi`, `maxDpi`, `dpiStep`, `dpiCycleRing`), controls (`controls()` returning `QList<ControlDescriptor>`), hotspots (`buttonHotspots()`, `scrollHotspots()`), feature support flags (`features()` returning `FeatureSupport`), images (`frontImagePath`, `sideImagePath`, `backImagePath`), default gestures (`defaultGestures()` keyed by `"up" / "down" / "left" / "right" / "click"`), and Easy-Switch slot positions (`easySwitchSlotPositions()`).
 
 Three structs carry the runtime values:
 
-- `ControlDescriptor`: HID++ `controlId` (e.g. `0x00C3` for the gesture button), zero-based `buttonIndex`, default name, `defaultActionType` (`"default"`, `"gesture-trigger"`, `"smartshift-toggle"`), and a `configurable` flag that tells the UI whether the user can remap this button.
+- `ControlDescriptor`: HID++ `controlId` (e.g. `0x00C3` for the gesture button), zero-based `buttonIndex`, default name, `defaultActionType` (`"default"`, `"keystroke"`, `"gesture-trigger"`, `"smartshift-toggle"`, `"dpi-cycle"`, `"app-launch"`, `"dbus"`, or `"media"`), and a `configurable` flag that tells the UI whether the user can remap this control.
 - `HotspotDescriptor`: per-button annotation coordinates for the QML overlay. `xPct` / `yPct` are 0 to 1 floats, `side` is `"front" / "side" / "back"`, `kind` distinguishes scroll / thumb-wheel hotspots from button hotspots.
 - `FeatureSupport`: 27 booleans gating UI visibility. When `smartShift` is `false`, the SmartShift slider is hidden; when `thumbWheel` is `false`, the Point & Scroll page hides thumb-wheel controls; and so on. See the MX Master 3S descriptor at `devices/mx-master-3s/descriptor.json` for the shape.
 
@@ -1081,7 +1087,7 @@ Three structs carry the runtime values:
 
 `JsonDevice` (`src/core/devices/JsonDevice.{h,cpp}`) is the only concrete `IDevice` implementation shipped with Logitune. `JsonDevice::load(dirPath)` opens `descriptor.json` in the given directory, parses it into the member structures (`m_pids`, `m_features`, `m_minDpi`, `m_controls`, `m_buttonHotspots`, `m_scrollHotspots`, `m_frontImage`, `m_sideImage`, `m_backImage`, `m_defaultGestures`, `m_easySwitchSlots`, `m_dpiCycleRing`), and stores `m_sourcePath` + `m_loadedMtime` so `DeviceRegistry::reload(path)` can do targeted live reloads when the descriptor changes on disk. `refreshFromObject(QJsonObject)` lets `EditorModel` push pending in-memory edits into the live device without going through disk.
 
-`status()` distinguishes `Verified` from `Beta` devices; the UI uses this to show a "beta descriptor" banner on first launch for community-contributed entries. There are no per-device C++ subclasses.
+`status()` distinguishes `Verified` from `Beta` devices; the UI uses this to show a "beta descriptor" banner on first launch for community-contributed entries. The descriptor schema accepts only `"verified"` and `"beta"`; older status spellings are rejected instead of coerced. There are no per-device C++ subclasses.
 
 ### DescriptorWriter
 
@@ -1089,9 +1095,19 @@ Three structs carry the runtime values:
 
 ### DeviceFetcher
 
-`DeviceFetcher` (`src/core/DeviceFetcher.{h,cpp}`) brings community-contributed descriptors from GitHub into the user's local devices directory. `fetchManifest()` is called at startup (when `isCacheFresh()` returns false; the TTL is `kCacheTtlSeconds = 3600`), GETs `kManifestUrl` (the `manifest.json` in the `logitune-devices` GitHub repository), and compares each listed slug's `manifestVersion` against what is already cached. `fetchForPid(pid)` is wired to `DeviceManager::unknownDeviceDetected(pid)`: when an unrecognized Logitech device appears, the fetcher looks up that PID in the cached manifest, downloads the matching descriptor plus images, and writes them into `deviceCachePath(slug)`.
+`DeviceFetcher` (`src/core/DeviceFetcher.{h,cpp}`) brings updated descriptors from GitHub into the user's local devices directory. `fetchManifest()` is called at startup (when `isCacheFresh()` returns false; the TTL is `kCacheTtlSeconds = 3600`), GETs `manifestUrl()` (the generated `devices/manifest.json` shipped from the main `mmaher88/logitune` repository unless `LOGITUNE_DEVICE_MANIFEST_URL` is set), and compares each listed slug's `manifestVersion` against what is already cached. `fetchForPid(pid)` is wired to `DeviceManager::unknownDeviceDetected(pid)`: when an unrecognized Logitech device appears, the fetcher looks up that PID in the cached manifest, then the bundled manifest, then the remote manifest if needed.
 
-On successful fetch, `DeviceFetcher` emits `descriptorsUpdated()`, which `DeviceRegistry` subscribes to so it can rescan the local directory and expose the new device without a restart. The HTTP cache is keyed on ETag (`saveEtag` / `loadEtag`) and timestamp (`saveTimestamp` / `isCacheFresh`) to avoid re-downloading unchanged manifests.
+Local fork or branch descriptor feeds can be tested without rebuilding by launching with both feed overrides:
+
+```bash
+LOGITUNE_DEVICE_MANIFEST_URL="https://raw.githubusercontent.com/<owner>/<repo>/<branch>/devices/manifest.json" \
+LOGITUNE_DEVICE_RAW_BASE_URL="https://raw.githubusercontent.com/<owner>/<repo>/<branch>/devices/" \
+logitune
+```
+
+Unset or empty override values use the upstream defaults. `rawBaseUrl()` normalizes `LOGITUNE_DEVICE_RAW_BASE_URL` to one trailing slash before descriptor image URLs are built.
+
+On successful fetch, `DeviceFetcher` emits `descriptorsUpdated()`, which `DeviceRegistry` subscribes to so it can rescan the local directory and expose the new device without a restart. The HTTP cache is keyed on ETag (`saveEtag` / `loadEtag`) and timestamp (`saveTimestamp` / `isCacheFresh`) to avoid re-downloading unchanged manifests. If the remote manifest request fails, returns invalid JSON, or returns an unexpected status, startup falls back to the stale cached manifest and only falls back to bundled descriptors when no cache exists.
 
 **Methods:**
 
@@ -1106,9 +1122,13 @@ On successful fetch, `DeviceFetcher` emits `descriptorsUpdated()`, which `Device
 | `loadEtag()` | Returns the last-saved ETag, or an empty string. |
 | `saveManifest(const QJsonObject &manifest)` | Persists the downloaded manifest JSON to disk. |
 | `loadManifest()` | Returns the cached manifest as a `QJsonObject`. |
+| `loadBundledManifest()` | Returns the shipped `devices/manifest.json` from the installed system devices directory. |
 | `findDeviceForPid(const QJsonObject &manifest, uint16_t pid)` | Returns `(slug, deviceInfo)` for the first manifest entry that claims `pid`, or an empty pair. |
+| `isSafeManifestFilename(const QString &filename)` | Rejects manifest file names that could escape the target device cache directory. |
 | `deviceNeedsUpdate(const QString &slug, int manifestVersion)` | Returns true if the cached descriptor for `slug` is older than `manifestVersion`. |
 | `deviceCachePath(const QString &slug)` | Returns the on-disk cache path for the device `slug`. |
+| `manifestUrl()` | Returns the manifest URL, honoring `LOGITUNE_DEVICE_MANIFEST_URL` when non-empty. |
+| `rawBaseUrl()` | Returns the raw descriptor-file base URL, honoring `LOGITUNE_DEVICE_RAW_BASE_URL` when non-empty and normalizing one trailing slash. |
 
 **Signals:**
 

--- a/scripts/generate-device-manifest.py
+++ b/scripts/generate-device-manifest.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Regenerate devices/manifest.json from bundled descriptors."""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+DEVICES = REPO / "devices"
+MANIFEST = DEVICES / "manifest.json"
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".svg", ".webp"}
+
+
+def manifest_files(device_dir: pathlib.Path) -> list[str]:
+    files = ["descriptor.json"]
+    for path in sorted(device_dir.iterdir()):
+        if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS:
+            files.append(path.name)
+    return files
+
+
+def build_manifest() -> dict:
+    devices: dict[str, dict] = {}
+    for descriptor in sorted(DEVICES.glob("*/descriptor.json")):
+        slug = descriptor.parent.name
+        data = json.loads(descriptor.read_text())
+        devices[slug] = {
+            "version": int(data.get("version", 1)),
+            "pids": data["productIds"],
+            "files": manifest_files(descriptor.parent),
+        }
+    return {"devices": devices}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    text = json.dumps(build_manifest(), indent=2) + "\n"
+    if args.check:
+        if not MANIFEST.exists() or MANIFEST.read_text() != text:
+            sys.stderr.write("devices/manifest.json is out of sync. Run: scripts/generate-device-manifest.py\n")
+            return 1
+        return 0
+
+    if not MANIFEST.exists() or MANIFEST.read_text() != text:
+        MANIFEST.write_text(text)
+        print(f"Updated {MANIFEST}")
+    else:
+        print(f"{MANIFEST} already up to date")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -54,7 +54,7 @@ EOF
 chmod 755 "$PKGDIR/DEBIAN/postinst"
 
 # Build .deb
-dpkg-deb --build "$PKGDIR" "logitune-${VERSION}_${ARCH}.deb"
+dpkg-deb --root-owner-group --build "$PKGDIR" "logitune-${VERSION}_${ARCH}.deb"
 rm -rf "$PKGDIR" build-release
 
 echo "logitune-${VERSION}_${ARCH}.deb"

--- a/src/core/DeviceFetcher.cpp
+++ b/src/core/DeviceFetcher.cpp
@@ -1,4 +1,5 @@
 #include "DeviceFetcher.h"
+#include "DeviceRegistry.h"
 #include "logging/LogManager.h"
 
 #include <QDateTime>
@@ -13,9 +14,22 @@
 namespace logitune {
 
 const QString DeviceFetcher::kManifestUrl =
-    QStringLiteral("https://raw.githubusercontent.com/mmaher88/logitune-devices/main/manifest.json");
+    QStringLiteral("https://raw.githubusercontent.com/mmaher88/logitune/master/devices/manifest.json");
 const QString DeviceFetcher::kRawBaseUrl =
-    QStringLiteral("https://raw.githubusercontent.com/mmaher88/logitune-devices/main/");
+    QStringLiteral("https://raw.githubusercontent.com/mmaher88/logitune/master/devices/");
+
+namespace {
+
+QString environmentUrlOrDefault(const char *name, const QString &defaultUrl)
+{
+    const QByteArray value = qgetenv(name);
+    if (value.isEmpty())
+        return defaultUrl;
+
+    return QString::fromUtf8(value);
+}
+
+} // namespace
 
 DeviceFetcher::DeviceFetcher(QObject *parent)
     : QObject(parent)
@@ -87,6 +101,16 @@ QJsonObject DeviceFetcher::loadManifest() const
     return doc.isObject() ? doc.object() : QJsonObject{};
 }
 
+QJsonObject DeviceFetcher::loadBundledManifest() const
+{
+    QFile f(QDir(DeviceRegistry::systemDevicesDir()).filePath(QStringLiteral("manifest.json")));
+    if (!f.open(QIODevice::ReadOnly))
+        return {};
+
+    const auto doc = QJsonDocument::fromJson(f.readAll());
+    return doc.isObject() ? doc.object() : QJsonObject{};
+}
+
 QPair<QString, QJsonObject> DeviceFetcher::findDeviceForPid(const QJsonObject &manifest,
                                                              uint16_t pid) const
 {
@@ -103,6 +127,21 @@ QPair<QString, QJsonObject> DeviceFetcher::findDeviceForPid(const QJsonObject &m
     }
 
     return {QString(), QJsonObject()};
+}
+
+bool DeviceFetcher::isSafeManifestFilename(const QString &filename) const
+{
+    if (filename == QStringLiteral("descriptor.json"))
+        return true;
+    if (filename.isEmpty() || filename.contains(QStringLiteral(".."))
+        || filename.contains(QLatin1Char('/')) || filename.contains(QLatin1Char('\\')))
+        return false;
+    const QString lower = filename.toLower();
+    return lower.endsWith(QStringLiteral(".png"))
+        || lower.endsWith(QStringLiteral(".jpg"))
+        || lower.endsWith(QStringLiteral(".jpeg"))
+        || lower.endsWith(QStringLiteral(".svg"))
+        || lower.endsWith(QStringLiteral(".webp"));
 }
 
 bool DeviceFetcher::deviceNeedsUpdate(const QString &slug, int manifestVersion) const
@@ -125,6 +164,20 @@ QString DeviceFetcher::deviceCachePath(const QString &slug) const
     return m_cacheDir + QStringLiteral("/devices/") + slug;
 }
 
+QString DeviceFetcher::manifestUrl()
+{
+    return environmentUrlOrDefault("LOGITUNE_DEVICE_MANIFEST_URL", kManifestUrl);
+}
+
+QString DeviceFetcher::rawBaseUrl()
+{
+    QString url = environmentUrlOrDefault("LOGITUNE_DEVICE_RAW_BASE_URL", kRawBaseUrl);
+    while (url.endsWith(QLatin1Char('/')))
+        url.chop(1);
+    url += QLatin1Char('/');
+    return url;
+}
+
 // ---- Network implementation --------------------------------------------------
 
 void DeviceFetcher::fetchManifest()
@@ -134,7 +187,7 @@ void DeviceFetcher::fetchManifest()
         return;
     }
 
-    QNetworkRequest req{QUrl(kManifestUrl)};
+    QNetworkRequest req{QUrl(manifestUrl())};
     req.setTransferTimeout(10000);
 
     const QString etag = loadEtag();
@@ -144,9 +197,16 @@ void DeviceFetcher::fetchManifest()
     auto *reply = m_nam.get(req);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
         reply->deleteLater();
+        const QJsonObject cached = loadManifest();
 
         if (reply->error() != QNetworkReply::NoError) {
             qCWarning(lcDevice) << "manifest fetch failed:" << reply->errorString();
+            if (!cached.isEmpty()) {
+                qCWarning(lcDevice) << "using stale cached device manifest";
+                onManifestReceived(cached);
+            } else if (!loadBundledManifest().isEmpty()) {
+                qCWarning(lcDevice) << "using bundled descriptors; remote updates unavailable";
+            }
             return;
         }
 
@@ -166,6 +226,12 @@ void DeviceFetcher::fetchManifest()
             const auto doc = QJsonDocument::fromJson(reply->readAll());
             if (!doc.isObject()) {
                 qCWarning(lcDevice) << "manifest is not valid JSON object";
+                if (!cached.isEmpty()) {
+                    qCWarning(lcDevice) << "using stale cached device manifest";
+                    onManifestReceived(cached);
+                } else if (!loadBundledManifest().isEmpty()) {
+                    qCWarning(lcDevice) << "using bundled descriptors; remote updates unavailable";
+                }
                 return;
             }
 
@@ -177,6 +243,12 @@ void DeviceFetcher::fetchManifest()
         }
 
         qCWarning(lcDevice) << "manifest fetch unexpected status:" << status;
+        if (!cached.isEmpty()) {
+            qCWarning(lcDevice) << "using stale cached device manifest";
+            onManifestReceived(cached);
+        } else if (!loadBundledManifest().isEmpty()) {
+            qCWarning(lcDevice) << "using bundled descriptors; remote updates unavailable";
+        }
     });
 }
 
@@ -199,8 +271,17 @@ void DeviceFetcher::fetchForPid(uint16_t pid)
         }
     }
 
+    const QJsonObject bundled = loadBundledManifest();
+    if (!bundled.isEmpty()) {
+        const auto [slug, devInfo] = findDeviceForPid(bundled, pid);
+        if (!slug.isEmpty()) {
+            m_pendingPid = 0;
+            return;
+        }
+    }
+
     // No cached manifest or PID not found — fetch fresh manifest
-    QNetworkRequest req{QUrl(kManifestUrl)};
+    QNetworkRequest req{QUrl(manifestUrl())};
     req.setTransferTimeout(10000);
 
     auto *reply = m_nam.get(req);
@@ -270,12 +351,15 @@ void DeviceFetcher::downloadDevice(const QString &slug, const QJsonObject &devic
 
     for (const auto &fileVal : files) {
         const QString filename = fileVal.toString();
-        if (filename.isEmpty())
+        if (!isSafeManifestFilename(filename)) {
+            qCWarning(lcDevice) << "unsafe manifest filename rejected:" << slug << "/" << filename;
+            m_failedDownloads++;
             continue;
+        }
 
         m_pendingDownloads++;
 
-        const QUrl url(kRawBaseUrl + slug + QStringLiteral("/") + filename);
+        const QUrl url(rawBaseUrl() + slug + QStringLiteral("/") + filename);
         QNetworkRequest req{url};
         req.setTransferTimeout(10000);
 
@@ -286,6 +370,7 @@ void DeviceFetcher::downloadDevice(const QString &slug, const QJsonObject &devic
             if (reply->error() != QNetworkReply::NoError) {
                 qCWarning(lcDevice) << "download failed:" << slug << "/" << filename
                                     << reply->errorString();
+                m_failedDownloads++;
             } else {
                 onFileDownloaded(slug, filename, reply->readAll());
             }
@@ -318,11 +403,12 @@ void DeviceFetcher::checkDownloadsComplete()
     if (m_pendingDownloads > 0)
         return;
 
-    if (m_hasNewDevices) {
+    if (m_hasNewDevices && m_failedDownloads == 0) {
         qCDebug(lcDevice) << "new descriptors downloaded";
-        m_hasNewDevices = false;
         emit descriptorsUpdated();
     }
+    m_hasNewDevices = false;
+    m_failedDownloads = 0;
 }
 
 } // namespace logitune

--- a/src/core/DeviceFetcher.h
+++ b/src/core/DeviceFetcher.h
@@ -23,9 +23,13 @@ public:
     QString loadEtag() const;
     void saveManifest(const QJsonObject &manifest);
     QJsonObject loadManifest() const;
+    QJsonObject loadBundledManifest() const;
     QPair<QString, QJsonObject> findDeviceForPid(const QJsonObject &manifest, uint16_t pid) const;
+    bool isSafeManifestFilename(const QString &filename) const;
     bool deviceNeedsUpdate(const QString &slug, int manifestVersion) const;
     QString deviceCachePath(const QString &slug) const;
+    static QString manifestUrl();
+    static QString rawBaseUrl();
 
 signals:
     void descriptorsUpdated();
@@ -40,6 +44,7 @@ private:
     QString m_cacheDir;
     uint16_t m_pendingPid = 0;
     int m_pendingDownloads = 0;
+    int m_failedDownloads = 0;
     bool m_hasNewDevices = false;
 
     static constexpr int kCacheTtlSeconds = 3600;

--- a/src/core/devices/JsonDevice.cpp
+++ b/src/core/devices/JsonDevice.cpp
@@ -19,11 +19,30 @@ bool JsonDevice::matchesPid(uint16_t pid) const
     return false;
 }
 
-static JsonDevice::Status parseStatus(const QString& s)
+static bool parseStatus(const QString& s, JsonDevice::Status& out)
 {
-    if (s == QStringLiteral("verified") || s == QStringLiteral("implemented"))
-        return JsonDevice::Status::Verified;
-    return JsonDevice::Status::Beta;
+    if (s == QStringLiteral("verified")) {
+        out = JsonDevice::Status::Verified;
+        return true;
+    }
+    if (s == QStringLiteral("beta")) {
+        out = JsonDevice::Status::Beta;
+        return true;
+    }
+    return false;
+}
+
+static bool parseDeviceKind(const QString& s, DeviceKind& out)
+{
+    if (s == QStringLiteral("mouse")) {
+        out = DeviceKind::Mouse;
+        return true;
+    }
+    if (s == QStringLiteral("keyboard")) {
+        out = DeviceKind::Keyboard;
+        return true;
+    }
+    return false;
 }
 
 static ButtonAction::Type parseButtonActionType(const QString& s)
@@ -164,8 +183,15 @@ bool JsonDevice::parseFromObject(const QJsonObject& root, const QString& dirPath
     const QDir dir(dirPath);
     const QString filePath = dir.absoluteFilePath(QStringLiteral("descriptor.json"));
 
-    m_status = parseStatus(root.value(QStringLiteral("status")).toString());
     m_name = root.value(QStringLiteral("name")).toString();
+    if (!parseStatus(root.value(QStringLiteral("status")).toString(), m_status)) {
+        qCWarning(lcDevice) << "JsonDevice: invalid or missing status in" << filePath;
+        return false;
+    }
+    if (!parseDeviceKind(root.value(QStringLiteral("deviceKind")).toString(), m_deviceKind)) {
+        qCWarning(lcDevice) << "JsonDevice: invalid or missing deviceKind in" << filePath;
+        return false;
+    }
 
     const QJsonArray pidArr = root.value(QStringLiteral("productIds")).toArray();
     for (const auto& v : pidArr) {
@@ -295,6 +321,7 @@ bool JsonDevice::refresh()
     m_backImage.clear();
     m_features = FeatureSupport{};
     m_name.clear();
+    m_deviceKind = DeviceKind::Mouse;
     m_status = Status::Beta;
     m_minDpi = 200;
     m_maxDpi = 8000;
@@ -320,6 +347,7 @@ bool JsonDevice::refreshFromObject(const QJsonObject &root)
     m_backImage.clear();
     m_features = FeatureSupport{};
     m_name.clear();
+    m_deviceKind = DeviceKind::Mouse;
     m_status = Status::Beta;
     m_minDpi = 200;
     m_maxDpi = 8000;

--- a/src/core/devices/JsonDevice.h
+++ b/src/core/devices/JsonDevice.h
@@ -21,6 +21,7 @@ public:
     qint64 loadedMtime() const { return m_loadedMtime; }
 
     QString deviceName() const override { return m_name; }
+    DeviceKind deviceKind() const override { return m_deviceKind; }
     std::vector<uint16_t> productIds() const override { return m_pids; }
     bool matchesPid(uint16_t pid) const override;
     QList<ControlDescriptor> controls() const override { return m_controls; }
@@ -43,6 +44,7 @@ private:
     bool parseFromObject(const QJsonObject& root, const QString& dirPath, bool strict = true);
 
     Status m_status = Status::Beta;
+    DeviceKind m_deviceKind = DeviceKind::Mouse;
     QString m_name;
     std::vector<uint16_t> m_pids;
     FeatureSupport m_features;

--- a/src/core/interfaces/IDevice.h
+++ b/src/core/interfaces/IDevice.h
@@ -8,6 +8,11 @@
 
 namespace logitune {
 
+enum class DeviceKind {
+    Mouse,
+    Keyboard,
+};
+
 struct ControlDescriptor {
     uint16_t controlId;
     int buttonIndex;
@@ -67,6 +72,7 @@ public:
     virtual ~IDevice() = default;
 
     virtual QString deviceName() const = 0;
+    virtual DeviceKind deviceKind() const = 0;
     virtual std::vector<uint16_t> productIds() const = 0;
     virtual bool matchesPid(uint16_t pid) const = 0;
     virtual QList<ControlDescriptor> controls() const = 0;

--- a/tests/mocks/MockDevice.h
+++ b/tests/mocks/MockDevice.h
@@ -14,6 +14,7 @@ public:
 
     // --- Configurable member data ---
     QString m_deviceName        = QStringLiteral("Mock Device");
+    DeviceKind m_deviceKind     = DeviceKind::Mouse;
     std::vector<uint16_t> m_productIds;
     QList<ControlDescriptor> m_controls;
     QList<HotspotDescriptor> m_buttonHotspots;
@@ -32,6 +33,7 @@ public:
     // --- IDevice implementation ---
 
     QString deviceName() const override { return m_deviceName; }
+    DeviceKind deviceKind() const override { return m_deviceKind; }
     std::vector<uint16_t> productIds() const override { return m_productIds; }
     bool matchesPid(uint16_t pid) const override {
         for (auto id : m_productIds)

--- a/tests/test_device_fetcher.cpp
+++ b/tests/test_device_fetcher.cpp
@@ -7,6 +7,7 @@
 #include <QJsonArray>
 #include <QFile>
 #include <QDir>
+#include <QByteArray>
 
 using namespace logitune;
 
@@ -44,6 +45,52 @@ static QJsonObject makeTestManifest()
     return manifest;
 }
 
+class ScopedEnvironmentVariable {
+public:
+    ScopedEnvironmentVariable(const char *name, const QByteArray &value)
+        : m_name(name)
+        , m_hadValue(qEnvironmentVariableIsSet(name))
+        , m_previous(qgetenv(name))
+    {
+        qputenv(name, value);
+    }
+
+    ~ScopedEnvironmentVariable()
+    {
+        if (m_hadValue)
+            qputenv(m_name, m_previous);
+        else
+            qunsetenv(m_name);
+    }
+
+private:
+    const char *m_name;
+    bool m_hadValue;
+    QByteArray m_previous;
+};
+
+class ScopedUnsetEnvironmentVariable {
+public:
+    explicit ScopedUnsetEnvironmentVariable(const char *name)
+        : m_name(name)
+        , m_hadValue(qEnvironmentVariableIsSet(name))
+        , m_previous(qgetenv(name))
+    {
+        qunsetenv(name);
+    }
+
+    ~ScopedUnsetEnvironmentVariable()
+    {
+        if (m_hadValue)
+            qputenv(m_name, m_previous);
+    }
+
+private:
+    const char *m_name;
+    bool m_hadValue;
+    QByteArray m_previous;
+};
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -77,6 +124,36 @@ TEST_F(DeviceFetcherTest, ManifestParseFindsPid)
 
     EXPECT_EQ(slug, QStringLiteral("mx-master-3s"));
     EXPECT_EQ(info[QStringLiteral("version")].toInt(), 2);
+}
+
+TEST_F(DeviceFetcherTest, BundledManifestLoads)
+{
+    const auto manifest = m_fetcher.loadBundledManifest();
+    ASSERT_FALSE(manifest.isEmpty());
+    EXPECT_TRUE(manifest[QStringLiteral("devices")].toObject().contains(QStringLiteral("mx-mechanical")));
+}
+
+TEST_F(DeviceFetcherTest, BundledManifestFindsMxMechanicalPid)
+{
+    const auto manifest = m_fetcher.loadBundledManifest();
+    const auto [slug, info] = m_fetcher.findDeviceForPid(manifest, 0xb366);
+
+    EXPECT_EQ(slug, QStringLiteral("mx-mechanical"));
+    EXPECT_EQ(info[QStringLiteral("version")].toInt(), 1);
+}
+
+TEST_F(DeviceFetcherTest, ManifestFilenameSafety)
+{
+    EXPECT_TRUE(m_fetcher.isSafeManifestFilename(QStringLiteral("descriptor.json")));
+    EXPECT_TRUE(m_fetcher.isSafeManifestFilename(QStringLiteral("front.png")));
+    EXPECT_TRUE(m_fetcher.isSafeManifestFilename(QStringLiteral("side.svg")));
+
+    EXPECT_FALSE(m_fetcher.isSafeManifestFilename(QString()));
+    EXPECT_FALSE(m_fetcher.isSafeManifestFilename(QStringLiteral("../descriptor.json")));
+    EXPECT_FALSE(m_fetcher.isSafeManifestFilename(QStringLiteral("nested/front.png")));
+    EXPECT_FALSE(m_fetcher.isSafeManifestFilename(QStringLiteral("nested\\front.png")));
+    EXPECT_FALSE(m_fetcher.isSafeManifestFilename(QStringLiteral("/tmp/front.png")));
+    EXPECT_FALSE(m_fetcher.isSafeManifestFilename(QStringLiteral("descriptor.json.bak")));
 }
 
 TEST_F(DeviceFetcherTest, ManifestParseReturnsEmptyForUnknownPid)
@@ -118,4 +195,51 @@ TEST_F(DeviceFetcherTest, DeviceCachePaths)
 {
     const QString expected = m_tmp.path() + QStringLiteral("/devices/mx-master-3s");
     EXPECT_EQ(m_fetcher.deviceCachePath(QStringLiteral("mx-master-3s")), expected);
+}
+
+TEST_F(DeviceFetcherTest, DescriptorFeedUrlsUseDefaultsWhenEnvironmentUnset)
+{
+    ScopedUnsetEnvironmentVariable manifest("LOGITUNE_DEVICE_MANIFEST_URL");
+    ScopedUnsetEnvironmentVariable rawBase("LOGITUNE_DEVICE_RAW_BASE_URL");
+
+    EXPECT_EQ(DeviceFetcher::manifestUrl(),
+              QStringLiteral("https://raw.githubusercontent.com/mmaher88/logitune/master/devices/manifest.json"));
+    EXPECT_EQ(DeviceFetcher::rawBaseUrl(),
+              QStringLiteral("https://raw.githubusercontent.com/mmaher88/logitune/master/devices/"));
+}
+
+TEST_F(DeviceFetcherTest, DescriptorFeedUrlsUseDefaultsWhenEnvironmentEmpty)
+{
+    ScopedEnvironmentVariable manifest("LOGITUNE_DEVICE_MANIFEST_URL", QByteArray());
+    ScopedEnvironmentVariable rawBase("LOGITUNE_DEVICE_RAW_BASE_URL", QByteArray());
+
+    EXPECT_EQ(DeviceFetcher::manifestUrl(),
+              QStringLiteral("https://raw.githubusercontent.com/mmaher88/logitune/master/devices/manifest.json"));
+    EXPECT_EQ(DeviceFetcher::rawBaseUrl(),
+              QStringLiteral("https://raw.githubusercontent.com/mmaher88/logitune/master/devices/"));
+}
+
+TEST_F(DeviceFetcherTest, DescriptorFeedUrlsUseEnvironmentOverrides)
+{
+    ScopedEnvironmentVariable manifest(
+        "LOGITUNE_DEVICE_MANIFEST_URL",
+        QByteArray("https://raw.githubusercontent.com/example/logitune/descriptor-work/devices/manifest.json"));
+    ScopedEnvironmentVariable rawBase(
+        "LOGITUNE_DEVICE_RAW_BASE_URL",
+        QByteArray("https://raw.githubusercontent.com/example/logitune/descriptor-work/devices/"));
+
+    EXPECT_EQ(DeviceFetcher::manifestUrl(),
+              QStringLiteral("https://raw.githubusercontent.com/example/logitune/descriptor-work/devices/manifest.json"));
+    EXPECT_EQ(DeviceFetcher::rawBaseUrl(),
+              QStringLiteral("https://raw.githubusercontent.com/example/logitune/descriptor-work/devices/"));
+}
+
+TEST_F(DeviceFetcherTest, DescriptorFeedRawBaseOverrideAddsTrailingSlash)
+{
+    ScopedEnvironmentVariable rawBase(
+        "LOGITUNE_DEVICE_RAW_BASE_URL",
+        QByteArray("https://raw.githubusercontent.com/example/logitune/descriptor-work/devices///"));
+
+    EXPECT_EQ(DeviceFetcher::rawBaseUrl(),
+              QStringLiteral("https://raw.githubusercontent.com/example/logitune/descriptor-work/devices/"));
 }

--- a/tests/test_device_registry.cpp
+++ b/tests/test_device_registry.cpp
@@ -10,8 +10,10 @@ using namespace logitune;
 struct DeviceSpec {
     uint16_t pid;
     const char* name;
+    DeviceKind kind;
     int minDpi, maxDpi, dpiStep;
     size_t buttonHotspots, scrollHotspots;
+    size_t easySwitchSlots;
     size_t minControls;
     uint16_t control0Cid, control5Cid;
     const char* control5ActionType, *control6ActionType;
@@ -26,8 +28,9 @@ static const DeviceSpec kDevices[] = {
     {
         .pid = 0xb019,
         .name = "MX Master 2S",
+        .kind = DeviceKind::Mouse,
         .minDpi = 200, .maxDpi = 4000, .dpiStep = 50,
-        .buttonHotspots = 6, .scrollHotspots = 3,
+        .buttonHotspots = 6, .scrollHotspots = 3, .easySwitchSlots = 3,
         .minControls = 7,
         .control0Cid = 0x0050, .control5Cid = 0x00C3,
         .control5ActionType = "gesture-trigger",
@@ -41,8 +44,9 @@ static const DeviceSpec kDevices[] = {
     {
         .pid = 0xb034,
         .name = "MX Master 3S",
+        .kind = DeviceKind::Mouse,
         .minDpi = 200, .maxDpi = 8000, .dpiStep = 50,
-        .buttonHotspots = 6, .scrollHotspots = 3,
+        .buttonHotspots = 6, .scrollHotspots = 3, .easySwitchSlots = 3,
         .minControls = 7,
         .control0Cid = 0x0050, .control5Cid = 0x00C3,
         .control5ActionType = "gesture-trigger",
@@ -56,8 +60,9 @@ static const DeviceSpec kDevices[] = {
     {
         .pid = 0xc52b,
         .name = "MX Master 3",
+        .kind = DeviceKind::Mouse,
         .minDpi = 200, .maxDpi = 4000, .dpiStep = 50,
-        .buttonHotspots = 6, .scrollHotspots = 3,
+        .buttonHotspots = 6, .scrollHotspots = 3, .easySwitchSlots = 3,
         .minControls = 7,
         .control0Cid = 0x0050, .control5Cid = 0x00C3,
         .control5ActionType = "gesture-trigger",
@@ -71,8 +76,9 @@ static const DeviceSpec kDevices[] = {
     {
         .pid = 0xb042,
         .name = "MX Master 4",
+        .kind = DeviceKind::Mouse,
         .minDpi = 200, .maxDpi = 8000, .dpiStep = 50,
-        .buttonHotspots = 6, .scrollHotspots = 3,
+        .buttonHotspots = 6, .scrollHotspots = 3, .easySwitchSlots = 3,
         .minControls = 7,
         .control0Cid = 0x0050, .control5Cid = 0x00C3,
         .control5ActionType = "gesture-trigger",
@@ -86,8 +92,9 @@ static const DeviceSpec kDevices[] = {
     {
         .pid = 0xb037,
         .name = "MX Anywhere 3S",
+        .kind = DeviceKind::Mouse,
         .minDpi = 200, .maxDpi = 8000, .dpiStep = 50,
-        .buttonHotspots = 4, .scrollHotspots = 2,
+        .buttonHotspots = 4, .scrollHotspots = 2, .easySwitchSlots = 3,
         .minControls = 6,
         .control0Cid = 0x0050, .control5Cid = 0x00C4,
         .control5ActionType = "smartshift-toggle",
@@ -101,8 +108,9 @@ static const DeviceSpec kDevices[] = {
     {
         .pid = 0xb038,
         .name = "MX Anywhere 3S for Business",
+        .kind = DeviceKind::Mouse,
         .minDpi = 200, .maxDpi = 8000, .dpiStep = 50,
-        .buttonHotspots = 4, .scrollHotspots = 2,
+        .buttonHotspots = 4, .scrollHotspots = 2, .easySwitchSlots = 3,
         .minControls = 6,
         .control0Cid = 0x0050, .control5Cid = 0x00C4,
         .control5ActionType = "smartshift-toggle",
@@ -116,8 +124,9 @@ static const DeviceSpec kDevices[] = {
     {
         .pid = 0xb025,
         .name = "MX Anywhere 3",
+        .kind = DeviceKind::Mouse,
         .minDpi = 200, .maxDpi = 4000, .dpiStep = 50,
-        .buttonHotspots = 4, .scrollHotspots = 2,
+        .buttonHotspots = 4, .scrollHotspots = 2, .easySwitchSlots = 3,
         .minControls = 6,
         .control0Cid = 0x0050, .control5Cid = 0x00C4,
         .control5ActionType = "smartshift-toggle",
@@ -131,8 +140,9 @@ static const DeviceSpec kDevices[] = {
     {
         .pid = 0xb02d,
         .name = "MX Anywhere 3 for Business",
+        .kind = DeviceKind::Mouse,
         .minDpi = 200, .maxDpi = 4000, .dpiStep = 50,
-        .buttonHotspots = 4, .scrollHotspots = 2,
+        .buttonHotspots = 4, .scrollHotspots = 2, .easySwitchSlots = 3,
         .minControls = 6,
         .control0Cid = 0x0050, .control5Cid = 0x00C4,
         .control5ActionType = "smartshift-toggle",
@@ -146,13 +156,30 @@ static const DeviceSpec kDevices[] = {
     {
         .pid = 0xb020,
         .name = "MX Vertical",
+        .kind = DeviceKind::Mouse,
         .minDpi = 400, .maxDpi = 4000, .dpiStep = 50,
-        .buttonHotspots = 4, .scrollHotspots = 2,
+        .buttonHotspots = 4, .scrollHotspots = 2, .easySwitchSlots = 3,
         .minControls = 6,
         .control0Cid = 0x0050, .control5Cid = 0x00C3,
         .control5ActionType = "dpi-cycle",
         .control6ActionType = nullptr,
         .battery = true, .adjustableDpi = true, .smartShift = false,
+        .reprogControls = true, .gestureV2 = false,
+        .gestureDownType = ButtonAction::Default,
+        .gestureDownPayload = nullptr,
+        .gestureUpType = ButtonAction::Default,
+    },
+    {
+        .pid = 0xb366,
+        .name = "MX Mechanical",
+        .kind = DeviceKind::Keyboard,
+        .minDpi = 200, .maxDpi = 8000, .dpiStep = 50,
+        .buttonHotspots = 0, .scrollHotspots = 0, .easySwitchSlots = 3,
+        .minControls = 36,
+        .control0Cid = 0x000A, .control5Cid = 0x00D4,
+        .control5ActionType = "default",
+        .control6ActionType = nullptr,
+        .battery = true, .adjustableDpi = false, .smartShift = false,
         .reprogControls = true, .gestureV2 = false,
         .gestureDownType = ButtonAction::Default,
         .gestureDownPayload = nullptr,
@@ -170,6 +197,7 @@ TEST_P(DeviceRegistryTest, FindsByPid) {
     auto* dev = reg.findByPid(s.pid);
     ASSERT_NE(dev, nullptr);
     EXPECT_EQ(dev->deviceName(), s.name);
+    EXPECT_EQ(dev->deviceKind(), s.kind);
 }
 
 TEST_P(DeviceRegistryTest, ControlsHaveExpectedCids) {
@@ -217,6 +245,8 @@ TEST_P(DeviceRegistryTest, DpiRange) {
     auto* dev = reg.findByPid(GetParam().pid);
     ASSERT_NE(dev, nullptr);
     auto& s = GetParam();
+    if (s.kind != DeviceKind::Mouse)
+        GTEST_SKIP() << "DPI assertions are mouse-only";
     EXPECT_EQ(dev->minDpi(), s.minDpi);
     EXPECT_EQ(dev->maxDpi(), s.maxDpi);
     EXPECT_EQ(dev->dpiStep(), s.dpiStep);
@@ -228,6 +258,7 @@ TEST_P(DeviceRegistryTest, Hotspots) {
     auto& s = GetParam();
     EXPECT_EQ(dev->buttonHotspots().size(), s.buttonHotspots);
     EXPECT_EQ(dev->scrollHotspots().size(), s.scrollHotspots);
+    EXPECT_EQ(dev->easySwitchSlotPositions().size(), s.easySwitchSlots);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -248,6 +279,18 @@ TEST(DeviceRegistry, ReturnsNullForUnknownPid) {
     EXPECT_EQ(reg.findByPid(0xFFFF), nullptr);
 }
 
+TEST(DeviceRegistry, MxMechanicalBoltReceiverPidFallsBackToName) {
+    DeviceRegistry reg;
+    EXPECT_EQ(reg.findByPid(0xc548), nullptr);
+
+    const auto *dev = reg.findByName(QStringLiteral("MX Mechanical"));
+    ASSERT_NE(dev, nullptr);
+    EXPECT_EQ(dev->deviceKind(), DeviceKind::Keyboard);
+    const auto ids = dev->productIds();
+    EXPECT_NE(std::find(ids.begin(), ids.end(), 0xb366), ids.end());
+    EXPECT_EQ(dev->deviceName(), QStringLiteral("MX Mechanical"));
+}
+
 TEST(DeviceRegistry, ReloadByPathRefreshesSingleDevice) {
     QTemporaryDir tmp;
     ASSERT_TRUE(tmp.isValid());
@@ -259,7 +302,7 @@ TEST(DeviceRegistry, ReloadByPathRefreshesSingleDevice) {
         QFile f(descPath);
         if (!f.open(QIODevice::WriteOnly | QIODevice::Truncate))
             return false;
-        f.write(QStringLiteral(R"({"name":"%1","status":"beta","productIds":["0xffff"],"features":{},"controls":[],"hotspots":{"buttons":[],"scroll":[]},"images":{},"easySwitchSlots":[]})").arg(name).toUtf8());
+        f.write(QStringLiteral(R"({"name":"%1","deviceKind":"mouse","status":"beta","productIds":["0xffff"],"features":{},"controls":[],"hotspots":{"buttons":[],"scroll":[]},"images":{},"easySwitchSlots":[]})").arg(name).toUtf8());
         f.close();
         return true;
     };

--- a/tests/test_editor_model.cpp
+++ b/tests/test_editor_model.cpp
@@ -17,6 +17,7 @@ QString writeMinimalDescriptor(const QString &dir) {
     f.open(QIODevice::WriteOnly | QIODevice::Truncate);
     f.write(R"({
   "name": "Tester",
+  "deviceKind": "mouse",
   "status": "beta",
   "productIds": ["0xffff"],
   "features": {},
@@ -82,7 +83,7 @@ TEST(EditorModel, UpdateHotspotMutatesPendingAndPushesUndo) {
     QFile f(tmp.path() + QStringLiteral("/dev/descriptor.json"));
     ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
     f.write(R"({
-  "name": "Tester", "status": "beta", "productIds": ["0xffff"],
+  "name": "Tester", "deviceKind": "mouse", "status": "beta", "productIds": ["0xffff"],
   "features": {}, "controls": [],
   "hotspots": {
     "buttons": [
@@ -111,7 +112,7 @@ TEST(EditorModel, UpdateScrollHotspotMutatesScrollArray) {
     QFile f(tmp.path() + QStringLiteral("/dev/descriptor.json"));
     ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
     f.write(R"({
-  "name": "Tester", "status": "beta", "productIds": ["0xffff"],
+  "name": "Tester", "deviceKind": "mouse", "status": "beta", "productIds": ["0xffff"],
   "features": {}, "controls": [],
   "hotspots": {
     "buttons": [],
@@ -165,7 +166,7 @@ TEST(EditorModel, UpdateTextEditsAllThreeKindsAndUndoes) {
     QFile f(tmp.path() + QStringLiteral("/dev/descriptor.json"));
     ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
     f.write(R"({
-  "name": "Original Name", "status": "beta", "productIds": ["0xffff"],
+  "name": "Original Name", "deviceKind": "mouse", "status": "beta", "productIds": ["0xffff"],
   "features": {},
   "controls": [
     {"controlId": "0x0050", "buttonIndex": 0, "defaultName": "Left", "defaultActionType": "default", "configurable": false}

--- a/tests/test_json_device.cpp
+++ b/tests/test_json_device.cpp
@@ -42,6 +42,7 @@ static QJsonObject makeMinimalVerified()
 {
     QJsonObject root;
     root[QStringLiteral("name")] = QStringLiteral("Test Device");
+    root[QStringLiteral("deviceKind")] = QStringLiteral("mouse");
     root[QStringLiteral("status")] = QStringLiteral("verified");
     root[QStringLiteral("productIds")] = QJsonArray{QStringLiteral("0xAAAA")};
     root[QStringLiteral("features")] = QJsonObject{
@@ -91,6 +92,7 @@ static QJsonObject makeMinimalBeta()
 {
     QJsonObject root;
     root[QStringLiteral("name")] = QStringLiteral("Beta Mouse");
+    root[QStringLiteral("deviceKind")] = QStringLiteral("mouse");
     root[QStringLiteral("status")] = QStringLiteral("beta");
     root[QStringLiteral("productIds")] = QJsonArray{QStringLiteral("0xBBBB")};
     root[QStringLiteral("features")] = QJsonObject{};
@@ -134,6 +136,7 @@ TEST(JsonDevice, LoadValidVerified)
     ASSERT_NE(dev, nullptr);
 
     EXPECT_EQ(dev->deviceName(), QStringLiteral("Test Device"));
+    EXPECT_EQ(dev->deviceKind(), DeviceKind::Mouse);
     EXPECT_EQ(dev->status(), JsonDevice::Status::Verified);
 
     // Product IDs
@@ -178,6 +181,28 @@ TEST(JsonDevice, LoadValidVerified)
     EXPECT_EQ(gestures[QStringLiteral("up")].type, ButtonAction::Default);
     EXPECT_EQ(gestures[QStringLiteral("down")].type, ButtonAction::Keystroke);
     EXPECT_EQ(gestures[QStringLiteral("down")].payload, QStringLiteral("Super+D"));
+}
+
+TEST(JsonDevice, RejectsMissingDeviceKind)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    auto obj = makeMinimalBeta();
+    obj.remove(QStringLiteral("deviceKind"));
+    writeJson(tmp.path(), obj);
+
+    EXPECT_EQ(JsonDevice::load(tmp.path()), nullptr);
+}
+
+TEST(JsonDevice, RejectsInvalidDeviceKind)
+{
+    QTemporaryDir tmp;
+    ASSERT_TRUE(tmp.isValid());
+    auto obj = makeMinimalBeta();
+    obj[QStringLiteral("deviceKind")] = QStringLiteral("trackball");
+    writeJson(tmp.path(), obj);
+
+    EXPECT_EQ(JsonDevice::load(tmp.path()), nullptr);
 }
 
 TEST(JsonDevice, HotspotKindRoundTrip)
@@ -411,6 +436,7 @@ TEST(JsonDevice, TracksSourcePathAndLoadMtime) {
     ASSERT_TRUE(f.open(QIODevice::WriteOnly));
     f.write(R"({
   "name": "Tester",
+  "deviceKind": "mouse",
   "status": "beta",
   "productIds": ["0xffff"],
   "features": {},
@@ -438,6 +464,7 @@ TEST(JsonDevice, ParsesOptionalEditorFields) {
     ASSERT_TRUE(f.open(QIODevice::WriteOnly));
     f.write(R"({
   "name": "Tester",
+  "deviceKind": "mouse",
   "status": "beta",
   "productIds": ["0xffff"],
   "features": {},
@@ -480,6 +507,7 @@ TEST(JsonDevice, OptionalEditorFieldsDefaultEmptyWhenAbsent) {
     ASSERT_TRUE(f.open(QIODevice::WriteOnly));
     f.write(R"({
   "name": "Tester",
+  "deviceKind": "mouse",
   "status": "beta",
   "productIds": ["0xffff"],
   "features": {},
@@ -510,6 +538,7 @@ TEST(JsonDevice, RefreshRereadsDescriptorInPlace) {
         ASSERT_TRUE(f.open(QIODevice::WriteOnly | QIODevice::Truncate));
         f.write(QStringLiteral(R"({
   "name": "%1",
+  "deviceKind": "mouse",
   "status": "beta",
   "productIds": ["0xffff"],
   "features": {},
@@ -532,14 +561,13 @@ TEST(JsonDevice, RefreshRereadsDescriptorInPlace) {
     EXPECT_EQ(dev.get(), raw);
 }
 
-TEST(JsonDevice, OldStatusStringsStillParse) {
+TEST(JsonDevice, RejectsInvalidStatus) {
     QTemporaryDir tmp;
     ASSERT_TRUE(tmp.isValid());
     auto root = makeMinimalVerified();
     root[QStringLiteral("status")] = QStringLiteral("implemented");
     writeJson(tmp.path(), root);
     writeDummyImage(tmp.path(), QStringLiteral("front.png"));
-    auto dev = logitune::JsonDevice::load(tmp.path());
-    ASSERT_NE(dev, nullptr);
-    EXPECT_EQ(dev->status(), logitune::JsonDevice::Status::Verified);
+
+    EXPECT_EQ(logitune::JsonDevice::load(tmp.path()), nullptr);
 }


### PR DESCRIPTION
## What changed

- Add a beta MX Mechanical keyboard descriptor with canonical deviceKind metadata, WPID 0xb366, battery/Easy-Switch support, and 36 ReprogControls key CIDs.
- Require descriptor status/deviceKind to use the new canonical schema and add version metadata to all bundled descriptors.
- Generate and ship devices/manifest.json from bundled descriptors, then point DeviceFetcher at the main logitune raw manifest path with stale-cache and bundled-manifest fallbacks.
- Document HID++-scoped Options+ parity boundaries and the MX Mechanical beta scope.
- Build Debian packages with root-owned payloads via dpkg-deb --root-owner-group.

## Validation

- python3 scripts/generate-device-manifest.py --check
- python3 scripts/generate-readme-devices.py --check
- git diff --check
- cmake --build build --target logitune-tests -j$(nproc)
- QT_QPA_PLATFORM=offscreen XDG_DATA_DIRS=/home/emre/logitune/build ./build/tests/logitune-tests (741 passed, 1 MX Mechanical DPI test skipped as keyboard-only)
- Built and installed local logitune_0.3.5~local deb; dpkg -V logitune clean; installed app loads 11 descriptors including MX Mechanical from /usr/share/logitune/devices and falls back to bundled descriptors when the not-yet-merged raw manifest is unavailable.

## Notes

The stable remote manifest URL will become available once this PR is merged to master. Until then, local builds correctly fall back to the bundled installed manifest.