### PR TITLE
fix: load uinput in Arch hook

### DIFF
--- a/packaging/logitune.install
+++ b/packaging/logitune.install
@@ -3,9 +3,14 @@ post_install() {
     echo "==> Logitune installed!"
     echo ""
 
+    # Ensure /dev/uinput exists before applying udev rules. Without the
+    # kernel module loaded, udev has no misc/uinput device to tag with uaccess.
+    modprobe uinput 2>/dev/null || true
+
     # Reload udev rules so hidraw/uinput permissions take effect
-    udevadm control --reload-rules 2>/dev/null
-    udevadm trigger 2>/dev/null
+    udevadm control --reload-rules 2>/dev/null || true
+    udevadm trigger --subsystem-match=misc --sysname-match=uinput --action=change 2>/dev/null || true
+    udevadm trigger --subsystem-match=hidraw --action=change 2>/dev/null || true
 
     echo "    1. Unplug and replug your Logitech device (or reboot)"
     echo "    2. Run: logitune"


### PR DESCRIPTION
### What happened

On my **Manjaro KDE Wayland** system, Logitune detected the mouse and received
button events correctly, but remapped button actions did nothing.

The log showed that **hidraw access was working**:

```text
button event: CID c4 pressed
button 6 action type= 7 payload= "Next"
```

But **uinput initialization failed**:

```text
UinputInjector: uinput init failed (no /dev/uinput access?)
Keystrokes will not be injected.
```

### Root cause

In my case, `/dev/uinput` existed, but the actual **uinput kernel device was
not loaded or registered**:

```text
/dev/uinput existed as crw------- root root
/sys/class/misc/uinput did not exist
/proc/misc did not contain uinput
lsmod did not show uinput
udevadm info -n /dev/uinput returned "Unknown device"
```

Because of that, reloading and triggering udev rules was not enough. The rule
with `TAG+="uaccess"` had no live `misc/uinput` device to apply to.

### Fix

This patch loads the **uinput** kernel module in the Arch install hook before
reloading and triggering udev rules.

It then triggers:

- `misc/uinput`, so `uaccess` can be applied to `/dev/uinput`
- `hidraw`, so Logitech device permissions are refreshed as before

After manually running `modprobe uinput` and reloading udev rules on my system,
Logitune stopped failing uinput init, and button remaps started working.
