### PR TITLE
packaging(obs): depend on qml6-module-qtquick-dialogs (Ubuntu 24.04 fails to run)

### DIFF
--- a/pkg/obs/debian.control
+++ b/pkg/obs/debian.control
@@ -8,7 +8,7 @@ Homepage: https://github.com/mmaher88/logitune
 
 Package: logitune
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libqt6core6 (>= 6.4), libqt6quick6, libqt6svg6, libqt6dbus6, libqt6widgets6, libudev1, qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-window, qml6-module-qtquick-templates, qml6-module-qtquick-layouts, qml6-module-qtqml, qml6-module-qtqml-workerscript
+Depends: ${shlibs:Depends}, ${misc:Depends}, libqt6core6 (>= 6.4), libqt6quick6, libqt6svg6, libqt6dbus6, libqt6widgets6, libudev1, qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-dialogs, qml6-module-qtquick-window, qml6-module-qtquick-templates, qml6-module-qtquick-layouts, qml6-module-qtqml, qml6-module-qtqml-workerscript
 Suggests: gnome-shell
 Description: Logitech device configurator for Linux
  Logitune is a Logitech Options+ alternative for Linux. Configure HID++


### PR DESCRIPTION
## Problem

`logitune` installed from the **OBS apt repo** on a clean **Ubuntu 24.04** starts, enumerates the device (HID++ talks to the MX Master 3S fine), then **shows no window**. Log:

```
DeviceRender.qml:3:1: module "QtQuick.Dialogs" is not installed
  → DeviceRender unavailable → ButtonsPage → DeviceView → Main.qml
QML loaded, root objects: 0
[CRIT] QML failed to load — no root objects
```

## Root cause

`DeviceRender.qml` does `import QtQuick.Dialogs`. On Debian/Ubuntu each QML module is a separate apt package, and QML modules are loaded by the engine at runtime (not linked as `.so`s), so `dpkg-shlibdeps` cannot auto-detect them — they must be declared by hand.

`pkg/obs/debian.control` (the OBS-built package, version `0.3.5-0`) listed every QtQuick module the app imports **except** `qml6-module-qtquick-dialogs`, so `apt` never pulled it in and the module was absent at runtime. It works on Arch only because `qt6-declarative` bundles all QtQuick modules in one package.

`scripts/package-deb.sh` (the GitHub `.deb`) already declares `qtquick-dialogs`; the OBS control file had drifted.

## Fix

Add `qml6-module-qtquick-dialogs` to the `Depends:` in `pkg/obs/debian.control`. One line. Verified against the full set of QML imports in the shipped code (`QtQuick`, `Controls`, `Dialogs`, `Layouts`, `Window` + transitive `Templates`/`qtqml`) — `Dialogs` was the only gap.

## Rollout note

OBS versions are tag-driven via `_service` + `set_version`, so this lands when the spec is synced + OBS rebuilds (next release tag, or a manual `trigger_obs` dispatch). Existing `0.3.5-0` installs can be unblocked immediately with `sudo apt install qml6-module-qtquick-dialogs`.

## Follow-up (not in this PR)

Two packaging dep lists (`package-deb.sh` and `pkg/obs/debian.control`) can drift independently — they already disagree (`package-deb.sh` also lists a stray `qt5compat-graphicaleffects` the code no longer imports). Worth a small CI lint that cross-checks both against the actual `import` statements in `src/**/*.qml`, alongside the existing README-devices and DeviceSpec checks.