### PR TITLE
ci: derive Debian QML deps from code, gate drift in CI + pre-push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,15 +230,17 @@ jobs:
     name: CI Summary
     if: always()
     runs-on: ubuntu-latest
-    needs: [build, deb-pkg]
+    needs: [build, deb-pkg, devices-table-check]
     steps:
       - name: Check all jobs passed
         run: |
-          echo "Build:  ${{ needs.build.result }}"
-          echo "Deb:    ${{ needs.deb-pkg.result }}"
+          echo "Build:                ${{ needs.build.result }}"
+          echo "Deb:                  ${{ needs.deb-pkg.result }}"
+          echo "Devices table check:  ${{ needs.devices-table-check.result }}"
 
           if [ "${{ needs.build.result }}" != "success" ] || \
-             [ "${{ needs.deb-pkg.result }}" != "success" ]; then
+             [ "${{ needs.deb-pkg.result }}" != "success" ] || \
+             [ "${{ needs.devices-table-check.result }}" != "success" ]; then
             echo ""
             echo "One or more jobs failed."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,12 @@ jobs:
       - name: Verify README.md table matches descriptors
         run: python3 scripts/generate-readme-devices.py --check
 
+      - name: Verify Debian package deps match QML imports
+        run: python3 scripts/generate_package_deps.py --check
+
+      - name: Verify package-deps generator tests
+        run: cd scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q
+
   # --------------------------------------------------------------------------
   # Job 3: Debian package
   # --------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
               qml6-module-qtquick qml6-module-qtquick-controls
               qml6-module-qtquick-layouts qml6-module-qtquick-window
               qml6-module-qtquick-templates qml6-module-qtqml-workerscript
-              qml6-module-qtquick-dialogs qml6-module-qt5compat-graphicaleffects
+              qml6-module-qtquick-dialogs
               qt6-qpa-plugins libqt6opengl6-dev libqt6svg6-dev
               libxkbcommon-dev qml6-module-qttest
               libudev-dev libgtest-dev
@@ -163,6 +163,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install pytest
+        run: sudo apt-get update -qq && sudo apt-get install -y python3-pytest
+
       - name: Verify README.md table matches descriptors
         run: python3 scripts/generate-readme-devices.py --check
 
@@ -204,7 +207,7 @@ jobs:
             qml6-module-qtquick qml6-module-qtquick-controls \
             qml6-module-qtquick-layouts qml6-module-qtquick-window \
             qml6-module-qtquick-templates qml6-module-qtqml-workerscript \
-            qml6-module-qtquick-dialogs qml6-module-qt5compat-graphicaleffects \
+            qml6-module-qtquick-dialogs \
             qt6-qpa-plugins libqt6opengl6-dev libqt6svg6-dev \
             libxkbcommon-dev libudev-dev
           # Ensure the cache dir is owned by the runner user before save.

--- a/docs/superpowers/plans/2026-06-13-code-derived-debian-deps.md
+++ b/docs/superpowers/plans/2026-06-13-code-derived-debian-deps.md
@@ -1,0 +1,485 @@
+# Code-derived Debian dependencies — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Derive the Debian `qml6-module-*` dependency list from the QML `import` statements in the code, shared by both Debian packaging definitions, with a `--check` gate in CI and pre-push.
+
+**Architecture:** A single importable Python generator (`scripts/generate_package_deps.py`) scans `src/**/*.qml`, maps each Qt module to its Debian package name algorithmically (plus a tiny implied/base set), and rewrites only the `qml6-module-*` segment of the `Depends:` line in `scripts/package-deb.sh` and `pkg/obs/debian.control`. A `--check` mode (set comparison) fails when either file is stale, wired into `hooks/pre-push` and `.github/workflows/ci.yml` next to the existing README-devices check.
+
+**Tech Stack:** Python 3 (stdlib only: `argparse`, `pathlib`, `re`), pytest (mirrors `tests/scripts/test_extractor.py`), POSIX sh hook, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-code-derived-debian-deps-design.md`
+
+**Note on filename:** the sibling generator is `generate-readme-devices.py` (hyphen), but this script must be importable by pytest, so it uses underscores: `generate_package_deps.py`. The CLI command is `python3 scripts/generate_package_deps.py`.
+
+---
+
+## File Structure
+
+- **Create** `scripts/generate_package_deps.py` — the generator: import scanning, package mapping, depends-line rewrite, `--check`/write CLI. Importable as `generate_package_deps` (pytest runs from `scripts/`, which puts it on `sys.path`).
+- **Create** `tests/scripts/test_package_deps.py` — pytest unit + repo-state tests.
+- **Modify** `scripts/package-deb.sh` — its `Depends:` line is regenerated (gains `qml6-module-qtqml`, drops unused `qml6-module-qt5compat-graphicaleffects`, sorted).
+- **Modify** `pkg/obs/debian.control` — its `Depends:` line is regenerated (gains `qml6-module-qtquick-dialogs`, sorted).
+- **Modify** `hooks/pre-push` — add a `--check`+regenerate block next to the README check.
+- **Modify** `.github/workflows/ci.yml` — add a `--check` step in the "README devices table" job.
+
+---
+
+## Task 1: Generator — import scanning + package mapping
+
+**Files:**
+- Create: `scripts/generate_package_deps.py`
+- Test: `tests/scripts/test_package_deps.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/scripts/test_package_deps.py`:
+
+```python
+"""Tests for scripts/generate_package_deps.py. See spec
+docs/superpowers/specs/2026-06-13-code-derived-debian-deps-design.md.
+Run from the scripts/ dir so the module is importable:
+    (cd scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q)
+"""
+import generate_package_deps as g
+
+
+def test_module_maps_to_debian_package():
+    pkgs = g.debian_packages({"QtQuick.Dialogs"})
+    assert "qml6-module-qtquick-dialogs" in pkgs
+
+
+def test_controls_implies_templates():
+    pkgs = g.debian_packages({"QtQuick.Controls"})
+    assert "qml6-module-qtquick-templates" in pkgs
+
+
+def test_base_qml_modules_always_present():
+    pkgs = g.debian_packages({"QtQuick"})
+    assert {"qml6-module-qtqml", "qml6-module-qtqml-workerscript"} <= pkgs
+
+
+def test_qml_imports_excludes_app_and_relative(tmp_path):
+    src = tmp_path / "qml"
+    src.mkdir()
+    (src / "A.qml").write_text(
+        'import QtQuick\n'
+        'import QtQuick.Dialogs\n'
+        'import Logitune\n'
+        'import "components"\n', encoding="utf-8")
+    assert g.qml_imports(src) == {"QtQuick", "QtQuick.Dialogs"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/mina/repos/logitune-wt-pkg-deps/scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'generate_package_deps'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `scripts/generate_package_deps.py`:
+
+```python
+#!/usr/bin/env python3
+"""Generate the qml6-module-* dependency list for the Debian packages from
+the QML imports in src/**/*.qml, keeping scripts/package-deb.sh and
+pkg/obs/debian.control in sync with the code.
+
+Usage:
+    scripts/generate_package_deps.py            # rewrite both files in place
+    scripts/generate_package_deps.py --check    # exit 1 if either is stale
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+SRC_DIR = REPO / "src"
+
+# Files whose `Depends:` line qml6-module-* segment this script owns.
+TARGETS = [
+    REPO / "scripts" / "package-deb.sh",
+    REPO / "pkg" / "obs" / "debian.control",
+]
+
+# Runtime QML modules not written as explicit imports but needed at load
+# time: qtqml is the base QML engine, workerscript backs WorkerScript, and
+# qtquick-controls is built on qtquick-templates.
+ALWAYS = {"qml6-module-qtqml", "qml6-module-qtqml-workerscript"}
+IMPLIES = {"qml6-module-qtquick-controls": "qml6-module-qtquick-templates"}
+
+# Matches `import QtQuick`, `import QtQuick.Dialogs`, etc. Quoted/relative
+# imports and the app's own `Logitune` module do not start with `Qt`.
+IMPORT_RE = re.compile(r"^\s*import\s+(Qt[A-Za-z0-9.]*)")
+DEPENDS_RE = re.compile(r"^Depends:\s*(.*)$")
+
+
+def qml_imports(src_dir: pathlib.Path) -> set[str]:
+    """Qt QML module paths imported by any .qml file under src_dir."""
+    modules: set[str] = set()
+    for qml in src_dir.rglob("*.qml"):
+        for line in qml.read_text(encoding="utf-8").splitlines():
+            m = IMPORT_RE.match(line)
+            if m:
+                modules.add(m.group(1))
+    return modules
+
+
+def debian_packages(modules: set[str]) -> set[str]:
+    """Map Qt module paths to Debian package names, plus implied/base modules."""
+    pkgs = {"qml6-module-" + m.lower().replace(".", "-") for m in modules}
+    pkgs |= ALWAYS
+    for trigger, implied in IMPLIES.items():
+        if trigger in pkgs:
+            pkgs.add(implied)
+    return pkgs
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/mina/repos/logitune-wt-pkg-deps/scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/mina/repos/logitune-wt-pkg-deps
+git add scripts/generate_package_deps.py tests/scripts/test_package_deps.py
+git commit -m "feat(pkg-deps): scan QML imports and map to Debian packages"
+```
+
+---
+
+## Task 2: Depends-line rewrite + token extraction
+
+**Files:**
+- Modify: `scripts/generate_package_deps.py` (append functions)
+- Test: `tests/scripts/test_package_deps.py` (append tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/scripts/test_package_deps.py`:
+
+```python
+def test_qml_tokens_extracts_only_qml():
+    value = "libqt6core6 (>= 6.4), qml6-module-qtquick, libudev1, qml6-module-qtqml"
+    assert g.qml_tokens(value) == {"qml6-module-qtquick", "qml6-module-qtqml"}
+
+
+def test_rewrite_keeps_non_qml_in_order_then_sorted_qml():
+    value = "libqt6core6 (>= 6.4), qml6-module-qtquick, libudev1, qml6-module-qtqml"
+    out = g.rewrite_depends_value(value, {"qml6-module-qtqml", "qml6-module-qtquick"})
+    assert out == ("libqt6core6 (>= 6.4), libudev1, "
+                   "qml6-module-qtqml, qml6-module-qtquick")
+
+
+def test_rewrite_preserves_dpkg_substvars():
+    value = "${shlibs:Depends}, ${misc:Depends}, libudev1, qml6-module-qtquick"
+    out = g.rewrite_depends_value(value, {"qml6-module-qtquick", "qml6-module-qtqml"})
+    assert out.startswith("${shlibs:Depends}, ${misc:Depends}, libudev1, ")
+    assert out.endswith("qml6-module-qtqml, qml6-module-qtquick")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/mina/repos/logitune-wt-pkg-deps/scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q`
+Expected: FAIL — `AttributeError: module 'generate_package_deps' has no attribute 'qml_tokens'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/generate_package_deps.py` (after `debian_packages`):
+
+```python
+def qml_tokens(depends_value: str) -> set[str]:
+    """The set of qml6-module-* tokens in a Depends: field value."""
+    return {t.strip() for t in depends_value.split(",")
+            if t.strip().startswith("qml6-module-")}
+
+
+def rewrite_depends_value(depends_value: str, packages: set[str]) -> str:
+    """Keep every non-qml token in its original order, then append the
+    qml packages sorted. Reproduces the existing libs-then-modules layout."""
+    non_qml = [t.strip() for t in depends_value.split(",")
+               if t.strip() and not t.strip().startswith("qml6-module-")]
+    return ", ".join(non_qml + sorted(packages))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/mina/repos/logitune-wt-pkg-deps/scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q`
+Expected: PASS (7 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/mina/repos/logitune-wt-pkg-deps
+git add scripts/generate_package_deps.py tests/scripts/test_package_deps.py
+git commit -m "feat(pkg-deps): rewrite the Depends qml segment, preserve the rest"
+```
+
+---
+
+## Task 3: File processing + CLI (`--check` / write)
+
+**Files:**
+- Modify: `scripts/generate_package_deps.py` (append `process_file`, `main`)
+- Test: `tests/scripts/test_package_deps.py` (append tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/scripts/test_package_deps.py`:
+
+```python
+def test_process_file_check_detects_stale_then_synced(tmp_path):
+    f = tmp_path / "debian.control"
+    f.write_text(
+        "Package: logitune\n"
+        "Depends: ${misc:Depends}, libudev1, qml6-module-qtquick\n"
+        "Description: x\n", encoding="utf-8")
+    want = {"qml6-module-qtquick", "qml6-module-qtqml"}
+
+    # check mode: stale -> returns False, file unchanged
+    assert g.process_file(f, want, check=True) is False
+    assert "qml6-module-qtqml" not in f.read_text()
+
+    # write mode: applies, file now contains both, sorted after non-qml
+    assert g.process_file(f, want, check=False) is False
+    text = f.read_text()
+    assert ("Depends: ${misc:Depends}, libudev1, "
+            "qml6-module-qtqml, qml6-module-qtquick\n") in text
+
+    # check mode again: now in sync
+    assert g.process_file(f, want, check=True) is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/mina/repos/logitune-wt-pkg-deps/scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q`
+Expected: FAIL — `AttributeError: module 'generate_package_deps' has no attribute 'process_file'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/generate_package_deps.py` (after `rewrite_depends_value`):
+
+```python
+def process_file(path: pathlib.Path, packages: set[str], check: bool) -> bool:
+    """Rewrite (or, in check mode, validate) the qml6-module-* segment of the
+    `Depends:` line. Returns True if the file is already in sync."""
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    out: list[str] = []
+    found = False
+    in_sync = True
+    for line in lines:
+        m = DEPENDS_RE.match(line.rstrip("\n"))
+        if m:
+            found = True
+            if qml_tokens(m.group(1)) != packages:
+                in_sync = False
+            newline = "Depends: " + rewrite_depends_value(m.group(1), packages)
+            out.append(newline + ("\n" if line.endswith("\n") else ""))
+        else:
+            out.append(line)
+    if not found:
+        sys.stderr.write(f"error: no 'Depends:' line in {path}\n")
+        sys.exit(2)
+    if not check and not in_sync:
+        path.write_text("".join(out), encoding="utf-8")
+    return in_sync
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true",
+                    help="Exit 1 if any packaging file is stale; do not modify.")
+    args = ap.parse_args()
+
+    packages = debian_packages(qml_imports(SRC_DIR))
+    if not packages:
+        sys.stderr.write("error: no QML imports found under src/\n")
+        return 2
+
+    stale = [p for p in TARGETS if not process_file(p, packages, args.check)]
+
+    if args.check:
+        if stale:
+            sys.stderr.write(
+                "Debian package deps are out of sync with QML imports:\n"
+                + "".join(f"  {p}\n" for p in stale)
+                + "Expected qml6-module-* set:\n  "
+                + ", ".join(sorted(packages)) + "\n"
+                + "Run: python3 scripts/generate_package_deps.py\n")
+            return 1
+        print("Debian package deps in sync.")
+        return 0
+
+    for p in stale:
+        print(f"Updated {p}")
+    if not stale:
+        print("Debian package deps already up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/mina/repos/logitune-wt-pkg-deps/scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q`
+Expected: PASS (8 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/mina/repos/logitune-wt-pkg-deps
+git add scripts/generate_package_deps.py tests/scripts/test_package_deps.py
+git commit -m "feat(pkg-deps): process_file + --check/write CLI"
+```
+
+---
+
+## Task 4: Regenerate the packaging files + repo-state guard test
+
+**Files:**
+- Modify: `scripts/package-deb.sh` (regenerated `Depends:` line)
+- Modify: `pkg/obs/debian.control` (regenerated `Depends:` line)
+- Test: `tests/scripts/test_package_deps.py` (append guard test)
+
+- [ ] **Step 1: Run the generator to update both files**
+
+Run: `cd /home/mina/repos/logitune-wt-pkg-deps && python3 scripts/generate_package_deps.py`
+Expected output (both updated, or one if PR #137 already merged dialogs into control):
+```
+Updated /home/mina/repos/logitune-wt-pkg-deps/scripts/package-deb.sh
+Updated /home/mina/repos/logitune-wt-pkg-deps/pkg/obs/debian.control
+```
+
+- [ ] **Step 2: Verify the diff is exactly the qml segment**
+
+Run: `cd /home/mina/repos/logitune-wt-pkg-deps && git diff scripts/package-deb.sh pkg/obs/debian.control`
+Expected: only the `Depends:` lines change. `package-deb.sh` gains `qml6-module-qtqml`, drops `qml6-module-qt5compat-graphicaleffects`, qml tokens sorted. `pkg/obs/debian.control` gains `qml6-module-qtquick-dialogs`, qml tokens sorted. Both qml segments are now identical:
+`qml6-module-qtqml, qml6-module-qtqml-workerscript, qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-dialogs, qml6-module-qtquick-layouts, qml6-module-qtquick-templates, qml6-module-qtquick-window`
+
+- [ ] **Step 3: Write the guard test (real committed files stay in sync)**
+
+Append to `tests/scripts/test_package_deps.py`:
+
+```python
+def test_real_packaging_files_in_sync():
+    """The committed package-deb.sh and debian.control must match the
+    QML imports — this is what the CI/pre-push --check enforces."""
+    packages = g.debian_packages(g.qml_imports(g.SRC_DIR))
+    for path in g.TARGETS:
+        assert g.process_file(path, packages, check=True) is True, (
+            f"{path} out of sync; run python3 scripts/generate_package_deps.py")
+```
+
+- [ ] **Step 4: Run the full test file to verify it passes**
+
+Run: `cd /home/mina/repos/logitune-wt-pkg-deps/scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q`
+Expected: PASS (9 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/mina/repos/logitune-wt-pkg-deps
+git add scripts/package-deb.sh pkg/obs/debian.control tests/scripts/test_package_deps.py
+git commit -m "packaging: regenerate Debian deps from QML imports
+
+Adds qml6-module-qtquick-dialogs to the OBS control, drops the unused
+qt5compat-graphicaleffects from package-deb.sh, and normalizes both qml
+segments to the generated set."
+```
+
+---
+
+## Task 5: Wire `--check` into pre-push and CI
+
+**Files:**
+- Modify: `hooks/pre-push` (add block after line 18, the README check)
+- Modify: `.github/workflows/ci.yml` (add step after line 167, the README check)
+
+- [ ] **Step 1: Add the pre-push check block**
+
+In `hooks/pre-push`, immediately after the README check block (after the closing `fi` on line 18, before the blank line and `echo "🔍 Running tests before push..."`), insert:
+
+```sh
+
+# Debian package deps must match the QML imports in src/. Regenerate on
+# drift so the developer just has to `git add` and retry.
+echo "📦 Checking Debian package deps..."
+if ! python3 "${REPO_ROOT}/scripts/generate_package_deps.py" --check > /dev/null 2>&1; then
+    echo "⚠️  Debian package deps are out of sync with src/**/*.qml imports."
+    python3 "${REPO_ROOT}/scripts/generate_package_deps.py" > /dev/null
+    echo "   Regenerated package-deb.sh + debian.control. Review the diff, then:"
+    echo "     git add scripts/package-deb.sh pkg/obs/debian.control && git commit --amend --no-edit"
+    echo "   or make a fresh commit and re-push."
+    exit 1
+fi
+```
+
+- [ ] **Step 2: Add a pytest block for the new tests in pre-push**
+
+In `hooks/pre-push`, after the existing "Extractor Python tests" block (after its closing `fi` on line 61, before `echo "✅ All tests passed. Pushing..."`), insert:
+
+```sh
+# Package-deps Python tests
+(cd scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q > /dev/null 2>&1)
+if [ $? -ne 0 ]; then
+    echo "❌ Package-deps pytest failed. Push aborted."
+    (cd scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q 2>&1 | tail -20)
+    exit 1
+fi
+```
+
+- [ ] **Step 3: Add the CI step**
+
+In `.github/workflows/ci.yml`, in the "README devices table" job, after the existing step (lines 166-167):
+
+```yaml
+      - name: Verify README.md table matches descriptors
+        run: python3 scripts/generate-readme-devices.py --check
+```
+
+add immediately below it:
+
+```yaml
+      - name: Verify Debian package deps match QML imports
+        run: python3 scripts/generate_package_deps.py --check
+      - name: Verify package-deps generator tests
+        run: cd scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q
+```
+
+- [ ] **Step 4: Verify the check passes locally (files already regenerated in Task 4)**
+
+Run: `cd /home/mina/repos/logitune-wt-pkg-deps && python3 scripts/generate_package_deps.py --check`
+Expected: `Debian package deps in sync.` (exit 0)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/mina/repos/logitune-wt-pkg-deps
+git add hooks/pre-push .github/workflows/ci.yml
+git commit -m "ci(pkg-deps): --check Debian deps in pre-push and CI"
+```
+
+---
+
+## Final verification (before PR)
+
+- [ ] Configure + build so the pre-push gate can run (worktree has no `build/` yet):
+  `cd /home/mina/repos/logitune-wt-pkg-deps && cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -Wno-dev && cmake --build build -j$(nproc)`
+- [ ] Run the new tests: `cd scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q` → 9 passed
+- [ ] Run `--check`: `python3 scripts/generate_package_deps.py --check` → in sync, exit 0
+- [ ] Push (pre-push gate runs full suite) and open a PR to `master`.
+
+---
+
+## Self-review (done during authoring)
+
+- **Spec coverage:** generator from QML imports (Tasks 1-3) ✓; both Debian files consume the same set (Task 4) ✓; `--check` in CI + pre-push (Task 5) ✓; drops unused graphicaleffects (Task 4 Step 2) ✓; Arch/Fedora untouched (no task touches them) ✓; set-based check (`process_file` compares `qml_tokens(...) != packages` as sets) ✓.
+- **Placeholders:** none — every step has full code/commands and expected output.
+- **Type consistency:** `qml_imports(Path)->set[str]`, `debian_packages(set)->set[str]`, `qml_tokens(str)->set[str]`, `rewrite_depends_value(str,set)->str`, `process_file(Path,set,bool)->bool` used consistently across Tasks 1-5; constants `SRC_DIR`, `TARGETS`, `ALWAYS`, `IMPLIES`, `DEPENDS_RE` defined in Task 1 and referenced later.

--- a/docs/superpowers/specs/2026-06-13-code-derived-debian-deps-design.md
+++ b/docs/superpowers/specs/2026-06-13-code-derived-debian-deps-design.md
@@ -1,0 +1,126 @@
+# Code-derived Debian package dependencies
+
+## Problem
+
+Logitune ships through several packaging paths. The runtime dependency on
+QML modules is declared by hand in **two** Debian definitions:
+
+- `scripts/package-deb.sh` — the GitHub `.deb`
+- `pkg/obs/debian.control` — the OBS-built `.deb` (what Ubuntu users `apt install`)
+
+QML modules are loaded by the Qt engine at runtime, not linked as shared
+objects, so `dpkg-shlibdeps` cannot auto-detect them. The two hand-maintained
+lists drifted from each other and from the code: `pkg/obs/debian.control` was
+missing `qml6-module-qtquick-dialogs`, which `DeviceRender.qml` imports. A clean
+Ubuntu 24.04 install therefore started, talked to the device, and showed no
+window (`QML failed to load — no root objects`).
+
+This is Debian-specific. **Arch** (`qt6-declarative`) and **Fedora**
+(`qt6-qtdeclarative` + rpm automatic dependency generation) bundle all QML
+modules into one package, so they cannot drift on a missing QML module.
+
+## Goals
+
+- The Debian `qml6-module-*` dependency list is **derived from the code** (the
+  `import` statements in `src/**/*.qml`), so it cannot drift from what the app
+  actually loads.
+- Both Debian definitions consume the **same generated list**, so they cannot
+  disagree with each other.
+- Drift is caught automatically in CI and pre-push, matching the existing
+  `generate-readme-devices.py` / `--check` pattern.
+
+## Non-goals (YAGNI)
+
+- Arch and Fedora declarations. They bundle QML modules and Fedora auto-generates
+  requires; there is nothing to drift. Left untouched.
+- The non-QML library dependencies (`libqt6core6`, `libqt6svg6`, `libudev1`, …).
+  These are stable and, on the OBS `.deb`, already covered by `${shlibs:Depends}`.
+  The generator does **not** manage them.
+
+## Design
+
+### New tool: `scripts/generate-package-deps.py`
+
+Mirrors `scripts/generate-readme-devices.py`: it can **write** the dependency
+segment into the packaging files, and run with **`--check`** to fail (non-zero,
+printing the expected list) when a file is stale.
+
+**Computing the `qml6-module-*` set:**
+
+1. Scan `src/**/*.qml` for `import <Module.Path>` statements. Ignore version
+   suffixes, relative/string imports (`import "..."`), and the app's own module
+   `Logitune`.
+2. Map each remaining module to its Debian package **algorithmically**:
+   `qml6-module-` + `module.lower().replace('.', '-')`.
+   - `QtQuick` → `qml6-module-qtquick`
+   - `QtQuick.Controls` → `qml6-module-qtquick-controls`
+   - `QtQuick.Dialogs` → `qml6-module-qtquick-dialogs`
+   - `QtQuick.Layouts` → `qml6-module-qtquick-layouts`
+   - `QtQuick.Window` → `qml6-module-qtquick-window`
+
+   A new `import` automatically pulls its package — no table to maintain.
+3. Add a small, documented **implied set** for runtime modules that are not
+   written as explicit imports:
+   - `qml6-module-qtquick-controls` present ⇒ also `qml6-module-qtquick-templates`
+     (Controls is built on Templates).
+   - Always: `qml6-module-qtqml`, `qml6-module-qtqml-workerscript` (base QML
+     engine underpinning any QtQuick app).
+   This set lives as a commented constant in the script (~3 entries).
+4. Sort and de-duplicate. This sorted list is the canonical segment.
+
+**Writing / checking the files (token replacement, no moved boilerplate):**
+
+The generator operates on each file's existing `Depends:` line. It preserves
+every non-`qml6-module-*` token verbatim (the `${shlibs:Depends}, ${misc:Depends}`
+prefix in `debian.control`, the `libqt6*`/`libudev1` libs in both) and replaces
+only the `qml6-module-*` tokens with the generated set, inserted at the position
+of the first existing `qml6-module-*` token. The library declarations stay in the
+packaging files where they belong; the script owns only the QML segment.
+
+- Write mode: rewrites the `Depends:` line in both files.
+- `--check` mode: extracts the `qml6-module-*` tokens from each file and compares
+  them to the generated set as a **set** (order-insensitive, so a harmless manual
+  reorder does not fail); on a missing/extra package it prints the expected
+  segment and exits 1. Write mode emits the tokens **sorted** for a deterministic
+  committed diff.
+
+### Integration
+
+- `hooks/pre-push`: add `generate-package-deps.py --check` next to the existing
+  README-devices check.
+- `.github/workflows/ci.yml`: same `--check` step.
+- Regenerate command: `python3 scripts/generate-package-deps.py`.
+
+### Tests
+
+`tests/scripts/test_package_deps.py` (pytest, alongside the existing
+`test_extractor.py`):
+
+- Mapping is algorithmic: `QtQuick.Dialogs` → `qml6-module-qtquick-dialogs`.
+- Implied set applied: a fixture importing `QtQuick.Controls` yields
+  `qml6-module-qtquick-templates`; base `qtqml`/`qtqml-workerscript` always present.
+- Exclusions: `import Logitune` and `import "..."` are ignored.
+- `--check` returns 0 on a synced file and non-zero on a stale one.
+- An end-to-end check that the real `package-deb.sh` and `debian.control` are in
+  sync after generation (guards the committed state).
+
+## Behavior change to note
+
+The shipped code does not `import Qt5Compat.GraphicalEffects`, so the generator
+**drops** the stray `qml6-module-qt5compat-graphicaleffects` currently
+over-declared in `scripts/package-deb.sh`. Correct (unused dependency), but a real
+diff.
+
+## Relationship to PR #137
+
+PR #137 is the immediate one-line fix adding `qml6-module-qtquick-dialogs` to
+`pkg/obs/debian.control`. This generator is the systemic prevention. If #137
+lands first, the generator validates it (same output). If this lands, it
+supersedes #137. Either order is fine.
+
+## Rollout
+
+No version/runtime behavior change in the app. The corrected Debian dependencies
+reach Ubuntu users when the OBS spec syncs and rebuilds (next release tag, or a
+manual `trigger_obs` dispatch). Existing `0.3.5-0` installs are unblocked with
+`sudo apt install qml6-module-qtquick-dialogs`.

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -17,6 +17,18 @@ if ! python3 "${REPO_ROOT}/scripts/generate-readme-devices.py" --check > /dev/nu
     exit 1
 fi
 
+# Debian package deps must match the QML imports in src/. Regenerate on
+# drift so the developer just has to `git add` and retry.
+echo "📦 Checking Debian package deps..."
+if ! python3 "${REPO_ROOT}/scripts/generate_package_deps.py" --check > /dev/null 2>&1; then
+    echo "⚠️  Debian package deps are out of sync with src/**/*.qml imports."
+    python3 "${REPO_ROOT}/scripts/generate_package_deps.py" > /dev/null
+    echo "   Regenerated package-deb.sh + debian.control. Review the diff, then:"
+    echo "     git add scripts/package-deb.sh pkg/obs/debian.control && git commit --amend --no-edit"
+    echo "   or make a fresh commit and re-push."
+    exit 1
+fi
+
 echo "🔍 Running tests before push..."
 
 # Set XDG_DATA_DIRS so DeviceRegistry finds JSON descriptors in the build tree
@@ -57,6 +69,14 @@ fi
 if [ $? -ne 0 ]; then
     echo "❌ Extractor pytest failed. Push aborted."
     (cd scripts && python3 -m pytest ../tests/scripts/test_extractor.py -q 2>&1 | tail -20)
+    exit 1
+fi
+
+# Package-deps Python tests
+(cd scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q > /dev/null 2>&1)
+if [ $? -ne 0 ]; then
+    echo "❌ Package-deps pytest failed. Push aborted."
+    (cd scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q 2>&1 | tail -20)
     exit 1
 fi
 

--- a/pkg/obs/debian.control
+++ b/pkg/obs/debian.control
@@ -8,7 +8,7 @@ Homepage: https://github.com/mmaher88/logitune
 
 Package: logitune
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libqt6core6 (>= 6.4), libqt6quick6, libqt6svg6, libqt6dbus6, libqt6widgets6, libudev1, qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-dialogs, qml6-module-qtquick-window, qml6-module-qtquick-templates, qml6-module-qtquick-layouts, qml6-module-qtqml, qml6-module-qtqml-workerscript
+Depends: ${shlibs:Depends}, ${misc:Depends}, libqt6core6 (>= 6.4), libqt6quick6, libqt6svg6, libqt6dbus6, libqt6widgets6, libudev1, qml6-module-qtqml, qml6-module-qtqml-workerscript, qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-dialogs, qml6-module-qtquick-layouts, qml6-module-qtquick-templates, qml6-module-qtquick-window
 Suggests: gnome-shell
 Description: Logitech device configurator for Linux
  Logitune is a Logitech Options+ alternative for Linux. Configure HID++

--- a/scripts/generate_package_deps.py
+++ b/scripts/generate_package_deps.py
@@ -57,9 +57,18 @@ def debian_packages(modules: set[str]) -> set[str]:
 
 
 def qml_tokens(depends_value: str) -> set[str]:
-    """The set of qml6-module-* tokens in a Depends: field value."""
-    return {t.strip() for t in depends_value.split(",")
-            if t.strip().startswith("qml6-module-")}
+    """The set of qml6-module-* package names in a Depends: field value,
+    with any version-constraint suffix removed
+    (e.g. 'qml6-module-x (>= 6.4)' -> 'qml6-module-x')."""
+    names: set[str] = set()
+    for raw in depends_value.split(","):
+        token = raw.strip()
+        if not token:
+            continue
+        name = token.split()[0]
+        if name.startswith("qml6-module-"):
+            names.add(name)
+    return names
 
 
 def rewrite_depends_value(depends_value: str, packages: set[str]) -> str:

--- a/scripts/generate_package_deps.py
+++ b/scripts/generate_package_deps.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Generate the qml6-module-* dependency list for the Debian packages from
+the QML imports in src/**/*.qml, keeping scripts/package-deb.sh and
+pkg/obs/debian.control in sync with the code.
+
+Usage:
+    scripts/generate_package_deps.py            # rewrite both files in place
+    scripts/generate_package_deps.py --check    # exit 1 if either is stale
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+SRC_DIR = REPO / "src"
+
+# Files whose `Depends:` line qml6-module-* segment this script owns.
+TARGETS = [
+    REPO / "scripts" / "package-deb.sh",
+    REPO / "pkg" / "obs" / "debian.control",
+]
+
+# Runtime QML modules not written as explicit imports but needed at load
+# time: qtqml is the base QML engine, workerscript backs WorkerScript, and
+# qtquick-controls is built on qtquick-templates.
+ALWAYS = {"qml6-module-qtqml", "qml6-module-qtqml-workerscript"}
+IMPLIES = {"qml6-module-qtquick-controls": "qml6-module-qtquick-templates"}
+
+# Matches `import QtQuick`, `import QtQuick.Dialogs`, etc. Quoted/relative
+# imports and the app's own `Logitune` module do not start with `Qt`.
+IMPORT_RE = re.compile(r"^\s*import\s+(Qt[A-Za-z0-9.]*)")
+DEPENDS_RE = re.compile(r"^Depends:\s*(.*)$")
+
+
+def qml_imports(src_dir: pathlib.Path) -> set[str]:
+    """Qt QML module paths imported by any .qml file under src_dir."""
+    modules: set[str] = set()
+    for qml in src_dir.rglob("*.qml"):
+        for line in qml.read_text(encoding="utf-8").splitlines():
+            m = IMPORT_RE.match(line)
+            if m:
+                modules.add(m.group(1))
+    return modules
+
+
+def debian_packages(modules: set[str]) -> set[str]:
+    """Map Qt module paths to Debian package names, plus implied/base modules."""
+    pkgs = {"qml6-module-" + m.lower().replace(".", "-") for m in modules}
+    pkgs |= ALWAYS
+    for trigger, implied in IMPLIES.items():
+        if trigger in pkgs:
+            pkgs.add(implied)
+    return pkgs

--- a/scripts/generate_package_deps.py
+++ b/scripts/generate_package_deps.py
@@ -77,3 +77,64 @@ def rewrite_depends_value(depends_value: str, packages: set[str]) -> str:
     non_qml = [t.strip() for t in depends_value.split(",")
                if t.strip() and not t.strip().startswith("qml6-module-")]
     return ", ".join(non_qml + sorted(packages))
+
+
+def process_file(path: pathlib.Path, packages: set[str], check: bool) -> bool:
+    """Rewrite (or, in check mode, validate) the qml6-module-* segment of the
+    `Depends:` line. Returns True if the file is already in sync."""
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    out: list[str] = []
+    found = False
+    in_sync = True
+    for line in lines:
+        m = DEPENDS_RE.match(line.rstrip("\n"))
+        if m:
+            found = True
+            if qml_tokens(m.group(1)) != packages:
+                in_sync = False
+            newline = "Depends: " + rewrite_depends_value(m.group(1), packages)
+            out.append(newline + ("\n" if line.endswith("\n") else ""))
+        else:
+            out.append(line)
+    if not found:
+        sys.stderr.write(f"error: no 'Depends:' line in {path}\n")
+        sys.exit(2)
+    if not check and not in_sync:
+        path.write_text("".join(out), encoding="utf-8")
+    return in_sync
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true",
+                    help="Exit 1 if any packaging file is stale; do not modify.")
+    args = ap.parse_args()
+
+    packages = debian_packages(qml_imports(SRC_DIR))
+    if not packages:
+        sys.stderr.write("error: no QML imports found under src/\n")
+        return 2
+
+    stale = [p for p in TARGETS if not process_file(p, packages, args.check)]
+
+    if args.check:
+        if stale:
+            sys.stderr.write(
+                "Debian package deps are out of sync with QML imports:\n"
+                + "".join(f"  {p}\n" for p in stale)
+                + "Expected qml6-module-* set:\n  "
+                + ", ".join(sorted(packages)) + "\n"
+                + "Run: python3 scripts/generate_package_deps.py\n")
+            return 1
+        print("Debian package deps in sync.")
+        return 0
+
+    for p in stale:
+        print(f"Updated {p}")
+    if not stale:
+        print("Debian package deps already up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_package_deps.py
+++ b/scripts/generate_package_deps.py
@@ -110,10 +110,11 @@ def main() -> int:
                     help="Exit 1 if any packaging file is stale; do not modify.")
     args = ap.parse_args()
 
-    packages = debian_packages(qml_imports(SRC_DIR))
-    if not packages:
+    modules = qml_imports(SRC_DIR)
+    if not modules:
         sys.stderr.write("error: no QML imports found under src/\n")
         return 2
+    packages = debian_packages(modules)
 
     stale = [p for p in TARGETS if not process_file(p, packages, args.check)]
 

--- a/scripts/generate_package_deps.py
+++ b/scripts/generate_package_deps.py
@@ -54,3 +54,17 @@ def debian_packages(modules: set[str]) -> set[str]:
         if trigger in pkgs:
             pkgs.add(implied)
     return pkgs
+
+
+def qml_tokens(depends_value: str) -> set[str]:
+    """The set of qml6-module-* tokens in a Depends: field value."""
+    return {t.strip() for t in depends_value.split(",")
+            if t.strip().startswith("qml6-module-")}
+
+
+def rewrite_depends_value(depends_value: str, packages: set[str]) -> str:
+    """Keep every non-qml token in its original order, then append the
+    qml packages sorted. Reproduces the existing libs-then-modules layout."""
+    non_qml = [t.strip() for t in depends_value.split(",")
+               if t.strip() and not t.strip().startswith("qml6-module-")]
+    return ", ".join(non_qml + sorted(packages))

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -34,7 +34,7 @@ Version: $VERSION
 Section: utils
 Priority: optional
 Architecture: $ARCH
-Depends: libqt6core6 (>= 6.4), libqt6qml6, libqt6quick6, libqt6svg6, libqt6dbus6, libqt6widgets6, libudev1, qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-dialogs, qml6-module-qtquick-window, qml6-module-qtquick-templates, qml6-module-qtquick-layouts, qml6-module-qtqml-workerscript, qml6-module-qt5compat-graphicaleffects
+Depends: libqt6core6 (>= 6.4), libqt6qml6, libqt6quick6, libqt6svg6, libqt6dbus6, libqt6widgets6, libudev1, qml6-module-qtqml, qml6-module-qtqml-workerscript, qml6-module-qtquick, qml6-module-qtquick-controls, qml6-module-qtquick-dialogs, qml6-module-qtquick-layouts, qml6-module-qtquick-templates, qml6-module-qtquick-window
 Recommends: gnome-shell-extension-appindicator
 Maintainer: Mina Maher <mina.maher88@hotmail.com>
 Description: Logitech device configurator for Linux

--- a/tests/scripts/test_package_deps.py
+++ b/tests/scripts/test_package_deps.py
@@ -3,6 +3,7 @@ docs/superpowers/specs/2026-06-13-code-derived-debian-deps-design.md.
 Run from the scripts/ dir so the module is importable:
     (cd scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q)
 """
+import pytest
 import generate_package_deps as g
 
 
@@ -76,3 +77,17 @@ def test_process_file_check_detects_stale_then_synced(tmp_path):
 
     # check mode again: now in sync
     assert g.process_file(f, want, check=True) is True
+
+
+def test_process_file_errors_without_depends_line(tmp_path):
+    f = tmp_path / "control"
+    f.write_text("Package: x\nDescription: y\n", encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        g.process_file(f, {"qml6-module-qtquick"}, check=True)
+    assert exc.value.code == 2
+
+
+def test_main_returns_2_when_no_qml_imports(tmp_path, monkeypatch):
+    monkeypatch.setattr(g, "SRC_DIR", tmp_path)  # empty dir -> no imports
+    monkeypatch.setattr("sys.argv", ["generate_package_deps.py", "--check"])
+    assert g.main() == 2

--- a/tests/scripts/test_package_deps.py
+++ b/tests/scripts/test_package_deps.py
@@ -54,3 +54,25 @@ def test_rewrite_preserves_dpkg_substvars():
 def test_qml_tokens_strips_version_constraint():
     value = "qml6-module-qtquick (>= 6.4), libudev1, qml6-module-qtqml"
     assert g.qml_tokens(value) == {"qml6-module-qtquick", "qml6-module-qtqml"}
+
+
+def test_process_file_check_detects_stale_then_synced(tmp_path):
+    f = tmp_path / "debian.control"
+    f.write_text(
+        "Package: logitune\n"
+        "Depends: ${misc:Depends}, libudev1, qml6-module-qtquick\n"
+        "Description: x\n", encoding="utf-8")
+    want = {"qml6-module-qtquick", "qml6-module-qtqml"}
+
+    # check mode: stale -> returns False, file unchanged
+    assert g.process_file(f, want, check=True) is False
+    assert "qml6-module-qtqml" not in f.read_text()
+
+    # write mode: applies, file now contains both, sorted after non-qml
+    assert g.process_file(f, want, check=False) is False
+    text = f.read_text()
+    assert ("Depends: ${misc:Depends}, libudev1, "
+            "qml6-module-qtqml, qml6-module-qtquick\n") in text
+
+    # check mode again: now in sync
+    assert g.process_file(f, want, check=True) is True

--- a/tests/scripts/test_package_deps.py
+++ b/tests/scripts/test_package_deps.py
@@ -49,3 +49,8 @@ def test_rewrite_preserves_dpkg_substvars():
     out = g.rewrite_depends_value(value, {"qml6-module-qtquick", "qml6-module-qtqml"})
     assert out.startswith("${shlibs:Depends}, ${misc:Depends}, libudev1, ")
     assert out.endswith("qml6-module-qtqml, qml6-module-qtquick")
+
+
+def test_qml_tokens_strips_version_constraint():
+    value = "qml6-module-qtquick (>= 6.4), libudev1, qml6-module-qtqml"
+    assert g.qml_tokens(value) == {"qml6-module-qtquick", "qml6-module-qtqml"}

--- a/tests/scripts/test_package_deps.py
+++ b/tests/scripts/test_package_deps.py
@@ -91,3 +91,12 @@ def test_main_returns_2_when_no_qml_imports(tmp_path, monkeypatch):
     monkeypatch.setattr(g, "SRC_DIR", tmp_path)  # empty dir -> no imports
     monkeypatch.setattr("sys.argv", ["generate_package_deps.py", "--check"])
     assert g.main() == 2
+
+
+def test_real_packaging_files_in_sync():
+    """The committed package-deb.sh and debian.control must match the
+    QML imports — this is what the CI/pre-push --check enforces."""
+    packages = g.debian_packages(g.qml_imports(g.SRC_DIR))
+    for path in g.TARGETS:
+        assert g.process_file(path, packages, check=True) is True, (
+            f"{path} out of sync; run python3 scripts/generate_package_deps.py")

--- a/tests/scripts/test_package_deps.py
+++ b/tests/scripts/test_package_deps.py
@@ -1,0 +1,32 @@
+"""Tests for scripts/generate_package_deps.py. See spec
+docs/superpowers/specs/2026-06-13-code-derived-debian-deps-design.md.
+Run from the scripts/ dir so the module is importable:
+    (cd scripts && python3 -m pytest ../tests/scripts/test_package_deps.py -q)
+"""
+import generate_package_deps as g
+
+
+def test_module_maps_to_debian_package():
+    pkgs = g.debian_packages({"QtQuick.Dialogs"})
+    assert "qml6-module-qtquick-dialogs" in pkgs
+
+
+def test_controls_implies_templates():
+    pkgs = g.debian_packages({"QtQuick.Controls"})
+    assert "qml6-module-qtquick-templates" in pkgs
+
+
+def test_base_qml_modules_always_present():
+    pkgs = g.debian_packages({"QtQuick"})
+    assert {"qml6-module-qtqml", "qml6-module-qtqml-workerscript"} <= pkgs
+
+
+def test_qml_imports_excludes_app_and_relative(tmp_path):
+    src = tmp_path / "qml"
+    src.mkdir()
+    (src / "A.qml").write_text(
+        'import QtQuick\n'
+        'import QtQuick.Dialogs\n'
+        'import Logitune\n'
+        'import "components"\n', encoding="utf-8")
+    assert g.qml_imports(src) == {"QtQuick", "QtQuick.Dialogs"}

--- a/tests/scripts/test_package_deps.py
+++ b/tests/scripts/test_package_deps.py
@@ -30,3 +30,22 @@ def test_qml_imports_excludes_app_and_relative(tmp_path):
         'import Logitune\n'
         'import "components"\n', encoding="utf-8")
     assert g.qml_imports(src) == {"QtQuick", "QtQuick.Dialogs"}
+
+
+def test_qml_tokens_extracts_only_qml():
+    value = "libqt6core6 (>= 6.4), qml6-module-qtquick, libudev1, qml6-module-qtqml"
+    assert g.qml_tokens(value) == {"qml6-module-qtquick", "qml6-module-qtqml"}
+
+
+def test_rewrite_keeps_non_qml_in_order_then_sorted_qml():
+    value = "libqt6core6 (>= 6.4), qml6-module-qtquick, libudev1, qml6-module-qtqml"
+    out = g.rewrite_depends_value(value, {"qml6-module-qtqml", "qml6-module-qtquick"})
+    assert out == ("libqt6core6 (>= 6.4), libudev1, "
+                   "qml6-module-qtqml, qml6-module-qtquick")
+
+
+def test_rewrite_preserves_dpkg_substvars():
+    value = "${shlibs:Depends}, ${misc:Depends}, libudev1, qml6-module-qtquick"
+    out = g.rewrite_depends_value(value, {"qml6-module-qtquick", "qml6-module-qtqml"})
+    assert out.startswith("${shlibs:Depends}, ${misc:Depends}, libudev1, ")
+    assert out.endswith("qml6-module-qtqml, qml6-module-qtquick")


### PR DESCRIPTION
## Summary

Stops the packaging-dependency drift that broke v0.3.5 on Ubuntu 24.04 (the OBS `.deb` was missing `qml6-module-qtquick-dialogs`, so the app started but showed no window — `QML failed to load`).

- **`scripts/generate_package_deps.py`** derives the `qml6-module-*` dependency list from the `import` statements in `src/**/*.qml` (algorithmic `QtQuick.Dialogs` → `qml6-module-qtquick-dialogs`, plus a small implied/base set: `templates` for Controls, base `qtqml` + `workerscript`). It owns only the `qml6-module-*` segment of the `Depends:` line in both Debian packaging files, preserving libs and `${shlibs:Depends}`.
- Regenerated **both** Debian definitions so they're identical and code-accurate: `pkg/obs/debian.control` gains `qml6-module-qtquick-dialogs`; `scripts/package-deb.sh` gains `qml6-module-qtqml` and drops the unused `qml6-module-qt5compat-graphicaleffects` (no `Qt5Compat` import exists).
- **`--check`** wired into `hooks/pre-push` and `.github/workflows/ci.yml`, and `devices-table-check` is now part of the `ci-ok` merge gate so the check actually blocks merges. Also removed the stale `qt5compat-graphicaleffects` from the CI apt installs and added a pytest install to the deps-check job.
- Arch/Fedora untouched — they bundle QML modules and can't drift.

Spec: `docs/superpowers/specs/2026-06-13-code-derived-debian-deps-design.md`
Plan: `docs/superpowers/plans/2026-06-13-code-derived-debian-deps.md`

## Test Plan
- [x] 12 generator unit tests (`tests/scripts/test_package_deps.py`), incl. a guard test asserting the real committed files match the code-derived set
- [x] `python3 scripts/generate_package_deps.py --check` → in sync, exit 0
- [x] Full suite green via pre-push gate (731 C++ / 9 tray / 72 QML / 45 script pytests)
- [x] CI: `devices-table-check` (README + deps `--check` + generator pytests) passes and gates the merge

## Known limitation
`process_file` handles single-line `Depends:` fields (current format); a multi-line/continuation Depends would need a parser tweak. Noted in review; not needed today.

## Relationship to #137
#137 was the one-line hotfix adding `qtquick-dialogs` to the OBS control. This PR supersedes it by making the deps code-derived. If #137 already merged, this just normalizes; otherwise this covers it. Close #137 in favor of this once merged.