### PR TITLE
fix(scroll): main wheel dies after KVM round-trip (stuck software-diverted)

### DIFF
--- a/src/core/hidpp/features/HiResWheel.cpp
+++ b/src/core/hidpp/features/HiResWheel.cpp
@@ -20,8 +20,13 @@ bool HiResWheel::parseRatchetSwitch(const Report &r)
 
 std::vector<uint8_t> HiResWheel::buildSetWheelMode(uint8_t currentMode, bool hiRes, bool invert)
 {
-    // Read-modify-write: preserve bit 0 (diversion), set bits 1+2
-    uint8_t newMode = currentMode & 0x01;
+    // Force bit 0 (diversion target) to 0 = hardware/native. logitune never
+    // consumes software-diverted wheel movement, so if the wheel comes back
+    // diverted-to-software (e.g. a KVM round-trip through a host whose driver
+    // left it that way), preserving that bit would silently kill scrolling.
+    // currentMode is intentionally ignored for the target bit.
+    (void)currentMode;
+    uint8_t newMode = 0;
     if (hiRes)  newMode |= 0x02;
     if (invert) newMode |= 0x04;
     return { newMode };

--- a/tests/test_scroll_features.cpp
+++ b/tests/test_scroll_features.cpp
@@ -136,12 +136,16 @@ TEST(HiResWheel, BuildSetInvertOnly)
     EXPECT_EQ(params[0], 0x04);
 }
 
-TEST(HiResWheel, BuildPreservesDiversionBit)
+TEST(HiResWheel, BuildForcesHardwareTarget)
 {
-    // currentMode has diversion bit set (0x01)
+    // Even when the device reports the wheel already diverted to software
+    // (bit 0 set — e.g. left that way by another host's driver over a KVM),
+    // logitune must clear it: it never consumes software-diverted wheel
+    // movement, so the wheel has to stay in hardware/native mode or the OS
+    // gets no scroll events at all.
     auto params = HiResWheel::buildSetWheelMode(0x01, true, false);
     ASSERT_EQ(params.size(), 1u);
-    EXPECT_EQ(params[0], 0x03); // diversion(0x01) + hiRes(0x02)
+    EXPECT_EQ(params[0], 0x02); // hiRes(0x02) only — diversion bit forced off
 }
 
 TEST(HiResWheel, ConstantValues)


### PR DESCRIPTION
## Symptom
After KVM-switching to another machine (macOS) and back to Linux, the **main wheel stops scrolling**. A clean reconnect/reboot fixes it — so it "comes and goes," which is why it's been chased repeatedly.

## Root cause
`HiResWheel::buildSetWheelMode` did a read-modify-write that **preserved bit 0** (the wheel's diversion target) from the device's currently-reported mode:
```cpp
uint8_t newMode = currentMode & 0x01;   // ← kept whatever target the device had
```
logitune has **no code path that injects software-diverted wheel movement** (no `REL_WHEEL` fed from the main wheel), so it must always keep the wheel in **hardware/native** mode. macOS Options+ leaves the wheel **software-diverted** (bit 0 = 1) for its smooth scrolling; on KVM-back, logitune read that mode and re-applied it verbatim via `setScrollConfig`, leaving the wheel diverted to software with nothing consuming its events → dead scroll.

A unit test (`BuildPreservesDiversionBit`) had **enshrined the buggy behavior**, asserting the diversion bit was kept — so the wrong assumption kept surviving.

## Fix
Force bit 0 = 0 (hardware target) on every `setWheelMode`; ignore the incoming target bit. Flip the test to `BuildForcesHardwareTarget`.

## Verification (MX Master 3S, on hardware)
Instrumented the wheel-mode byte and reproduced the KVM round-trip:
```
Scroll: ... raw modeByte=1  divertedToSW=true    ← came back diverted from the Mac
setScrollConfig ... wrote  modeByte=0  divertedToSW=false   ← fix forced hardware
```
Main-wheel scrolling worked again immediately. Full suite green: 731 C++ / 9 tray / 72 QML.

## Scope
One-line behavioral fix + test. `hiRes`/`invert` bits are unchanged (hi-res scrolling still works in hardware mode).