### PR TITLE
fix(profile): button-initiated DPI/SmartShift changes update the UI and persist

### DIFF
--- a/src/app/AppRoot.cpp
+++ b/src/app/AppRoot.cpp
@@ -211,6 +211,14 @@ void AppRoot::wireSignals()
     connect(&m_profileOrchestrator, &ProfileOrchestrator::currentDeviceChanged,
             &m_buttonDispatcher, &ButtonActionDispatcher::onCurrentDeviceChanged);
 
+    // Button-initiated device changes persist into the active profile, so a
+    // DPI cycle or SmartShift toggle survives the next profile apply instead
+    // of snapping back to the stored value.
+    connect(&m_buttonDispatcher, &ButtonActionDispatcher::dpiChangedByButton,
+            &m_profileOrchestrator, &ProfileOrchestrator::onDpiChangedByButton);
+    connect(&m_buttonDispatcher, &ButtonActionDispatcher::smartShiftChangedByButton,
+            &m_profileOrchestrator, &ProfileOrchestrator::onSmartShiftChangedByButton);
+
     // DeviceModel *ChangeRequested -> cache + disk + UI + (if active)
     // hardware. The orchestrator owns the guard logic; AppRoot
     // only supplies the mutator / forwarder pair for each control.

--- a/src/app/services/ButtonActionDispatcher.cpp
+++ b/src/app/services/ButtonActionDispatcher.cpp
@@ -126,8 +126,10 @@ void ButtonActionDispatcher::onDivertedButtonPressed(uint16_t controlId, bool pr
     if (ba.type == ButtonAction::SmartShiftToggle) {
         bool current = session->smartShiftEnabled();
         session->setSmartShift(!current, session->smartShiftThreshold());
+        emit smartShiftChangedByButton(!current, session->smartShiftThreshold());
     } else if (ba.type == ButtonAction::DpiCycle) {
         session->cycleDpi();
+        emit dpiChangedByButton(session->currentDPI());
     } else if ((ba.type == ButtonAction::Keystroke || ba.type == ButtonAction::Media)
                && !ba.payload.isEmpty()) {
         m_actionExecutor->injectKeystroke(ba.payload);

--- a/src/app/services/ButtonActionDispatcher.h
+++ b/src/app/services/ButtonActionDispatcher.h
@@ -36,6 +36,15 @@ public:
     friend class test::AppRootFixture;
     friend class test::ButtonActionDispatcherFixture;
 
+signals:
+    /// Emitted after a diverted button changes a device setting, so the
+    /// orchestrator can persist it into the active profile. Notifying
+    /// explicitly (rather than having the orchestrator listen to
+    /// DeviceSession's change signals) keeps a profile *application* from
+    /// echoing back and rewriting the profile it just applied.
+    void dpiChangedByButton(int dpi);
+    void smartShiftChangedByButton(bool enabled, int threshold);
+
 public slots:
     void onGestureRaw(int16_t dx, int16_t dy);
     void onDivertedButtonPressed(uint16_t controlId, bool pressed);

--- a/src/app/services/ProfileOrchestrator.cpp
+++ b/src/app/services/ProfileOrchestrator.cpp
@@ -174,6 +174,19 @@ void ProfileOrchestrator::onUserButtonChanged(int buttonId,
     }
 }
 
+void ProfileOrchestrator::onDpiChangedByButton(int dpi)
+{
+    applyHardwareChange([dpi](Profile &p) { p.dpi = dpi; });
+}
+
+void ProfileOrchestrator::onSmartShiftChangedByButton(bool enabled, int threshold)
+{
+    applyHardwareChange([enabled, threshold](Profile &p) {
+        p.smartShiftEnabled   = enabled;
+        p.smartShiftThreshold = threshold;
+    });
+}
+
 void ProfileOrchestrator::onTabSwitched(const QString &profileName)
 {
     const QString serial = activeSerial();

--- a/src/app/services/ProfileOrchestrator.h
+++ b/src/app/services/ProfileOrchestrator.h
@@ -57,8 +57,30 @@ public:
             hardwareForward();
     }
 
+    /// Mirror of applyDisplayedChange for changes that originate at the
+    /// device (a diverted button cycling DPI or toggling SmartShift). The
+    /// button acted on the hardware, so the change belongs to the HARDWARE
+    /// profile — not whichever profile the user happens to be viewing — and
+    /// no hardware forward is needed because the device is already in the
+    /// new state. The UI is refreshed only when the viewed profile is the
+    /// active one.
+    template<typename Mutator>
+    void applyHardwareChange(Mutator mutator) {
+        const QString serial = activeSerial();
+        if (serial.isEmpty()) return;
+        const QString name = m_profileEngine->hardwareProfile(serial);
+        if (name.isEmpty()) return;
+        Profile &p = m_profileEngine->cachedProfile(serial, name);
+        mutator(p);
+        m_profileEngine->saveProfileToDisk(serial, name);
+        if (name == m_profileEngine->displayProfile(serial))
+            pushDisplayValues(p);
+    }
+
 public slots:
     void saveCurrentProfile();
+    void onDpiChangedByButton(int dpi);
+    void onSmartShiftChangedByButton(bool enabled, int threshold);
     void onUserButtonChanged(int buttonId, const QString &actionName, const QString &actionType);
     void onTabSwitched(const QString &profileName);
     void onDisplayProfileChanged(const QString &serial, const Profile &profile);

--- a/tests/helpers/AppRootFixture.h
+++ b/tests/helpers/AppRootFixture.h
@@ -54,6 +54,13 @@ protected:
                                        nullptr, m_ctrl.get());
         m_session->m_connected = true;
         m_session->m_deviceName = QStringLiteral("Mock Device");
+        // Match the seeded default profile. On real hardware enumeration
+        // fills these in and applyProfileToHardware keeps them in step; the
+        // mock session has neither, so seed them explicitly. A diverted
+        // button toggles SmartShift relative to this value, so leaving it at
+        // the zero-initialised default would make the toggle a no-op.
+        m_session->m_smartShiftEnabled = true;
+        m_session->m_smartShiftThreshold = 128;
         // PhysicalDevice::descriptor() forwards to its primary session's
         // descriptor(). onPhysicalDeviceAdded writes that into AppRoot's
         // m_currentDevice, so the mock session must already know which

--- a/tests/services/test_profile_orchestrator.cpp
+++ b/tests/services/test_profile_orchestrator.cpp
@@ -238,3 +238,46 @@ TEST_F(ProfileOrchestratorFixture, PresetRefRoundTripRestoresTypeAndName) {
     EXPECT_EQ(m_buttonModel->actionTypeForButton(3), QStringLiteral("preset"));
     EXPECT_EQ(m_buttonModel->actionNameForButton(3),  QStringLiteral("Show desktop"));
 }
+
+// --- button-initiated hardware changes persist to the active profile -------
+
+TEST_F(ProfileOrchestratorFixture, ButtonDpiChangePersistsToHardwareProfile) {
+    attachMockSession();
+
+    m_orchestrator->onDpiChangedByButton(4100);
+
+    // Persisted into the hardware (active) profile...
+    EXPECT_EQ(cached().dpi, 4100);
+    // ...and the UI reflects it, because display == hardware.
+    EXPECT_EQ(m_deviceModel->currentDPI(), 4100);
+}
+
+TEST_F(ProfileOrchestratorFixture, ButtonSmartShiftChangePersistsToHardwareProfile) {
+    attachMockSession();
+
+    m_orchestrator->onSmartShiftChangedByButton(false, 200);
+
+    EXPECT_FALSE(cached().smartShiftEnabled);
+    EXPECT_EQ(cached().smartShiftThreshold, 200);
+    EXPECT_FALSE(m_deviceModel->smartShiftEnabled());
+}
+
+TEST_F(ProfileOrchestratorFixture, ButtonChangeWritesHardwareProfileWhileViewingAnother) {
+    attachMockSession();
+    const QString kSerial = QStringLiteral("mock-serial");
+
+    // View a different profile while hardware stays on "default". A button
+    // press acts on the device, so it must persist to the HARDWARE profile
+    // and must not disturb the profile the user is currently viewing.
+    m_profileEngine->createProfileForApp(kSerial, QStringLiteral("other"),
+                                         QStringLiteral("other"));
+    m_profileEngine->setDisplayProfile(kSerial, QStringLiteral("other"));
+    const int viewedDpiBefore = cached(QStringLiteral("other")).dpi;
+    const int shownDpiBefore  = m_deviceModel->currentDPI();
+
+    m_orchestrator->onDpiChangedByButton(4100);
+
+    EXPECT_EQ(cached().dpi, 4100);                                    // hardware profile updated
+    EXPECT_EQ(cached(QStringLiteral("other")).dpi, viewedDpiBefore);  // viewed profile untouched
+    EXPECT_EQ(m_deviceModel->currentDPI(), shownDpiBefore);           // UI unchanged
+}

--- a/tests/test_app_root.cpp
+++ b/tests/test_app_root.cpp
@@ -509,3 +509,43 @@ TEST_F(AppRootFixture, DisplayProfileChangedIgnoredForNonSelectedDevice) {
     // onDisplayProfileChanged filter rejected device B's signal.
     EXPECT_EQ(deviceModel().currentDPI(), 1000);
 }
+
+// --- button-initiated changes reach the UI and the active profile ---------
+//
+// Regression guard: a diverted button that cycles DPI or toggles SmartShift
+// changes the device directly, bypassing the UI's change path. The value must
+// still show up in the UI and be persisted into the active profile, so the
+// next profile apply does not snap it back.
+
+TEST_F(AppRootFixture, DpiCycleButtonUpdatesUiAndActiveProfile) {
+    setProfileButton(QStringLiteral("default"), 6,
+                     ButtonAction{ButtonAction::DpiCycle, {}});
+
+    const int before = deviceModel().currentDPI();
+    pressButton(0x00C4);
+    releaseButton(0x00C4);
+    const int after = deviceModel().currentDPI();
+
+    EXPECT_NE(after, before) << "UI did not reflect the DPI cycled by the button";
+
+    const Profile &p = profileEngine().cachedProfile(QStringLiteral("mock-serial"),
+                                                     QStringLiteral("default"));
+    EXPECT_EQ(p.dpi, after) << "cycled DPI was not persisted into the active profile";
+}
+
+TEST_F(AppRootFixture, SmartShiftButtonUpdatesUiAndActiveProfile) {
+    setProfileButton(QStringLiteral("default"), 6,
+                     ButtonAction{ButtonAction::SmartShiftToggle, {}});
+
+    const bool before = deviceModel().smartShiftEnabled();
+    pressButton(0x00C4);
+    releaseButton(0x00C4);
+    const bool after = deviceModel().smartShiftEnabled();
+
+    EXPECT_NE(after, before) << "UI did not reflect the SmartShift toggled by the button";
+
+    const Profile &p = profileEngine().cachedProfile(QStringLiteral("mock-serial"),
+                                                     QStringLiteral("default"));
+    EXPECT_EQ(p.smartShiftEnabled, after)
+        << "toggled SmartShift was not persisted into the active profile";
+}


### PR DESCRIPTION
## Symptom
Bind a button to **DPI cycle** or **SmartShift toggle**, press it: the hardware changes but the **UI keeps showing the old value**. This one has been chased repeatedly.

## Root cause
Traced with instrumentation on real hardware:

```
smartShiftChanged relay fired      → clears DeviceModel's display cache
smartShiftEnabled() → hasDisplayCache=false, live=false   ← correct, briefly
onDisplayProfileChanged ... smartShift=true               ← re-pushes the UNCHANGED profile
smartShiftEnabled() → hasDisplayCache=true, display=true, live=false   ← UI stale again
```

The button wrote straight to `DeviceSession`, bypassing the profile. `DeviceModel` has **two sources of truth** — a display cache (fed by profile loads / UI edits) and the live session — and the getters short-circuit to the cache. The relay correctly cleared the cache, but `onDisplayProfileChanged` then re-armed it from the *unchanged* profile, clobbering the live value.

That's why cache-invalidation patches kept regressing: the bug is a **sequencing race** (clear → re-arm), so any new caller of `setDisplayValues` reintroduces it. The value also snapped back on the next profile apply.

## Fix
Persist button-initiated changes into the active profile, so there's one source of truth.

- **`ProfileOrchestrator::applyHardwareChange`** — mirror of `applyDisplayedChange`, but targets the **hardware** profile (the button acted on the device, not on whichever profile you're viewing), and skips the hardware forward since the device is already in the new state. UI refreshes only when the viewed profile is the active one.
- **Dispatcher notifies explicitly** (`dpiChangedByButton` / `smartShiftChangedByButton`) rather than having the orchestrator listen to `DeviceSession`'s change signals — this is what stops a profile *application* from echoing back and rewriting the profile it just applied.
- **AppRoot** wires the two signals, honoring the "zero `connect()` calls in the .cpp" convention.

### Behavior change
A DPI cycled by button now **survives the next profile apply** instead of snapping back, and is written to the profile on disk. That is the intended semantics for this change. Saves are synchronous, matching the existing `applyDisplayedChange` path (which already saves per UI change, including slider drags).

## Test fixture fix
`AppRootFixture` seeded a default profile with SmartShift **on** but left the mock session's SmartShift at its zero-initialised `false`, so a toggle computed from the session was a silent no-op. Seeded the session to match, as real enumeration + `applyProfileToHardware` do in production.

## Tests
- 3 orchestrator tests, incl. **writing the hardware profile while viewing a different one** (viewed profile and UI must stay untouched)
- 2 end-to-end tests driving a real button press through dispatcher → AppRoot wiring → orchestrator → UI + profile

Full suite green: **736 C++**. Smoke-tested on an MX Master 3S — SmartShift toggle and DPI cycle both reflect in the UI immediately.