### PR TITLE
docs(readme): add Hyprland column to the DE support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,19 +132,19 @@ Other Logitech HID++ 2.0 devices can be added by contributing a [device descript
 
 ## 🖥️ Desktop Environment Support
 
-| Feature | KDE Plasma 6 | GNOME 42+ (Wayland) | Other DEs |
-|---------|:---:|:---:|:---:|
-| Button remapping | ✅ | ✅ | ✅ |
-| Media controls | ✅ | ✅ | ✅ |
-| DPI / SmartShift / Scroll | ✅ | ✅ | ✅ |
-| Thumb wheel modes | ✅ | ✅ | ✅ |
-| Gesture actions | ✅ | ✅ | ✅ |
-| Per-app profiles | ✅ | ✅ | ❌ |
-| Auto profile switching | ✅ | ✅ | ❌ |
-| Block shortcuts during capture | ✅ | ✅ | ❌ |
-| System tray | ✅ | ✅ | ✅ |
+| Feature | KDE Plasma 6 | GNOME 42+ (Wayland) | Hyprland | Other DEs |
+|---------|:---:|:---:|:---:|:---:|
+| Button remapping | ✅ | ✅ | ✅ | ✅ |
+| Media controls | ✅ | ✅ | ✅ | ✅ |
+| DPI / SmartShift / Scroll | ✅ | ✅ | ✅ | ✅ |
+| Thumb wheel modes | ✅ | ✅ | ✅ | ✅ |
+| Gesture actions | ✅ | ✅ | ✅ | ✅ |
+| Per-app profiles | ✅ | ✅ | ✅ | ❌ |
+| Auto profile switching | ✅ | ✅ | ✅ | ❌ |
+| Block shortcuts during capture | ✅ | ✅ | ❌ | ❌ |
+| System tray | ✅ | ✅ | ✅ | ✅ |
 
-> **Note:** All device configuration (buttons, DPI, scroll, gestures, thumb wheel) works on every DE — it's pure HID++ over hidraw. Per-app profile switching requires desktop-specific focus tracking. KDE uses a KWin script, GNOME uses a Shell extension (auto-installed on first run). See [Adding a Desktop Environment](https://github.com/mmaher88/logitune/wiki/Adding-a-Desktop-Environment) to contribute support for other DEs.
+> **Note:** All device configuration (buttons, DPI, scroll, gestures, thumb wheel) works on every DE — it's pure HID++ over hidraw. Per-app profile switching requires desktop-specific focus tracking. KDE uses a KWin script, GNOME uses a Shell extension (auto-installed on first run), and Hyprland subscribes to the compositor's event socket. Hyprland has no stable compositor-wide shortcut-blocking API, so global bindings may still fire while capturing a keystroke — capture itself works. See [Adding a Desktop Environment](https://github.com/mmaher88/logitune/wiki/Adding-a-Desktop-Environment) to contribute support for other DEs.
 
 ## 🛠️ Tech Stack
 


### PR DESCRIPTION
Follow-up to #117, which added Hyprland support but didn't touch `README.md`.

The DE table listed only KDE / GNOME / **Other DEs**, so Hyprland fell into "Other DEs" — which marks **per-app profiles** and **auto profile switching** as unsupported. That understated the feature: Hyprland's focus tracking is implemented over the compositor event socket (`activeWindowChanged` is emitted), so both work.

Column values verified against the merged implementation, not assumed:

| Row | Hyprland | Why |
|---|:--:|---|
| Per-app profiles / auto switching | ✅ | event-socket focus tracking emits `activeWindowChanged` |
| Block shortcuts during capture | ❌ | `blockGlobalShortcuts` is a documented no-op — Hyprland has no stable compositor-wide shortcut-block API |
| Everything else | ✅ | pure HID++ over hidraw, DE-independent |

The note below the table now also mentions the event-socket mechanism alongside the KWin script and GNOME Shell extension, and spells out the shortcut-blocking consequence (capture works; global bindings may still fire).

Docs only — no code change. `generate-readme-devices.py --check` and `generate_package_deps.py --check` both pass, and the full suite ran clean via the pre-push gate.