### PR TITLE
fix(ui): hide the Test Exception button outside debug builds

### DIFF
--- a/src/app/models/SettingsModel.h
+++ b/src/app/models/SettingsModel.h
@@ -12,6 +12,10 @@ class SettingsModel : public QObject {
 
     Q_PROPERTY(bool loggingEnabled READ loggingEnabled WRITE setLoggingEnabled NOTIFY loggingEnabledChanged)
     Q_PROPERTY(QString logFilePath READ logFilePath NOTIFY loggingEnabledChanged)
+    /// True only in debug builds. Gates developer-only affordances in QML —
+    /// notably the Test Exception button, which deliberately crashes the app
+    /// and must never be reachable in a shipped build.
+    Q_PROPERTY(bool debugBuild READ debugBuild CONSTANT)
 
 public:
     explicit SettingsModel(QObject *parent = nullptr);
@@ -19,6 +23,16 @@ public:
     bool loggingEnabled() const;
     void setLoggingEnabled(bool enabled);
     QString logFilePath() const;
+
+    /// Qt defines QT_NO_DEBUG for release configurations; packaging builds all
+    /// use CMAKE_BUILD_TYPE=Release, so this is false in every shipped package.
+    bool debugBuild() const {
+#ifdef QT_NO_DEBUG
+        return false;
+#else
+        return true;
+#endif
+    }
 
     Q_INVOKABLE void saveThemeDark(bool dark);
     Q_INVOKABLE void openBugReport();

--- a/src/app/qml/AppSettingsView.qml
+++ b/src/app/qml/AppSettingsView.qml
@@ -136,9 +136,10 @@ Item {
             }
         }
 
-        // Test crash button
+        // Test crash button — debug builds only. This deliberately throws, so
+        // it must never be reachable in a shipped package (see issue #146).
         Rectangle {
-            visible: SettingsModel.loggingEnabled
+            visible: SettingsModel.debugBuild && SettingsModel.loggingEnabled
             width: 180; height: 40
             radius: 4; color: "transparent"
             border.color: "#ff4444"; border.width: 1

--- a/tests/test_settings_model.cpp
+++ b/tests/test_settings_model.cpp
@@ -90,4 +90,28 @@ TEST_F(SettingsModelTest, LogFilePathReturnsNonEmpty) {
     SUCCEED();
 }
 
+
+// --- debug-build gating for the test-crash affordance ----------------------
+//
+// The "Test Exception" button deliberately crashes the app. It was gated only
+// on loggingEnabled, which is on by default, so it shipped to end users and
+// produced real crash reports (issue #146). It must be a debug-build-only
+// affordance.
+
+TEST_F(SettingsModelTest, DebugBuildPropertyIsExposedToQml) {
+    SettingsModel m;
+    const QVariant v = m.property("debugBuild");
+    ASSERT_TRUE(v.isValid()) << "debugBuild must be a Q_PROPERTY so QML can gate on it";
+    EXPECT_EQ(v.metaType().id(), QMetaType::Bool);
+}
+
+TEST_F(SettingsModelTest, DebugBuildReflectsBuildConfiguration) {
+    SettingsModel m;
+#ifdef QT_NO_DEBUG
+    EXPECT_FALSE(m.debugBuild()) << "release builds must not expose the crash affordance";
+#else
+    EXPECT_TRUE(m.debugBuild()) << "debug builds keep the crash affordance available";
+#endif
+}
+
 } // namespace logitune::test


### PR DESCRIPTION
## Problem

The "Test Exception" button in Settings calls `SettingsModel::testCrash()`, which deliberately throws. It was gated only on:

```qml
visible: SettingsModel.loggingEnabled
```

Logging is **enabled by default**, so this shipped to end users — a red crash button sitting in the Settings page. #146 is a real crash report from a user on Fedora 43 running 0.3.6, titled `St13runtime_error: Test crash from UI`. They found the button and pressed it, and the crash handler dutifully filed it.

## Fix

Add a `CONSTANT` `debugBuild` property to `SettingsModel` (false when `QT_NO_DEBUG` is defined) and gate the button on `SettingsModel.debugBuild && SettingsModel.loggingEnabled`.

**Verified this actually holds for shipped builds** rather than assuming it: configuring with `CMAKE_BUILD_TYPE=Release` and inspecting `compile_commands.json` shows both `QT_NO_DEBUG` and `NDEBUG` are defined. Every packaging path — `packaging/PKGBUILD`, `scripts/package-deb.sh`, `scripts/package-rpm.sh`, and `pkg/obs/logitune.spec` — builds Release, so the button is absent from all shipped packages while remaining available during development.

## Tests

Two added to `test_settings_model.cpp`:
- `DebugBuildPropertyIsExposedToQml` — guards against the property being removed or renamed, which would silently make the QML binding `undefined` (and therefore falsy, hiding it even in debug)
- `DebugBuildReflectsBuildConfiguration` — asserts the value tracks the build configuration in both directions

Full suite green: **754 C++ / 72 QML**.

Closes #146